### PR TITLE
fix(planner): unlock CT + KY plans (slug reconciliation) — #819

### DIFF
--- a/data/ct/programs/ct-state.json
+++ b/data/ct/programs/ct-state.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "ctstate",
+  "college_slug": "ct-state",
   "catalog_year": "",
   "catalog_url": "https://catalog.ctstate.edu",
   "scraped_at": "2026-05-07T01:06:55.308Z",

--- a/data/ky/programs/ashland-community-and-technical-college.json
+++ b/data/ky/programs/ashland-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "ashland-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/big-sandy-community-and-technical-college.json
+++ b/data/ky/programs/big-sandy-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "big-sandy-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/bluegrass-community-and-technical-college.json
+++ b/data/ky/programs/bluegrass-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "bluegrass-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/elizabethtown-community-and-technical-college.json
+++ b/data/ky/programs/elizabethtown-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "elizabethtown-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/gateway-community-and-technical-college.json
+++ b/data/ky/programs/gateway-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "gateway-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/hazard-community-and-technical-college.json
+++ b/data/ky/programs/hazard-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "hazard-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/henderson-community-college.json
+++ b/data/ky/programs/henderson-community-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "henderson-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/hopkinsville-community-college.json
+++ b/data/ky/programs/hopkinsville-community-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "hopkinsville-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/jefferson-community-and-technical-college.json
+++ b/data/ky/programs/jefferson-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "jefferson-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/madisonville-community-college.json
+++ b/data/ky/programs/madisonville-community-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "madisonville-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/maysville-community-and-technical-college.json
+++ b/data/ky/programs/maysville-community-and-technical-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "kctcs",
+  "college_slug": "maysville-community-and-technical-college",
   "catalog_year": "",
   "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
   "scraped_at": "2026-05-13T17:17:21.132Z",

--- a/data/ky/programs/owensboro-community-and-technical-college.json
+++ b/data/ky/programs/owensboro-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "owensboro-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/somerset-community-college.json
+++ b/data/ky/programs/somerset-community-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "somerset-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/southcentral-kentucky-community-and-technical-college.json
+++ b/data/ky/programs/southcentral-kentucky-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "southcentral-kentucky-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/southeast-kentucky-community-and-technical-college.json
+++ b/data/ky/programs/southeast-kentucky-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "southeast-kentucky-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ky/programs/west-kentucky-community-and-technical-college.json
+++ b/data/ky/programs/west-kentucky-community-and-technical-college.json
@@ -1,0 +1,15450 @@
+{
+  "college_slug": "west-kentucky-community-and-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.kctcs.edu/programs-of-study/",
+  "scraped_at": "2026-05-13T17:17:21.132Z",
+  "programs": [
+    {
+      "title": "Additive Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "190",
+              "title": "Film Boot Camp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "260",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/agriculture/agriculture-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "101",
+              "title": "The Economics of Food and Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology Iand Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "116",
+              "title": "Biology IIand Biology Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Zoology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Botany with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology Iand Principles of Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "125",
+              "title": "Introduction to Fertilizers and Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "130",
+              "title": "Field Applications in Agriculture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "140",
+              "title": "Issues In Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "230",
+              "title": "Career Development in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "240",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "250",
+              "title": "Introduction to Plants/Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/additive-technology/additive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "101",
+              "title": "Intro to Additive Engineering Technologyand CAD for Additive Engineeringand Slicing and Programming Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technologyand Introduction to Engineering Mechanics for 3D Printingand Special Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AEG",
+              "number": "230",
+              "title": "Strategic Business Applications of Additive Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Office Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/administrative-office-technology/administrative-office-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "160",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "210",
+              "title": "Advanced Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "215",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "275",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BEX",
+              "number": "101",
+              "title": "Basic Electricity Lab for Non-Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Print Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "118",
+              "title": "Residential Network Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "199",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "240",
+              "title": "Energy Efficiency and Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "290",
+              "title": "Selected Topics in Engineering Technology: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "114",
+              "title": "Voice & Data Installer Level II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "120",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "122",
+              "title": "Voice & Data Installer Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETT",
+              "number": "123",
+              "title": "Voice & Data Installer Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "1003",
+              "title": "CPR & First Aid",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "205",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "220",
+              "title": "Engineering Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "123",
+              "title": "Mining Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNG",
+              "number": "286",
+              "title": "Roof Control and Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "105",
+              "title": "Plumbing Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/air-conditioning-technology/air-conditioning-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricityand HVAC Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Process Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/applied-process-technologies/applied-process-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry (Recommended)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistryand Introductory General and Biological Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistryand Introductory General Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues (Recommended)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics (Recommended)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "OSHA, Health, & Environmental Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "102",
+              "title": "Process Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "104",
+              "title": "Rotating and Reciprocating Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "106",
+              "title": "Process Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "108",
+              "title": "Stationary Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "202",
+              "title": "Federally Mandated Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "204",
+              "title": "Safety Skills Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "251",
+              "title": "Application of Process Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "291",
+              "title": "Special Problems in Applied Process Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EES",
+              "number": "101",
+              "title": "Basic Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/apprenticeship-studies/apprenticeship-studies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACH",
+              "number": "180",
+              "title": "Selected Topics in Architectural Technology (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "194",
+              "title": "Visual Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "198",
+              "title": "Practicum in Architectural Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "280",
+              "title": "Revit/Building Information Modeling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "290",
+              "title": "Building Codes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "291",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "292",
+              "title": "Building Codes II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "293",
+              "title": "Presentation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "294",
+              "title": "Specification Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "295",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "297",
+              "title": "Estimating Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "298",
+              "title": "Computer 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/architectural-technology/architectural-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "100",
+              "title": "Construction Documents I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "110",
+              "title": "Survey of the Architectural Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "120",
+              "title": "Theory and History of Architecture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "150",
+              "title": "Construction Documents II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "160",
+              "title": "Building Materials and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "161",
+              "title": "Building Materials and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "170",
+              "title": "Theory and History of Architecture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "175",
+              "title": "Introduction to Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "195",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "200",
+              "title": "Construction Documents III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "225",
+              "title": "Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "250",
+              "title": "Construction Documents IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "260",
+              "title": "Office Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACH",
+              "number": "275",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "237",
+              "title": "Building Controls I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "238",
+              "title": "Building Controls II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "291",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "293",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "295",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "151",
+              "title": "Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "261",
+              "title": "Electrical Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Agriculture Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "150",
+              "title": "Agricultural Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "170",
+              "title": "Introduction to Equipment, Machines, and Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "190",
+              "title": "Industrial Computer Programming Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "250",
+              "title": "PLC Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "270",
+              "title": "Advanced PLC Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "135",
+              "title": "Industrial Refrigeration - I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "145",
+              "title": "Utility Technician I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "235",
+              "title": "Industrial Refrigeration - II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "245",
+              "title": "Utility Technician II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "290",
+              "title": "Selected Topics in Advanced Integrated Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Brake Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "161",
+              "title": "Suspension and Steering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation and Industrial Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-and-Industrial-technology/automation-and-industrial-technology-aas/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Writing: An Accelerated Course",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1002",
+              "title": "Power Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1201",
+              "title": "Electrical Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1301",
+              "title": "Principles of Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1302",
+              "title": "Integrated Process Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1401",
+              "title": "Basic Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1501",
+              "title": "Intermediate Electrical Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2710",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2711",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation, Industrial, and Robotics, Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automation-industrial-and-robotics-technology/automation-industrial-and-robotics-technology-aas/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Basic Digital and Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "248",
+              "title": "Motor Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "Rotating Machinery",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Programmable Logic Controllers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/automotive-technology/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Manual Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Basic Fuel and Ignition Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Emission Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "160",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "240",
+              "title": "Computer Control Systems and Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/aviation-maintenance-technology/aviation-maintenance-technology-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "101",
+              "title": "Pre-Aviation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Introduction to Aircraft Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "105",
+              "title": "Introduction to Aircraft Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "107",
+              "title": "Introduction to Aircraft Maintenance III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "109",
+              "title": "Introduction to Aircraft Maintenance IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "201",
+              "title": "Aircraft Powerplants and Related Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "203",
+              "title": "Aircraft Powerplants and Related Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "205",
+              "title": "Aircraft Powerplants and Related Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Aircraft Powerplants and Related Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "211",
+              "title": "Aircraft Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "213",
+              "title": "Aircraft Structures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "215",
+              "title": "Aircraft Structures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "217",
+              "title": "Aircraft Structures IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "221",
+              "title": "Aircraft Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "223",
+              "title": "Aircraft Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "225",
+              "title": "Aircraft Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "227",
+              "title": "Aircraft Systems IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Technology Systems - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biomedical-technology-systems/biomedical-technology-systems-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1001",
+              "title": "Basic Electrical Knowledge",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1101",
+              "title": "Electrical Power Distribution",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (fulfills digital literacy requirement)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "100",
+              "title": "Biomedical Technology Systems: A Career Perspective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "110",
+              "title": "Environmental Risks and Precautionary Measures for the BTS Service Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "120",
+              "title": "Essentials of Biomedical Electronics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "125",
+              "title": "Essentials of Biomedical Electronics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "130",
+              "title": "Medical Equipment Management I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "140",
+              "title": "Science Principles Employed in Medical Technologies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "200",
+              "title": "Patient Care Support and Management Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "210",
+              "title": "Diagnostic Medical Equipment and Non-Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "220",
+              "title": "Laboratory Devices, Instruments, and Analyzers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "230",
+              "title": "Medical Equipment Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "250",
+              "title": "Introduction to Medical-Based IT Networks and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "260",
+              "title": "Radiographic Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "270",
+              "title": "Therapeutic Equipment Modalities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "275",
+              "title": "Therapeutic Equipment Modalities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "280",
+              "title": "General Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "285",
+              "title": "Critical Care Monitoring and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTS",
+              "number": "290",
+              "title": "Clinical Experience in Biomedical Technology Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/biotechnology-laboratory-technician/biotechnology-laboratory-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "105",
+              "title": "Applied Laboratory Calculations for Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "106",
+              "title": "Fundamentals of Scientific Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "110",
+              "title": "Nucleic Acid Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "115",
+              "title": "Biomanufacturing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "120",
+              "title": "Biofuels",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "125",
+              "title": "Bioinformatics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "126",
+              "title": "Bioinformatics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "160",
+              "title": "Introduction to Agricultural Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "210",
+              "title": "Cell Culture and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "220",
+              "title": "Immunological Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "225",
+              "title": "Protein Bioseparation Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "295",
+              "title": "Independent Investigation in Biotechnology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "298",
+              "title": "Biotechnology Learning Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadband Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/broadband-technology/broadband-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "289",
+              "title": "Broadband Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "100",
+              "title": "Introduction to HFC/Cable-TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BBT",
+              "number": "200",
+              "title": "Introduction to Cellular Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/business-administration/business-administration-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "260",
+              "title": "Professional Development and Protocol",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "267",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil Engineering Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "100",
+              "title": "Introduction to Engineering Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "125",
+              "title": "Principles of Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "225",
+              "title": "Civil Engineering and Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLW",
+              "number": "295",
+              "title": "Engineering Design and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/civil-engineering-technology/civil-engineering-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "110",
+              "title": "Principles of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "150",
+              "title": "Civil Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "200",
+              "title": "Civil Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "210",
+              "title": "Infrastructure Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "260",
+              "title": "Hydrology and Drainage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRU",
+              "number": "100",
+              "title": "Truck Driving",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Drafting and Design - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-aided-drafting-design/computer-aided-drafting-design-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Drafting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Engineering Technology- AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-engineering-technology/computer-engineering-technology-aas/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometryand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "College Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers (or demonstrated digital literacy competency)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "115U",
+              "title": "Introduction to Computer Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "215U",
+              "title": "Introduction to Program Design, Abstraction, and Problem Solving",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer and Information Technologies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "111",
+              "title": "Client-side Informatics Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "128",
+              "title": "Principles of Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "211",
+              "title": "Collaboration Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "215",
+              "title": "Information Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFM",
+              "number": "225",
+              "title": "Advanced Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer and Information Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computer-information-technologies/computer-information-technologies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "155",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Computational Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "170",
+              "title": "Database Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "180",
+              "title": "Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computerized Manufacturing & Machining - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/computerized-manufacturing-machining/computerized-manufacturing--machining-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - Aand Fundamentals of Machine Tools - B",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining Iand Applied Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programmingand CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "138",
+              "title": "Intro. to Programming & CNC Machines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining Iand Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining Iand Advanced Industrial Machining II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2301",
+              "title": "Introduction to Conversational Programmingand Conversational Editing and Subroutines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "234",
+              "title": "CNC Machines & Coding Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "2401",
+              "title": "Introduction to 3D Code Sequencing and Tool Path Productionand Advanced 3D Code Sequencing and Macro Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "244",
+              "title": "Advance Programming/Setup Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinistand Mechanical Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/construction-technology/construction-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "126",
+              "title": "Intro to Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "127",
+              "title": "Intro to Construction - Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "140",
+              "title": "Surveying & Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "141",
+              "title": "Surveying & Foundations-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "190",
+              "title": "Light Frame Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "191",
+              "title": "Light Frame Const. I-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "196",
+              "title": "Light Frame Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "197",
+              "title": "Light Frame Const. II-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "200",
+              "title": "Light Frame Construction III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Light Frame Const. III-Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "298",
+              "title": "Practicum in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "299",
+              "title": "Co-op in Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/criminal-justice/criminal-justice-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "255",
+              "title": "State Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Issues and Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "217",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "295",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/culinary-arts/culinary-arts-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Introduction to Culinary Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Applied Introduction to Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Garde Manger",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "190",
+              "title": "Basic Food Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "195",
+              "title": "Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NFS",
+              "number": "101",
+              "title": "Human Nutrition and Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Meats, Seafood, & Poultry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "270",
+              "title": "Human Relations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Cost and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "285",
+              "title": "Front of the House",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Front of the House-Catering",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CYS",
+              "number": "231",
+              "title": "Internet of Things Security and Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "234",
+              "title": "Computer Operating Systems Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "249",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "250",
+              "title": "Secure Software Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "258",
+              "title": "Survey of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "211",
+              "title": "Liability & Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/cybersecurity/cybersecurity-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "100",
+              "title": "Cybersecurity Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "101",
+              "title": "Cybersecurity Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "130",
+              "title": "Introduction to Cyber Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "140",
+              "title": "Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "145",
+              "title": "Foundations of Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "150",
+              "title": "Secure Software Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "202",
+              "title": "Human, Organizational, and Societal Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "245",
+              "title": "Advanced Cyber Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "285",
+              "title": "Cryptography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYS",
+              "number": "299",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-assisting-and-dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "101",
+              "title": "Infection Control & Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "121",
+              "title": "Dental Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "124",
+              "title": "Materials In Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "131",
+              "title": "Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "135",
+              "title": "Oral Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAH",
+              "number": "235",
+              "title": "Practice Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "120",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "130",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "132",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "134",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "136",
+              "title": "Periodontology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "220",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "221",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "226",
+              "title": "Advanced Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "228",
+              "title": "Evidence-Based Practice for the Dental Hygienist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "230",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHG",
+              "number": "238",
+              "title": "Community Dental Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/dental-hygiene/dental-hygiene-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "226",
+              "title": "Principles of Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "120",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "122",
+              "title": "Dental Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "123",
+              "title": "Oral Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "124",
+              "title": "Materials in Dentistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "130",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "132",
+              "title": "Oral Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "135",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "136",
+              "title": "Periodontics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "220",
+              "title": "Dental Hygiene III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "222",
+              "title": "Special Needs Patients",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "226",
+              "title": "Periodontics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "229",
+              "title": "Local Anesthesia and Nitrous Oxide Sedation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "230",
+              "title": "Dental Hygiene IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "235",
+              "title": "Principles of Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHP",
+              "number": "238",
+              "title": "Community Dental Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diagnostic-medical-sonography/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra (Or Higher Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Introductory Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills Iand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "100",
+              "title": "Medicaid Nurse Aideand CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "104",
+              "title": "Health Care Basic Skills I with Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "180",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "181",
+              "title": "Brakes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "160",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "161",
+              "title": "Steering and Suspension Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Introduction to Maintenance Welding Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenanceand Welding for Maintenance Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Weldingand Shielded Metal Arc Welding Fillet Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "123",
+              "title": "Undercarriage Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "152",
+              "title": "Powertrain for Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "153",
+              "title": "Powertrain for Construction Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105",
+              "title": "Mechanical Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "199",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/diesel-technology/diesel-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BEX",
+              "number": "100",
+              "title": "Basic Electricity for Non-Majorsand Basic Electricity Lab for Non-Majors",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricityand Basic Automotive Electricity Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "170",
+              "title": "Climate Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "171",
+              "title": "Climate Control Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Preventive Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Introduction To Diesel Enginesand Introduction To Diesel Engines Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "150",
+              "title": "Engine Repairand Engine Repair Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "112",
+              "title": "Diesel Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Diesel Engine Repair Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "150",
+              "title": "Power Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "151",
+              "title": "Power Trains Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "190",
+              "title": "Electrical Systems for Diesel Equipmentand Electrical Systems for Diesel Equipment Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "260",
+              "title": "Electrical Systemsand Electrical Systems Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/education/education-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "108",
+              "title": "History of the United States Through 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "109",
+              "title": "History of the United States Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Introduction to American Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "202",
+              "title": "Human Development and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "203",
+              "title": "Teaching Exceptional Learners in Regular Classrooms",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDP",
+              "number": "260",
+              "title": "Motivation and Classroom Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260U",
+              "title": "Classroom Assessment",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/electrical-technology/electrical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls Iand Electrical Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machineryand Rotating Machinery Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "272",
+              "title": "Electrical Motor Controls IIand Electrical Motor Controls II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls Iand Rotating Machinery and Motor Controls I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformersand Rotating Machinery and Transformers Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controlsand Electrical Motor Controls Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Medical Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Field",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/emergency-medical-services-paramedic/emergency-medical-services-paramedic-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "200",
+              "title": "Introduction to Paramedicineand Emergency Pharmacology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Fundamentals Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "215",
+              "title": "Clinical Experience I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Cardiac and Trauma Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Medical Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Traumatic Emergenciesand EMS Operations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Medical Emergencies Iand Medical Emergencies II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Cardiovascular Emergenciesand Special Populationsand Seminar in Advanced Life Support (ALS)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Clinical Experience IIand Clinical Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "285",
+              "title": "Field Internship & Summation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Principles of Paramedicine I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Paramedic Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Practicum I-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "209",
+              "title": "Paramedic Lab III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Principles of Paramedicine IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2081",
+              "title": "Principles of Paramedicine IV Part Iand Principles of Paramedicine IV Part 2",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Principles of Paramedicine II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "205",
+              "title": "Principles of Paramedicine III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Practicum II-Clinical",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Practicum III-Fieldand Principles of Paramedicine V",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technologies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/energy-technologies/energy-technologies-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "170",
+              "title": "Energy Utility Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGY",
+              "number": "120",
+              "title": "Outside Plant Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (up to 8 credits)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "258",
+              "title": "Lineman Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APT",
+              "number": "259",
+              "title": "Lineman Technology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Electronics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/engineering-electronics-technology/engineering-electronics-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principlesand Industrial Maintenance Electrical Principles Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Blueprint Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Principles of Biology Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "101",
+              "title": "Introduction to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "201",
+              "title": "Biotechnology Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "202",
+              "title": "Biotechnology Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "180",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "185",
+              "title": "General College Chemistry Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "270",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "275",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic) (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "111",
+              "title": "Physical Geology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "154",
+              "title": "Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/environmental-science-technology/environmental-science-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "175",
+              "title": "General College Chemistry Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "140",
+              "title": "Introduction to Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "141",
+              "title": "Introduction to Ecology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "160",
+              "title": "Hydrological Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "161",
+              "title": "Hydrologic Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "170",
+              "title": "Environmental Sampling Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "220",
+              "title": "Pollution of Aquatic Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "230",
+              "title": "Aquatic Chemistry Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "240",
+              "title": "Sources and Effects of Air Pollution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "250",
+              "title": "Solid and Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "260",
+              "title": "Environmental Analysis Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "270",
+              "title": "Environmental Law and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EST",
+              "number": "290",
+              "title": "Applied Projects in Environmental Science Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equine Studies - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/equine-studies/equine-studies-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EQS",
+              "number": "104",
+              "title": "Equine Care Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "110",
+              "title": "Basic Equine Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "115",
+              "title": "Equine Health and Medications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "125",
+              "title": "Equine Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "200",
+              "title": "Lameness in Racehorses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "223",
+              "title": "Training Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "225",
+              "title": "Life Skills for Horsemen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQS",
+              "number": "240",
+              "title": "Equine Legal and Business Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fermentation-science/fermentation-science-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "107",
+              "title": "Western Culture: Science and Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "Introductory Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "120",
+              "title": "Brewery Facilities and Operational Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2002",
+              "title": "Quality Control and SPC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "125",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COED",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "100",
+              "title": "Fundamentals of Fermentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "110",
+              "title": "Principles of Fermentation Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "130",
+              "title": "Sensory Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "140",
+              "title": "Materials Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "150",
+              "title": "Recipe Formulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRM",
+              "number": "160",
+              "title": "Beverage Packaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fire-science-technology/fire-science-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIR",
+              "number": "101",
+              "title": "Basic Firefighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "102",
+              "title": "Basic Firefighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "103",
+              "title": "Basic Firefighting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "104",
+              "title": "Basic Firefighting IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "105",
+              "title": "Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "106",
+              "title": "Intro to Special Responses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "107",
+              "title": "Intro to Rescue & Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "230",
+              "title": "Emergency Medical Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "215",
+              "title": "Emergency Medical Responder",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "198",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "202",
+              "title": "Fire Instructor I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "203",
+              "title": "Fire Instructor II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "205",
+              "title": "Fire Officer I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "206",
+              "title": "Fire Officer II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "207",
+              "title": "Fire Officer III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "208",
+              "title": "Fire Officer IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "210",
+              "title": "Aircraft Rescue Firefighting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "212",
+              "title": "Driver/Operator - Pumper",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "213",
+              "title": "Driver/Operator - Aerial",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "220",
+              "title": "Hazardous Materials Technician",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "225",
+              "title": "Special Topics in Fire Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "240",
+              "title": "Fire Inspector I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "260",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "261",
+              "title": "Building Construction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "262",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "263",
+              "title": "Fire Service Safety & Wellness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "264",
+              "title": "Fire Prevention",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "265",
+              "title": "Fire Protection Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "280",
+              "title": "Fire Service Legal Aspects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "281",
+              "title": "Fire Service Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIR",
+              "number": "282",
+              "title": "Strategy and Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fixed Wing Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/fixed-wing-flight-training/fixed-wing-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "120",
+              "title": "Private Pilot Fixed Wing Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "130",
+              "title": "Private Pilot Fixed Wing Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "140",
+              "title": "Fixed Wing Aircraft Instrument Pilot Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "150",
+              "title": "Fixed Wing Instrument Pilot Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "160",
+              "title": "Fixed Wing Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "170",
+              "title": "Commercial Flight Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "171",
+              "title": "Commercial Flight Lab Phase II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "172",
+              "title": "Commercial Flight Lab Single Engine Land Phase III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "173",
+              "title": "Commercial Flight Lab Multi-Engine Phase III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "180",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "190",
+              "title": "Fixed Wing Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FWT",
+              "number": "191",
+              "title": "Fixed Wing Commercial Multi-Engine Ground & Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Library Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/graphic-design-library-technology/graphic-design-library-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "100",
+              "title": "Digital Information & Communication Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "115",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "126",
+              "title": "Introduction to Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "270",
+              "title": "Professional Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "275",
+              "title": "Information Management and Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "271",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-information-technology/health-information-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "151",
+              "title": "Introduction to Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Pathophysiology / Pharmacology for Health Information Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "109",
+              "title": "Clinical Classification Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Legal & Ethical Issues in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "200",
+              "title": "Information Systems in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Clinical Classification Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Quality Mgmt & PI - Health Info",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "207",
+              "title": "Clinical Classification Systems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Health Care Management and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Clinical Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "2151",
+              "title": "Clinical Practicum Iand Clinical Practicum II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Science Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/health-science-technology/health-science-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Facilities Leadership - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/healthcare-facilities-leadership/healthcare-facilities-leadership-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFO",
+              "number": "100",
+              "title": "Healthcare Facilities Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "100",
+              "title": "Introduction to Healthcare Facility Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "110",
+              "title": "Introduction to Healthcare Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "120",
+              "title": "Infection Control and Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "130",
+              "title": "Compliance, Codes and Standards I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "140",
+              "title": "Maintenance and Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "150",
+              "title": "Planning, Design and Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "170",
+              "title": "General College Chemistry Iand General College Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biologyand Introduction to Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design (Digital Literacy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "230",
+              "title": "Compliance, Codes and Standards II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "240",
+              "title": "Maintenance and Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "250",
+              "title": "Planning, Design and Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "260",
+              "title": "Healthcare Facilities Leadership Capstone I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFL",
+              "number": "270",
+              "title": "Healthcare Facilities Leadership Capstone II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "212",
+              "title": "Introduction to Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Helicopter Flight Training - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/helicopter-flight-training/helicopter-flight-training-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "251",
+              "title": "Weather and Climate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "101",
+              "title": "Private Helicopter Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "102",
+              "title": "Private Pilot Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "103",
+              "title": "Helicopter Instrument Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "104",
+              "title": "Helicopter Instrument Pilot Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "105",
+              "title": "Helicopter Commercial Pilot",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "106",
+              "title": "Commercial Helicopter Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "210",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Ground School",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "220",
+              "title": "Helicopter Certified Flight Instructor & Certified Flight Instructor Instrument Flight Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human and Social Services - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/human-and-social-services/human-and-social-services-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "101",
+              "title": "Human Services Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "102",
+              "title": "Values of Human Services in a Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "103",
+              "title": "Theories and Techniques in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "104",
+              "title": "Group Dynamics for Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "248",
+              "title": "Foundational Skills in Para-Professional Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Clinical Practices in Human Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "100",
+              "title": "Refrigeration Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "101",
+              "title": "Refrigeration Fundamentals Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "102",
+              "title": "HVAC Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "103",
+              "title": "HVAC Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "Sheet Metal Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Sheet Metal Fabrication Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "131",
+              "title": "Electrical Components Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "170",
+              "title": "Heat Load/Duct Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "201",
+              "title": "Commercial Refrigeration Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "206",
+              "title": "Boilers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "207",
+              "title": "Commercial HVAC Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "208",
+              "title": "Chillers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Manual N Commercial Load Calculation and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "250",
+              "title": "Cooling and Dehumidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "251",
+              "title": "Cooling and Dehumidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "260",
+              "title": "Heating and Humidification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "262",
+              "title": "Heating and Humidification Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "270",
+              "title": "Heat Pump Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "271",
+              "title": "Heat Pump Application Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "290",
+              "title": "Journeyman Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "130",
+              "title": "Measurement and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "140",
+              "title": "Industrial Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "150",
+              "title": "Industrial Controls II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "160",
+              "title": "Workplace Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "200",
+              "title": "Process Management and Quality Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "110",
+              "title": "Basic Blueprint Reading for Machinist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "112",
+              "title": "Blueprint Reading for Machinist",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "120",
+              "title": "Basic Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "210",
+              "title": "Mechanical Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "112",
+              "title": "Engineering Graphics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "120",
+              "title": "Introduction to Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "150",
+              "title": "Programming in CAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "200",
+              "title": "Intermediate Computer Aided Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Parametric Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "212",
+              "title": "Industrial Drafting Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "216",
+              "title": "Building Information Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "220",
+              "title": "Architectural Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "222",
+              "title": "Mechanical Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Construction Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "240",
+              "title": "Advanced Dimensioning and Measurement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "292",
+              "title": "Industrial Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "112",
+              "title": "Fundamentals of Machine Tools - B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "118",
+              "title": "Metrology/Control Charts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "120",
+              "title": "Applied Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "122",
+              "title": "Applied Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "124",
+              "title": "Applied Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "130",
+              "title": "Manual Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "132",
+              "title": "CAD/CAM/CNC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "134",
+              "title": "Manual Programming CAD/CAM/CNC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "150",
+              "title": "Shop Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "151",
+              "title": "Machinery's Handbook and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "152",
+              "title": "Jigs, Fixtures, and Gaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "153",
+              "title": "Mold Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "154",
+              "title": "Die Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "210",
+              "title": "Industrial Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "212",
+              "title": "Industrial Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "214",
+              "title": "Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "220",
+              "title": "Advanced Industrial Machining I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "222",
+              "title": "Advanced Industrial Machining II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "224",
+              "title": "Advanced Industrial Machining",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "230",
+              "title": "Conversational Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "240",
+              "title": "Introduction to 3-D Programming",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Electrical Safety in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Voice & Data Installer Level I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Fiber Optics Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "127",
+              "title": "Electrical Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "150",
+              "title": "Transformers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "151",
+              "title": "Transformers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "154",
+              "title": "Electrical Construction I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "155",
+              "title": "Electrical Construction I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "200",
+              "title": "Robotic Systems I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Robotic Systems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "202",
+              "title": "Robotic Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "203",
+              "title": "Robotic Vision Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "250",
+              "title": "National Electrical Code",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electrical Construction II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "253",
+              "title": "Electrical Construction II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Electrical Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Electrical Construction Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "264",
+              "title": "Rotating Machinery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "265",
+              "title": "Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "266",
+              "title": "Rotating Machinery and Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "267",
+              "title": "Rotating Machinery and Transformers Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "268",
+              "title": "Rotating Machinery Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "269",
+              "title": "Rotating Machinery and Motor Controls I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "274",
+              "title": "Electrical Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "275",
+              "title": "Electrical Motor Controls Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Programmable Logic Controllers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "280",
+              "title": "Multi-Platform Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Problems I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "283",
+              "title": "Special Problems II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "285",
+              "title": "Special Problems III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286",
+              "title": "Programmable Logic Controllers II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "287",
+              "title": "Programmable Logic Controllers II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Troubleshooting Industrial Controls and Motors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "295",
+              "title": "Alternative Energy Photovoltaic and Wind Electrical Generations Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "120",
+              "title": "Digital I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "124",
+              "title": "Mechanical Power Transmission Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "214",
+              "title": "Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "Digital II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "222",
+              "title": "Mechanics of Telephony",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Basic Telecommunications Installation and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Communications Electronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Electrical Machinery and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "Programmable Logic Controllers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "265",
+              "title": "Applied Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "289",
+              "title": "Engineering and Electronics Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "110",
+              "title": "Industrial Maintenance Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "111",
+              "title": "Industrial Maintenance Electrical Principles Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "115",
+              "title": "Maintenance Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "116",
+              "title": "Maintenance Machining I Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "120",
+              "title": "Industrial Maintenance Rotating Machinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "121",
+              "title": "Industrial Maintenance Rotating Machinery Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "138",
+              "title": "Lean Manufacturing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1381",
+              "title": "Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1382",
+              "title": "5S",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1383",
+              "title": "Total Production Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1384",
+              "title": "Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1385",
+              "title": "Maintenance Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "140",
+              "title": "Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "141",
+              "title": "Industrial Mechanics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "150",
+              "title": "Maintaining Industrial Equipment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "151",
+              "title": "Maintaining Industrial Equipment I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "160",
+              "title": "FANUC Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "161",
+              "title": "KUKA Robot Level 1 Robot Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "162",
+              "title": "YASKAWA/MOTOMAN Robot Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "198",
+              "title": "Industrial Maintenance Technology Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "199",
+              "title": "Industrial Maintenance Technology Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "200",
+              "title": "Industrial Robotics and Robotic Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "220",
+              "title": "Industrial Maintenance Electrical Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "221",
+              "title": "Industrial Maintenance Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "222",
+              "title": "Industrial Maintenance Motor Controls II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "223",
+              "title": "Industrial Maintenance Motor Controls II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "230",
+              "title": "Industrial Maintenance of PLCs",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "231",
+              "title": "Industrial Maintenance of PLC's Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "240",
+              "title": "Industrial Maintenance Motor Control Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "241",
+              "title": "Industrial Maintenance Motor Control Concepts Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "250",
+              "title": "Maintaining Industrial Equipment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "251",
+              "title": "Maintaining Industrial Equipment II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "260",
+              "title": "Presswork and Die Maintenance",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "280",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "281",
+              "title": "Advanced Programmable Logic Controllers Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "282",
+              "title": "PLC Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "289",
+              "title": "Industrial Maintenance Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "290",
+              "title": "Special Problems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "102",
+              "title": "Fundamentals of Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "210",
+              "title": "Fundamentals of Process Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "200",
+              "title": "Advanced Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "201",
+              "title": "Advanced Hydraulic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "204",
+              "title": "Advanced Pneumatic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "205",
+              "title": "Advanced Pneumatic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "206",
+              "title": "Electrohydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "207",
+              "title": "Electrohydraulics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Trade",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "151",
+              "title": "Basic Plumbing Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "175",
+              "title": "Applied Physics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHX",
+              "number": "150",
+              "title": "Introductory Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMX",
+              "number": "100",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "235",
+              "title": "Gas Tungsten Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/industrial-maintenance-technology/industrial-maintenance-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/integrated-engineering-technology/integrated-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I (or higher level physics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications (or above)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "104",
+              "title": "Blueprint Reading/Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "111",
+              "title": "Lean Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "112",
+              "title": "Lean Manufacturing Concepts -TPS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "113",
+              "title": "Lean 5S Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "114",
+              "title": "Lean Problem Solving Methodology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "115",
+              "title": "Lean Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "121",
+              "title": "Basic Electricity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "124",
+              "title": "Introduction to Welding and Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "128",
+              "title": "Introduction to Machine Tool Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "110",
+              "title": "Fundamentals of Machine Tools - A",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "202",
+              "title": "Motor Controls and Sensing Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "204",
+              "title": "Automated Motor Controls",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "205",
+              "title": "Robot Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "207",
+              "title": "Electro-Hydraulics and Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IET",
+              "number": "208",
+              "title": "Mechanical Drives",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Interdisciplinary Early Childhood Education - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/interdisciplinary-early-childhood-education/interdisciplinary-early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "101",
+              "title": "Orientation to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "102",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "130",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "170",
+              "title": "Observation and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "180",
+              "title": "Curriculum Design and Instruction in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "216",
+              "title": "Language and Literacy in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "221",
+              "title": "Creative Expressions in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "235",
+              "title": "Introduction to Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "246",
+              "title": "Sciences and Math in IECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "295",
+              "title": "IECE Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "210",
+              "title": "Families and Communities in Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "230",
+              "title": "Business Administration of ECE Programs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "240",
+              "title": "Administration of Early Childhood Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "250",
+              "title": "School Age Child Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IEC",
+              "number": "260",
+              "title": "Infant and Toddler Education and Programming",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Logistics and Operations Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/logistics-operations-management/logistics-operations-management-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "283",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "287",
+              "title": "Supervisory Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Introduction to Global Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Engineering Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/manufacturing-engineering-technology/manufacturing-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebraand Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebraand Trigonometryand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculusand Introduction to Applied Statisticsand Applied Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "103",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "100",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPX",
+              "number": "101",
+              "title": "Fluid Power Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "135",
+              "title": "Fundamentals of Mechatronics",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "175",
+              "title": "Lean Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "256",
+              "title": "Production Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "295",
+              "title": "Manufacturing Engineering Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marine Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/marine-technology/marine-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "140",
+              "title": "Development of Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "100",
+              "title": "Intro to Marine Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "101",
+              "title": "Anatomy of a Towboat",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "102",
+              "title": "Basic Marine Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "103",
+              "title": "Applied Marine Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "104",
+              "title": "Marine Crew Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "203",
+              "title": "Environmental Protection Rules",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "100",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSM",
+              "number": "110",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/massage-therapy-technology/massage-therapy-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "100",
+              "title": "Musculoskeletal Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "110",
+              "title": "Musculoskeletal Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "125",
+              "title": "Medical Massage Techniques I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "126",
+              "title": "Medical Massage Techniques Iand Medical Massage Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "135",
+              "title": "Medical Massage Techniques II with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "136",
+              "title": "Medical Massage Techniques IIand Medical Massage Lab II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "Advanced Clinical Massage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "232",
+              "title": "Advanced Medical Massage I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "210",
+              "title": "Advanced Clinical Massage II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "234",
+              "title": "Advanced Medical Massage II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "220",
+              "title": "Massage Therapy Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "215",
+              "title": "Massage Therapy Student Clinic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "286",
+              "title": "Student Massage Clinic Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-assisting/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KHP",
+              "number": "190",
+              "title": "First Aid and Emergency Care",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Information Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-information-technology/medical-information-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "105",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "110",
+              "title": "Word Processing Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "240",
+              "title": "Advanced Microsoft Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "217",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "224",
+              "title": "Medical Practice Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "228",
+              "title": "Electronic Medical Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "230",
+              "title": "Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "250",
+              "title": "Legal Issues in Medical Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "295",
+              "title": "Medical Information Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Laboratory Technician - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/medical-laboratory-technician/medical-laboratory-technician-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "130",
+              "title": "Introductory General and Biological Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "115",
+              "title": "Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "215",
+              "title": "Hematology Iand Hematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "217",
+              "title": "Fundamentals of Hematologyand Clinical Hematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Immunohematology Iand Immunohematology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "227",
+              "title": "Immunohematology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "278",
+              "title": "Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Imaging - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nuclear-medicine-imaging/nuclear-medicine-imaging-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "171",
+              "title": "Applied Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "140",
+              "title": "Introductory General Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "145",
+              "title": "Introductory General Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "100",
+              "title": "Introduction to Patient Care and Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "102",
+              "title": "Introduction to Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "109",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "111",
+              "title": "Radionuclides and Pharmaceuticals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "200",
+              "title": "Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "203",
+              "title": "Nuclear Physics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "204",
+              "title": "Clinic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "210",
+              "title": "Clinical Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMI",
+              "number": "216",
+              "title": "Clinic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMG",
+              "number": "230",
+              "title": "Sectional Anatomy for Advanced Medical Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing-Academic/Career Mobility Program - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-academic-career-mobility-program/academiccareer-mobility-program-nursing-aas/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "100",
+              "title": "CPR for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "101",
+              "title": "Nursing Care Iand Nursing Care II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "200",
+              "title": "LPN-ADN Transition",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "203",
+              "title": "Nursing Care III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "204",
+              "title": "Nursing Care IV",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/nursing-integrated-nursing-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "116",
+              "title": "Fundamentals in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "126",
+              "title": "Introduction to Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "212",
+              "title": "Advanced Alterations in Health and Wellness",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NIP",
+              "number": "217",
+              "title": "Transition to Practice in Health and Wellness Management",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Integrated Nursing — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing-integrated-nursing/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAA",
+              "number": "100",
+              "title": "Nursing Assistant Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/nursing/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "225",
+              "title": "Medical Microbiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/occupational-therapy-assistant/occupational-therapy-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Orthotics and Prosthetics Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/orthotics-and-prosthetics-technology/orthotics-and-prosthetics-aas/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "103",
+              "title": "Medical Office Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "100",
+              "title": "Introduction to Orthotics and Prosthetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "101",
+              "title": "Lower Extremity Orthotics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "102",
+              "title": "Spinal Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "103",
+              "title": "Lower Extremity Orthotics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "104",
+              "title": "Lower Extremity Orthotics III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "105",
+              "title": "Upper Extremity Orthotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "106",
+              "title": "Orthotic and Prosthetic Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "107",
+              "title": "Orthotic Prosthetic Biomaterials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "108",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "195",
+              "title": "Clinical Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "200",
+              "title": "Transtibial Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "201",
+              "title": "Transfemoral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "202",
+              "title": "Transradial and Transhumeral Prosthetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "203",
+              "title": "Advanced Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORP",
+              "number": "295",
+              "title": "Clinical Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/paralegal-technology/paralegal-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Productivity Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "111",
+              "title": "Legal Systems and Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "112",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "113",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "211",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "212",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "221",
+              "title": "Wills and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "213",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "214",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "223",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "224",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "231",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "233",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGL",
+              "number": "235",
+              "title": "Paralegal Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "223",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/plumbing-technology/plumbing-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "150",
+              "title": "Plumbing, Introduction to the Tradeand Basic Plumbing Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "100",
+              "title": "Basic Theory of Plumbingand Plumbing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "160",
+              "title": "Plumbing Systems, DWV & Water",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "161",
+              "title": "Rough-in of Plumbing Fixtures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "250",
+              "title": "Plumbing Appliances & Fixtures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "251",
+              "title": "Pumps and Water Heaters",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "260",
+              "title": "Serviceand Advanced Plumbing Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "269",
+              "title": "Sewer and Drain Cleaning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "262",
+              "title": "Backflow Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "270",
+              "title": "License Preparation for Journeyman Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "298",
+              "title": "Practicum/Repairs & Maintenance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "299",
+              "title": "Cooperative Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRX",
+              "number": "220",
+              "title": "Blueprint Reading for Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFM",
+              "number": "100",
+              "title": "Personal Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "270",
+              "title": "Business Employability Seminar",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Studio Artist-Bluegrass & Traditional Music - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/professional-studio-artist/professional-studio-artist-bluegrass-and-traditional-music/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "101",
+              "title": "Fundamentals of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "174",
+              "title": "Theory for Nonmusic Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Class Instruction in Piano I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "101",
+              "title": "Bluegrass & Traditional Music History I: Geographic Influence & Instrumental Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "105",
+              "title": "Recording I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "107",
+              "title": "Songwriting I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "112",
+              "title": "Individual Stringed Instrument Instruction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "113",
+              "title": "Guitar I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "114",
+              "title": "Bluegrass & Traditional Band/Ensemble",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "118",
+              "title": "Bluegrass & Traditional Harmony/Part Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "121",
+              "title": "Bluegrass & Traditional Music History II: Evolution of Old Time, Folk and Early Bluegrass",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "125",
+              "title": "Recording II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "117",
+              "title": "Songwriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "231",
+              "title": "Bluegrass & Traditional Music History III: Early Stringband & Country Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "235",
+              "title": "Recording III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "217",
+              "title": "Songwriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "245",
+              "title": "Recording IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "227",
+              "title": "Songwriting IV",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSA",
+              "number": "240",
+              "title": "Professional Artist Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "241",
+              "title": "Bluegrass & Traditional Music History IV: The Masters & Their Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSM",
+              "number": "250",
+              "title": "Field Experience/Production/Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/radiography/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Statistics and Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Finite Mathematics and its Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "170",
+              "title": "Brief Calculus with Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "174",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "184",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "185",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "275",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "220",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/respiratory-care/respiratory-therapist-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "139",
+              "title": "Human Anatomy and Physiology II with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "141",
+              "title": "Liberal Arts Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "110",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "120",
+              "title": "Theory and Principles of Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "125",
+              "title": "Evaluation and Treatment of Patients with Cardiopulmonary Issues",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "135",
+              "title": "Respiratory Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "150",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "175",
+              "title": "Clinical Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "180",
+              "title": "Ventilatory Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "190",
+              "title": "Advanced Ventilatory Support",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "200",
+              "title": "Clinical Practice III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "206",
+              "title": "Emergency & Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "210",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "212",
+              "title": "Neonatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "214",
+              "title": "Advanced Diagnostic Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "225",
+              "title": "Clinical Practice IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "228",
+              "title": "Preventive and Long-Term Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "250",
+              "title": "Clinical Practice V",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RCP",
+              "number": "260",
+              "title": "Respiratory Care Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/supply-chain-management/supply-chain-management-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Contemporary Economic Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "235",
+              "title": "Business Communications Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "256",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "288",
+              "title": "Personal and Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "289",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "256",
+              "title": "Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "100",
+              "title": "Introduction to Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "101",
+              "title": "Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "102",
+              "title": "Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "202",
+              "title": "Applied Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "210",
+              "title": "Lean for Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "101",
+              "title": "Introduction to Quality Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "210",
+              "title": "Managing Quality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "201",
+              "title": "Customer Service Improvement Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "258",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMS",
+              "number": "212",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOM",
+              "number": "180",
+              "title": "Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical First Assisting - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-first-assisting/surgical-first-assisting-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical Technology Fundamentals",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "202",
+              "title": "Surgical Technology Advanced Theory",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "280",
+              "title": "Surgical Anatomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "282",
+              "title": "Perioperative Bioscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "286",
+              "title": "Surgical Anatomy II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "288",
+              "title": "Principles of Surgical Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "294",
+              "title": "Surgical First Assistant Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "295",
+              "title": "Surgical First Assistant Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "297",
+              "title": "Surgical First Assistant Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/surgical-technology/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "137",
+              "title": "Human Anatomy and Physiology I with Laboratoryand Human Anatomy and Physiology II with Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "135",
+              "title": "Basic Anatomy and Physiology with Laboratory (Only available for Pathway 2 students.)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Systems Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/unmanned-systems-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "Introduction to Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Computer Hardware and Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Intro to Digital Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "160",
+              "title": "Intro to Networking Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "GIS Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "100",
+              "title": "Introduction to 3D Printing Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "102",
+              "title": "3D Printing Technology Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "150",
+              "title": "Introduction to Engineering Mechanics for 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DPT",
+              "number": "280",
+              "title": "Special Projects for 3D Printing, Level I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "270",
+              "title": "Electrical Motor Controls I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "271",
+              "title": "Electrical Motor Controls I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "145",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Geospatial Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "260",
+              "title": "Geospatial Web Mapping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "100",
+              "title": "Intro to Unmanned Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "105",
+              "title": "Unmanned Systems Safety and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "200",
+              "title": "Drone Fabrication and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "210",
+              "title": "Visual Observer Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "211",
+              "title": "Night Time VO Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "220",
+              "title": "First Responder Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "221",
+              "title": "Crew Resource Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "290",
+              "title": "UST Flight Mastery",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "295",
+              "title": "UST Learning Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/veterinary-technology/veterinary-technology-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Writing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics (or Higher-Level Mathematics Course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "Introduction to Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "114",
+              "title": "Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "113",
+              "title": "Introduction to Biology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Biology Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "105",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "115",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Veterinary Nursing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "123",
+              "title": "Veterinary Nursing I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Clinical Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "190",
+              "title": "Veterinary Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "195",
+              "title": "Veterinary Emergency & Critical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Veterinary Nursing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "260",
+              "title": "Veterinary Surgery & Anesthesia",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Clinical Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "270",
+              "title": "Veterinary Dentistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "Exotic and Lab Animal Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Veterinary Technology Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "273",
+              "title": "Corporate Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "274",
+              "title": "Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Communication Arts Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-communication-arts-technology/communication-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Renaissance Through Modern Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "163",
+              "title": "Basic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "173",
+              "title": "Basic Advertising Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "174",
+              "title": "Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "290",
+              "title": "Folio Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "299",
+              "title": "Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "164",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "263",
+              "title": "Product Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "264",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "145",
+              "title": "Foundations of Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "125",
+              "title": "Social Media Marketing: Fundamental Concepts, Skills, and Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "126",
+              "title": "Social Media Marketing: Project Management and Implementation Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "160",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "170",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "200",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "282",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "JavaScript I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "PHP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "155",
+              "title": "Web Page Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "157",
+              "title": "Web Site Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "Creative Writing: (Subtitle Required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "281",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "282",
+              "title": "International Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "200",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "107",
+              "title": "Commercial Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "170",
+              "title": "Drone Media Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Graphic Design & Media Production - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-graphic-design-media-production/visual-communciation-graphic-design-and-media-production-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication: Multimedia — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "2-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "133",
+              "title": "Beginning Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "180",
+              "title": "Intermediate Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "240",
+              "title": "Multimedia Development for the Web",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "250",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "255",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMD",
+              "number": "258",
+              "title": "Visual Effects for Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "105",
+              "title": "Drawing Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "106",
+              "title": "Creative Typographical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "120",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "131",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "132",
+              "title": "Illustration For Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "151",
+              "title": "Digital Filmmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "152",
+              "title": "Digital Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "171",
+              "title": "Advertising Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "251",
+              "title": "Digital Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "252",
+              "title": "Digital Filmmaking IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "135",
+              "title": "Photo Editing for Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "150",
+              "title": "Mac Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "214",
+              "title": "Promotional Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "216",
+              "title": "Apparel Graphics & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "218",
+              "title": "Digital Printing & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "230",
+              "title": "Advanced InDesign",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "235",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "245",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "260",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "265",
+              "title": "Graphic Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "266",
+              "title": "Advanced Photoshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "275",
+              "title": "Sign and Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "285",
+              "title": "Advanced Sign & Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "115",
+              "title": "2-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "125",
+              "title": "Foundations of Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "140",
+              "title": "Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "210",
+              "title": "3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "215",
+              "title": "After Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "220",
+              "title": "Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "225",
+              "title": "Advanced 3-D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "230",
+              "title": "Advanced Webpage Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "240",
+              "title": "Advanced Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCP",
+              "number": "255",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication: Multimedia - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/visual-communication-multimedia/multimedia-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "100",
+              "title": "Introduction to Visual Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "106",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "108",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "110",
+              "title": "Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "125",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "166",
+              "title": "Photoshop Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "200",
+              "title": "Illustrator Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "220",
+              "title": "InDesign Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "255",
+              "title": "Emerging Media Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCA",
+              "number": "280",
+              "title": "Professional Portfolio Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "297",
+              "title": "Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COE",
+              "number": "199",
+              "title": "Cooperative Education: (Topic)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADX",
+              "number": "120",
+              "title": "Basic Automotive Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADX",
+              "number": "121",
+              "title": "Basic Automotive Electricity Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMM",
+              "number": "114",
+              "title": "Fundamentals of Machine Tools",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Circuits I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Circuits II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "260",
+              "title": "Robotic and Industrial Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "100",
+              "title": "Welding for Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "101",
+              "title": "Welding for Maintenance Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISX",
+              "number": "101",
+              "title": "Introduction to Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "101",
+              "title": "Industrial Health, Safety, and Environmental Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "109",
+              "title": "Rigging Awareness & Fundamentals for Welders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Gas Metal Arc Welding Aluminum Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "147",
+              "title": "Flux Cored Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "151",
+              "title": "Basic Welding A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "152",
+              "title": "Basic Welding B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "161",
+              "title": "Submerged Arc Welding Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "198",
+              "title": "Special Topics in Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "227",
+              "title": "Shielded Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "229",
+              "title": "Shielded Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "237",
+              "title": "Gas Tungsten Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "239",
+              "title": "Orbital Tube Welding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "245",
+              "title": "Gas Metal Arc Welding Pipe Lab A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "247",
+              "title": "Gas Metal Arc Welding Pipe Lab B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "251",
+              "title": "Welding Automation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "253",
+              "title": "Pipe Fitting and Template Development Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPP",
+              "number": "200",
+              "title": "Workplace Principles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - AAS — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.kctcs.edu/programs-of-study/aas/welding-technology/welding-technology-aas/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Applied Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Technical Algebra and Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Contemporary College Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Introductory Physics Iand Introductory Physics I Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "252",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "181",
+              "title": "Basic Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "100",
+              "title": "Oxy-Fuel Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Oxy-Fuel Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "111",
+              "title": "Cutting Processes Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "Shielded Metal Arc Welding Fillet Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding Groove with Backing Lab (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "225",
+              "title": "Shielded Metal Arc Welding Open Groove Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "Gas Tungsten Arc Welding Fillet Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Gas Tungsten Arc Welding Groove Lab (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Gas Metal Arc Welding Fillet Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Gas Metal Arc Welding Groove Lab (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Blueprint Reading for Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Blueprint Reading for Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "220",
+              "title": "Welding Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Welding Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "298",
+              "title": "Welding Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "299",
+              "title": "Cooperative Education Program",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/scripts/ct/scrape-programs.ts
+++ b/scripts/ct/scrape-programs.ts
@@ -16,7 +16,7 @@ import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
 
 const COLLEGES: AcalogProgramConfig[] = [
   {
-    collegeSlug: "ctstate",
+    collegeSlug: "ct-state",
     baseUrl: "https://catalog.ctstate.edu",
     catoidFallback: 24,
     programNavoids: [2935],


### PR DESCRIPTION
## What changes for someone using the site

The major-plan page (e.g. `/{state}/college/{id}/program/{slug}`) now renders for **CT** and **KY** colleges. Before this PR it returned 404 / empty for every program in both states because the planner couldn't load the program file. After: a Connecticut State CC student opening Architecture AS sees a 5-term suggested sequence with the same transfer badges + section counts the existing 🟢 states show; a Jefferson CC (KY) student opening Air Conditioning Technology sees a 19-term sequence. Sampled coverage rate is 4 out of 5 KY programs and 2 out of 5 CT programs producing real sequences (the others were certificates too short to gate, not failures).

## What changes on the technical front

Two slug-mismatches, no code edits to the planner itself:

1. **CT (issue #819 item 1).** PR #822 renamed `data/ct/programs/ctstate.json` → `ct-state.json` so the loader could find it (institution id is `ct-state`), but left the internal `college_slug: "ctstate"` field and `scripts/ct/scrape-programs.ts`'s `collegeSlug: "ctstate"` intact — so the next scrape would write to the wrong filename and recreate the original bug. This PR updates both.

2. **KY (issue #819 item 3).** The KCTCS scrape stored all 91 system-wide programs in one `kctcs.json`, but `loadCollegeProgramsFromFile` reads `data/ky/programs/{collegeSlug}.json` — and no KY institution's slug is `kctcs`. KCTCS shares a single system catalog across its 16 colleges, so this PR copies the program list to each of the 16 institution slugs (matching `data/ky/courses/`) with `college_slug` updated per file, and removes the unused `kctcs.json`.

Items 2 (NJ/ND `ELEC XXX`) and 4 (SD empty `prereqs.json`) from issue #819 are not addressed here — they need real scraper work (Bergen catalog encodes electives as descriptive placeholders, not specific courses; ND only has program listings; SD has no captured prereq data). The 🟡 mid-coverage states (NY/MD/MA/VA/NV/UT/AR/NH/VT/LA) also need per-college prereq acquisition, deferred.

## Verification

Ran `buildMajorPlan(state, college, programSlug)` against the first 5 programs of each fixed college:

| College | Plans | Sequences | Sample coverage |
|---|---|---|---|
| ct/ct-state | 4/5 (1 NULL = too few real courses) | 2/5 | 0.57, 0.60 |
| ky/jefferson-cc | 5/5 | 4/5 | 0.59, 0.61, 0.82, 0.56 |
| ky/bluegrass-cc | 5/5 | 4/5 | 0.59, 0.61, 0.82, 0.56 |

## Test plan

- [ ] After merge, visit `/ct/college/ct-state/program/architecture-architectural-design-technology-as-as` on prod — sequence view should show 5 terms
- [ ] Visit `/ky/college/jefferson-community-and-technical-college/program/agriculture-aas-diploma-diploma` — sequence view should show 5 terms
- [ ] Re-running `npx tsx scripts/ct/scrape-programs.ts` writes to `data/ct/programs/ct-state.json` (not `ctstate.json`)

Closes part of #819 (items 1 + 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)