### PR TITLE
feat(planner): saved_plans — user-owned degree plans + seat-availability join

### DIFF
--- a/app/account/AccountDashboard.tsx
+++ b/app/account/AccountDashboard.tsx
@@ -53,11 +53,20 @@ interface SavedTransfer {
   created_at: string;
 }
 
+interface SavedPlan {
+  id: string;
+  state: string;
+  name: string;
+  target_courses: string[];
+  created_at: string;
+}
+
 interface Props {
   user: AccountUser;
   savedSchedules: SavedSchedule[];
   savedCourses: SavedCourse[];
   savedTransfers: SavedTransfer[];
+  savedPlans: SavedPlan[];
 }
 
 // ---------------------------------------------------------------------------
@@ -128,6 +137,7 @@ export default function AccountDashboard({
   savedSchedules: initialSchedules,
   savedCourses: initialCourses,
   savedTransfers: initialTransfers,
+  savedPlans: initialPlans,
 }: Props) {
   const router = useRouter();
   const { signOut } = useAuth();
@@ -141,12 +151,14 @@ export default function AccountDashboard({
   const [schedules, setSchedules] = useState(initialSchedules);
   const [courses, setCourses] = useState(initialCourses);
   const [transfers, setTransfers] = useState(initialTransfers);
+  const [plans, setPlans] = useState(initialPlans);
 
   const states = getAllStates();
 
   const schedulesGrouped = useMemo(() => groupByState(schedules), [schedules]);
   const coursesGrouped = useMemo(() => groupByState(courses), [courses]);
   const transfersGrouped = useMemo(() => groupByState(transfers), [transfers]);
+  const plansGrouped = useMemo(() => groupByState(plans), [plans]);
 
   // ── Preferences ──
   const handleSavePreferences = async () => {
@@ -183,6 +195,12 @@ export default function AccountDashboard({
     setTransfers((prev) => prev.filter((t) => t.id !== id));
   };
 
+  const deletePlan = async (id: string) => {
+    const supabase = createClient();
+    await supabase.from("saved_plans").delete().eq("id", id);
+    setPlans((prev) => prev.filter((p) => p.id !== id));
+  };
+
   // ── Delete account ──
   const handleDeleteAccount = async () => {
     setDeleting(true);
@@ -200,7 +218,8 @@ export default function AccountDashboard({
     setDeleting(false);
   };
 
-  const totalSaved = schedules.length + courses.length + transfers.length;
+  const totalSaved =
+    schedules.length + courses.length + transfers.length + plans.length;
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
@@ -289,7 +308,15 @@ export default function AccountDashboard({
         <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-4">
           Saved Data
         </h2>
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <a href="#plans" className="text-center p-4 rounded-lg bg-gray-50 dark:bg-slate-800 hover:ring-2 hover:ring-teal-200 dark:hover:ring-teal-800 transition">
+            <p className="text-2xl font-bold text-teal-600">
+              {plans.length}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">
+              Degree Plans
+            </p>
+          </a>
           <a href="#schedules" className="text-center p-4 rounded-lg bg-gray-50 dark:bg-slate-800 hover:ring-2 hover:ring-teal-200 dark:hover:ring-teal-800 transition">
             <p className="text-2xl font-bold text-teal-600">
               {schedules.length}
@@ -320,6 +347,39 @@ export default function AccountDashboard({
             Nothing saved yet. Use the schedule builder, course search, or
             transfer tool and click the save/bookmark buttons to keep your work.
           </p>
+        )}
+      </section>
+
+      {/* ── Degree Plans ── */}
+      <section id="plans" className="mb-6">
+        <SectionHeading
+          title="Degree Plans"
+          count={plans.length}
+          icon={
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h12M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
+            </svg>
+          }
+        />
+        {plans.length === 0 ? (
+          <EmptyCard
+            message="No saved plans yet."
+            linkText="Build a plan"
+            linkHref={user.defaultState ? `/${user.defaultState}/plan` : "/"}
+          />
+        ) : (
+          <div className="space-y-3">
+            {Array.from(plansGrouped.entries()).map(([stateSlug, items]) => (
+              <div key={stateSlug}>
+                <StateLabel state={stateSlug} />
+                <div className="space-y-2">
+                  {items.map((p) => (
+                    <PlanRow key={p.id} plan={p} onDelete={deletePlan} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
         )}
       </section>
 
@@ -582,6 +642,58 @@ function ScheduleRow({ schedule, onDelete }: { schedule: SavedSchedule; onDelete
           </Link>
         )}
         <DeleteButton onDelete={() => onDelete(schedule.id)} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plan Row
+// ---------------------------------------------------------------------------
+
+function PlanRow({ plan, onDelete }: { plan: SavedPlan; onDelete: (id: string) => void }) {
+  const targetCount = plan.target_courses?.length ?? 0;
+  const preview = (plan.target_courses ?? []).slice(0, 4).join(", ");
+  const extra = targetCount > 4 ? ` +${targetCount - 4} more` : "";
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-4 py-3 flex items-center gap-3">
+      {/* Plan icon */}
+      <div className="shrink-0 text-teal-600 dark:text-teal-400">
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h12M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
+        </svg>
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">
+          {plan.name}
+        </p>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
+          {preview && (
+            <p className="text-xs text-gray-500 dark:text-slate-400 truncate">
+              {preview}{extra}
+            </p>
+          )}
+          <span className="text-xs text-gray-400 dark:text-slate-500">
+            {targetCount} target{targetCount === 1 ? "" : "s"}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-slate-500">
+            {formatDate(plan.created_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 shrink-0">
+        <Link
+          href={`/plan/${plan.id}`}
+          className="inline-flex items-center gap-1 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-2.5 py-1.5 text-xs font-medium text-teal-600 dark:text-teal-400 hover:bg-gray-50 dark:hover:bg-slate-700 transition"
+        >
+          Open
+        </Link>
+        <DeleteButton onDelete={() => onDelete(plan.id)} />
       </div>
     </div>
   );

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -29,6 +29,7 @@ export default async function AccountPage() {
     { data: schedules },
     { data: courses },
     { data: transfers },
+    { data: plans },
   ] = await Promise.all([
     supabase
       .from("saved_schedules")
@@ -43,6 +44,11 @@ export default async function AccountPage() {
     supabase
       .from("saved_transfers")
       .select("id, state, name, selected_courses, selected_universities, filters, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("saved_plans")
+      .select("id, state, name, target_courses, created_at")
       .eq("user_id", user.id)
       .order("created_at", { ascending: false }),
   ]);
@@ -67,6 +73,7 @@ export default async function AccountPage() {
       savedSchedules={schedules ?? []}
       savedCourses={courses ?? []}
       savedTransfers={transfers ?? []}
+      savedPlans={plans ?? []}
     />
   );
 }

--- a/app/api/[state]/sections-for-courses/route.ts
+++ b/app/api/[state]/sections-for-courses/route.ts
@@ -1,0 +1,238 @@
+/**
+ * GET /api/{state}/sections-for-courses?codes=BIOL+1010,MATH+1100&term=2026FA
+ *
+ * Bulk seat-availability lookup for the SemesterPlanner. For each requested
+ * (course_prefix, course_number) pair, returns:
+ *   - section_count          how many sections offered this term
+ *   - total_seats_open       sum of seats_open across those sections
+ *   - total_seats_total      sum of seats_total across those sections
+ *   - scraped_at             timestamp of the freshest section row (proxy
+ *                            for 'last updated'; used by the planner to
+ *                            display 'seats as of [timestamp]')
+ *   - is_stale               true when scraped_at is >3 days old (matches
+ *                            the existing 3-day staleness convention used
+ *                            by app/[state]/college/[id]/CollegeTermSection)
+ *   - sample_sections        up to 3 representative sections (with college,
+ *                            mode, days/times) for UI display
+ *
+ * Codes that have ZERO sections in the requested term return an entry with
+ * section_count: 0 — the planner uses this to render an en-dash badge with
+ * a tooltip 'not offered this term'.
+ *
+ * Codes that the term lookup couldn't resolve to any database row are
+ * simply OMITTED from the response. The planner shows no badge for those.
+ *
+ * Term defaulting: if ?term is omitted or invalid, falls back to the
+ * state's current term (same as the search API).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { rateLimit, getClientKey } from "@/lib/rate-limit";
+import { isValidState } from "@/lib/states/registry";
+import { getCurrentTerm } from "@/lib/terms";
+import { getAvailableTerms } from "@/lib/courses";
+
+type RouteContext = { params: Promise<{ state: string }> };
+
+// Cap the number of codes per request — a typical plan has 10-30 courses,
+// 100 is a very generous ceiling that protects against pathological clients.
+const MAX_CODES_PER_REQUEST = 100;
+const STALE_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000;
+
+type SectionRow = {
+  course_prefix: string;
+  course_number: string;
+  college_code: string | null;
+  crn: string | null;
+  seats_open: number | null;
+  seats_total: number | null;
+  mode: string | null;
+  days: string | null;
+  start_time: string | null;
+  end_time: string | null;
+  created_at: string;
+};
+
+interface SectionSummary {
+  course_code: string;
+  section_count: number;
+  total_seats_open: number | null;
+  total_seats_total: number | null;
+  scraped_at: string | null;
+  is_stale: boolean;
+  sample_sections: Array<{
+    college_code: string | null;
+    crn: string | null;
+    mode: string | null;
+    days: string | null;
+    start_time: string | null;
+    end_time: string | null;
+    seats_open: number | null;
+    seats_total: number | null;
+  }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { state } = await context.params;
+
+  if (!isValidState(state)) {
+    return NextResponse.json({ error: "Unknown state" }, { status: 404 });
+  }
+
+  const { allowed } = rateLimit(getClientKey(request));
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again in a minute." },
+      { status: 429, headers: { "Retry-After": "60" } },
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+  const codesParam = searchParams.get("codes")?.trim() || "";
+  if (!codesParam) {
+    return NextResponse.json({ error: "codes parameter is required" }, { status: 400 });
+  }
+
+  // Parse "BIOL+1010,MATH+1100,ENGL 101" into [{prefix:"BIOL", number:"1010"}, ...]
+  // Accepts +-encoded spaces (URL-safe) or literal spaces.
+  const parsed: Array<{ prefix: string; number: string; code: string }> = [];
+  const seen = new Set<string>();
+  for (const raw of codesParam.split(",")) {
+    const normalized = raw.trim().replace(/\+/g, " ").replace(/\s+/g, " ");
+    if (!normalized) continue;
+    const m = normalized.match(/^([A-Z]{2,5})\s+(\d{3,4}[A-Z]*)$/i);
+    if (!m) continue;
+    const prefix = m[1].toUpperCase();
+    const number = m[2].toUpperCase();
+    const code = `${prefix} ${number}`;
+    if (seen.has(code)) continue;
+    seen.add(code);
+    parsed.push({ prefix, number, code });
+    if (parsed.length >= MAX_CODES_PER_REQUEST) break;
+  }
+
+  if (parsed.length === 0) {
+    return NextResponse.json(
+      { error: "No valid course codes parsed from 'codes'." },
+      { status: 400 },
+    );
+  }
+
+  // Term defaulting (matches courses/search behavior).
+  const termParam = searchParams.get("term")?.trim();
+  let term: string;
+  if (termParam) {
+    const available = await getAvailableTerms(state);
+    term = available.includes(termParam) ? termParam : await getCurrentTerm(state);
+  } else {
+    term = await getCurrentTerm(state);
+  }
+
+  // ── One bulk query for ALL requested courses ─────────────────────────────
+  // We can't do a "(prefix, number) IN ((a, b), ...)" tuple-IN on PostgREST,
+  // but we can pull rows matching the union of prefixes — the candidate set
+  // is small (handful of unique prefixes per plan) — then filter to the
+  // exact (prefix, number) pairs in memory. This is one round-trip rather
+  // than N parallel queries.
+  const uniquePrefixes = [...new Set(parsed.map((p) => p.prefix))];
+  const allowedPairs = new Set(parsed.map((p) => p.code));
+  const PAGE_SIZE = 1000;
+  const collected: SectionRow[] = [];
+
+  // Page through results; most plans won't approach the page limit but a
+  // popular subject like ENGL in a state with many colleges can exceed it.
+  for (let pageStart = 0; pageStart < 5000; pageStart += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("courses")
+      .select(
+        "course_prefix, course_number, college_code, crn, seats_open, seats_total, mode, days, start_time, end_time, created_at",
+      )
+      .eq("state", state)
+      .eq("term", term)
+      .in("course_prefix", uniquePrefixes)
+      .range(pageStart, pageStart + PAGE_SIZE - 1);
+    if (error) {
+      console.error("sections-for-courses query error:", error.message);
+      return NextResponse.json({ error: "Query failed" }, { status: 500 });
+    }
+    if (!data || data.length === 0) break;
+    for (const row of data as SectionRow[]) {
+      const code = `${row.course_prefix} ${row.course_number}`;
+      if (allowedPairs.has(code)) collected.push(row);
+    }
+    if (data.length < PAGE_SIZE) break;
+  }
+
+  // ── Aggregate per course code ────────────────────────────────────────────
+  const byCode = new Map<string, SectionRow[]>();
+  for (const row of collected) {
+    const code = `${row.course_prefix} ${row.course_number}`;
+    if (!byCode.has(code)) byCode.set(code, []);
+    byCode.get(code)!.push(row);
+  }
+
+  const now = Date.now();
+  const summaries: SectionSummary[] = parsed.map(({ code }) => {
+    const rows = byCode.get(code) ?? [];
+    if (rows.length === 0) {
+      return {
+        course_code: code,
+        section_count: 0,
+        total_seats_open: null,
+        total_seats_total: null,
+        scraped_at: null,
+        is_stale: false,
+        sample_sections: [],
+      };
+    }
+
+    let seatsOpenSum = 0;
+    let seatsTotalSum = 0;
+    let hadOpen = false;
+    let hadTotal = false;
+    let freshest = 0;
+    for (const r of rows) {
+      if (r.seats_open != null) {
+        seatsOpenSum += r.seats_open;
+        hadOpen = true;
+      }
+      if (r.seats_total != null) {
+        seatsTotalSum += r.seats_total;
+        hadTotal = true;
+      }
+      const t = new Date(r.created_at).getTime();
+      if (t > freshest) freshest = t;
+    }
+
+    const sample_sections = rows.slice(0, 3).map((r) => ({
+      college_code: r.college_code,
+      crn: r.crn,
+      mode: r.mode,
+      days: r.days,
+      start_time: r.start_time,
+      end_time: r.end_time,
+      seats_open: r.seats_open,
+      seats_total: r.seats_total,
+    }));
+
+    return {
+      course_code: code,
+      section_count: rows.length,
+      total_seats_open: hadOpen ? seatsOpenSum : null,
+      total_seats_total: hadTotal ? seatsTotalSum : null,
+      scraped_at: freshest > 0 ? new Date(freshest).toISOString() : null,
+      is_stale: freshest > 0 ? now - freshest > STALE_THRESHOLD_MS : false,
+      sample_sections,
+    };
+  });
+
+  return NextResponse.json(
+    { term, courses: summaries },
+    {
+      // Cache-friendly: seats change but the cron-driven scrape is ~daily, so
+      // a short cache + stale-while-revalidate gives a fast typical-case
+      // response without making the data wildly stale.
+      headers: { "Cache-Control": "private, max-age=60, stale-while-revalidate=300" },
+    },
+  );
+}

--- a/app/plan/[id]/SavedPlanView.tsx
+++ b/app/plan/[id]/SavedPlanView.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import SemesterPlanner from "@/components/SemesterPlanner";
+
+interface SavedPlanViewProps {
+  planId: string;
+  state: string;
+  systemName?: string;
+  name: string;
+  targetCourses: string[];
+  createdAt: string;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function SavedPlanView({
+  planId,
+  state,
+  systemName,
+  name,
+  targetCourses,
+  createdAt,
+}: SavedPlanViewProps) {
+  void planId;
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
+      {/* Header */}
+      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link
+            href="/account#plans"
+            className="text-sm text-slate-500 dark:text-slate-400 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
+          >
+            &larr; My Plans
+          </Link>
+          <Link
+            href={`/${state}`}
+            className="text-sm text-slate-500 dark:text-slate-400 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
+          >
+            {systemName || state.toUpperCase()} home &rarr;
+          </Link>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="max-w-3xl mx-auto px-4 py-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+            {name}
+          </h1>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Saved {formatDate(createdAt)} · {targetCourses.length} target
+            {targetCourses.length === 1 ? "" : "s"}
+          </p>
+        </div>
+
+        {/* Source banner — explains immutability + offers a fresh-start link.
+            Saves on this page create a NEW saved_plans row (the Save button
+            always INSERTs, never UPDATEs); this banner makes that obvious. */}
+        <div className="mb-6 rounded-lg border border-teal-200 dark:border-teal-800/50 bg-teal-50 dark:bg-teal-900/20 px-4 py-3 text-sm text-teal-800 dark:text-teal-200 flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="font-medium">Viewing a saved plan.</span>
+          <span className="text-teal-700 dark:text-teal-300/80">
+            Add or remove courses below. Saving creates a new plan rather than
+            overwriting this one.
+          </span>
+          <Link
+            href={`/${state}/plan`}
+            className="ml-auto inline-flex items-center gap-1 underline underline-offset-2 hover:text-teal-900 dark:hover:text-teal-100"
+          >
+            Start fresh
+          </Link>
+        </div>
+
+        <SemesterPlanner
+          state={state}
+          initialTargets={targetCourses}
+          initialName={name}
+        />
+      </main>
+    </div>
+  );
+}

--- a/app/plan/[id]/page.tsx
+++ b/app/plan/[id]/page.tsx
@@ -1,0 +1,79 @@
+/**
+ * /plan/[id] — view a saved degree plan.
+ *
+ * State-less URL (the plan is the noun, state is metadata on the row). The
+ * server component reads the plan row by ID via RLS (Supabase auth.uid()
+ * must match user_id), validates the state slug, then renders the standard
+ * SemesterPlanner UI hydrated with the saved targets.
+ *
+ * "Duplicate to edit" semantics, per the PR 1 design discussion:
+ *   - Plans are immutable in this PR. The user can add/remove targets on
+ *     this page and click Save; that creates a NEW saved_plans row (the
+ *     Save button always INSERTs, never UPDATEs). Source plan is unchanged.
+ *   - A banner above the planner identifies the source plan + offers a
+ *     "Start fresh" link to /[state]/plan for an empty planner.
+ *
+ * RLS lockdown:
+ *   - Unauthenticated users get redirected to / (no plan ID enumeration).
+ *   - Authenticated users who don't own this plan get the not-found page
+ *     (RLS returns no rows; we treat that as 404, not 403, to avoid
+ *     confirming the ID exists).
+ */
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getStateConfig } from "@/lib/states/registry";
+import SavedPlanView from "./SavedPlanView";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export const metadata = {
+  title: "Saved plan — Community College Path",
+  robots: { index: false, follow: false },
+};
+
+export default async function SavedPlanPage({ params }: Props) {
+  const { id } = await params;
+  // Reject anything that isn't a plausible UUID before hitting the DB.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    notFound();
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/?next=/plan/${id}`);
+  }
+
+  const { data: plan } = await supabase
+    .from("saved_plans")
+    .select("id, state, name, target_courses, created_at")
+    .eq("id", id)
+    .single();
+
+  // RLS returns null when the row exists but doesn't belong to this user,
+  // OR when the row doesn't exist. Either way, 404 — don't confirm
+  // existence to non-owners.
+  if (!plan) {
+    notFound();
+  }
+
+  const config = getStateConfig(plan.state);
+  if (!config) {
+    // Plan references a state that was removed from the registry — treat
+    // as not-found rather than crashing.
+    notFound();
+  }
+
+  return (
+    <SavedPlanView
+      planId={plan.id}
+      state={plan.state}
+      systemName={config.systemName}
+      name={plan.name}
+      targetCourses={plan.target_courses ?? []}
+      createdAt={plan.created_at}
+    />
+  );
+}

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -22,6 +22,16 @@ interface PlanCourse {
   isTarget: boolean; // was this explicitly selected by the user?
 }
 
+/** Per-course seat summary returned by /api/{state}/sections-for-courses */
+interface SeatSummary {
+  course_code: string;
+  section_count: number;
+  total_seats_open: number | null;
+  total_seats_total: number | null;
+  scraped_at: string | null;
+  is_stale: boolean;
+}
+
 interface SemesterPlannerProps {
   state: string;
   /** Pre-populate the planner with these target courses. Used by /plan/[id]
@@ -347,13 +357,62 @@ function FlowStyles() {
   );
 }
 
+/** A small pill that displays current seat availability for a course in the
+ *  plan. Same emerald/amber/red color scheme as components/schedule/
+ *  ScheduleResults.tsx's section badge, plus a 'not offered this term'
+ *  state and a 'stale' visual cue when scraped_at is >3 days old. */
+function SeatBadge({ seats }: { seats: SeatSummary }) {
+  if (seats.section_count === 0) {
+    return (
+      <span
+        className="text-[9px] px-1.5 py-0.5 rounded-full border border-slate-200 dark:border-slate-600 text-slate-400 dark:text-slate-500"
+        title="Not offered this term"
+      >
+        —
+      </span>
+    );
+  }
+  const open = seats.total_seats_open ?? 0;
+  const color =
+    open === 0
+      ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
+      : open <= 10
+        ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
+        : "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400";
+  // Stale: dim the color with reduced opacity. Keeps the at-a-glance
+  // signal but flags reduced confidence per the 3-day staleness convention.
+  const staleClass = seats.is_stale ? "opacity-60" : "";
+  const tooltip = (() => {
+    const parts = [
+      `${open} seat${open === 1 ? "" : "s"} open`,
+      seats.total_seats_total != null ? `${seats.total_seats_total} total` : null,
+      `${seats.section_count} section${seats.section_count === 1 ? "" : "s"}`,
+      seats.scraped_at
+        ? `as of ${new Date(seats.scraped_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+        : null,
+      seats.is_stale ? "(data may be outdated)" : null,
+    ];
+    return parts.filter(Boolean).join(" · ");
+  })();
+  return (
+    <span
+      className={`text-[9px] px-1.5 py-0.5 rounded-full border font-medium ${color} ${staleClass}`}
+      title={tooltip}
+    >
+      {open === 0 ? "Full" : open}
+    </span>
+  );
+}
+
 /** A single course node in the flowchart */
 function CourseNode({
   course,
   onRemove,
+  seats,
 }: {
   course: PlanCourse;
   onRemove?: (code: string) => void;
+  seats?: SeatSummary;
 }) {
   const [hover, setHover] = useState(false);
 
@@ -382,6 +441,7 @@ function CourseNode({
         `}
       >
         {course.code}
+        {seats && <SeatBadge seats={seats} />}
         {course.isTarget && (
           <span className="text-[8px] font-black px-1 py-0.5 rounded bg-teal-200/60 dark:bg-teal-700/60 text-teal-600 dark:text-teal-300 uppercase">
             target
@@ -428,11 +488,13 @@ function SemesterColumn({
   courses,
   isLast,
   onRemove,
+  seatsByCode,
 }: {
   semester: number;
   courses: PlanCourse[];
   isLast: boolean;
   onRemove: (code: string) => void;
+  seatsByCode: Map<string, SeatSummary>;
 }) {
   return (
     <div className="flex flex-col items-center gap-1.5 shrink-0">
@@ -454,6 +516,7 @@ function SemesterColumn({
             key={course.code}
             course={course}
             onRemove={course.isTarget ? onRemove : undefined}
+            seats={seatsByCode.get(course.code)}
           />
         ))}
       </div>
@@ -481,6 +544,14 @@ export default function SemesterPlanner({
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
     "idle",
   );
+
+  // Seat-availability data for every course in the current plan. Fetched
+  // from /api/{state}/sections-for-courses whenever the set of course codes
+  // changes. A Map keyed by 'BIOL 1010' style so SemesterColumn can index it.
+  const [seatsByCode, setSeatsByCode] = useState<Map<string, SeatSummary>>(
+    () => new Map(),
+  );
+  const [anyStale, setAnyStale] = useState(false);
 
   // Fetch all courses on mount
   useEffect(() => {
@@ -511,6 +582,51 @@ export default function SemesterPlanner({
     if (targets.length === 0) return [];
     return buildPlan(targets, lookup);
   }, [targets, lookup]);
+
+  // Stable key for the current plan's course codes — used to gate the
+  // seat-fetch effect so it only re-runs when the set of courses actually
+  // changes, not on every render. Sorted so order-independent.
+  const planCodesKey = useMemo(() => {
+    return plan.map((c) => c.code).sort().join("|");
+  }, [plan]);
+
+  // Fetch seat availability for every course in the plan. Debounced via the
+  // key so rapid target add/remove doesn't fire a request per keystroke.
+  useEffect(() => {
+    const codes = planCodesKey.split("|").filter(Boolean);
+    if (codes.length === 0) {
+      setSeatsByCode(new Map());
+      setAnyStale(false);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const param = codes.map((c) => c.replace(/ /g, "+")).join(",");
+        const res = await fetch(
+          `/api/${state}/sections-for-courses?codes=${encodeURIComponent(param)}`,
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as { courses: SeatSummary[] };
+        if (cancelled) return;
+        const next = new Map<string, SeatSummary>();
+        let stale = false;
+        for (const s of data.courses ?? []) {
+          next.set(s.course_code, s);
+          if (s.is_stale) stale = true;
+        }
+        setSeatsByCode(next);
+        setAnyStale(stale);
+      } catch {
+        // Non-fatal — the planner still works without seat data, badges
+        // just don't render.
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [planCodesKey, state]);
 
   // Group plan by semester
   const semesters = useMemo(() => {
@@ -691,6 +807,15 @@ export default function SemesterPlanner({
       {/* Semester flowchart */}
       {semesters.length > 0 ? (
         <>
+          {/* Stale-data banner — matches the 3-day staleness convention used by
+              app/[state]/college/[id]/CollegeTermSection.tsx. Reduces user
+              confidence in seat counts when the underlying scrape is old. */}
+          {anyStale && (
+            <div className="rounded-lg border border-amber-200 dark:border-amber-800/50 bg-amber-50 dark:bg-amber-900/20 px-4 py-2 text-xs text-amber-800 dark:text-amber-300">
+              Seat counts shown may be outdated (last updated more than 3 days
+              ago for one or more courses).
+            </div>
+          )}
           <FlowStyles />
           <div className="overflow-x-auto pb-3 -mx-1 px-1">
             <div className="flex items-start">
@@ -702,6 +827,7 @@ export default function SemesterPlanner({
                     courses={courses}
                     isLast={idx === semesters.length - 1}
                     onRemove={removeTarget}
+                    seatsByCode={seatsByCode}
                   />
                 </Fragment>
               ))}

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { Fragment, useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { track } from "@/lib/analytics";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,6 +24,13 @@ interface PlanCourse {
 
 interface SemesterPlannerProps {
   state: string;
+  /** Pre-populate the planner with these target courses. Used by /plan/[id]
+   *  to hydrate a saved plan; also lets a user "Duplicate to edit" a saved
+   *  plan by sending them to /[state]/plan with the same targets seeded. */
+  initialTargets?: string[];
+  /** Pre-fill the name field for the save dialog. Used by /plan/[id]
+   *  "Duplicate" flow to seed the new plan with the source plan's name. */
+  initialName?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -455,11 +465,22 @@ function SemesterColumn({
 // Main component
 // ---------------------------------------------------------------------------
 
-export default function SemesterPlanner({ state }: SemesterPlannerProps) {
+export default function SemesterPlanner({
+  state,
+  initialTargets,
+  initialName,
+}: SemesterPlannerProps) {
   const [allCourses, setAllCourses] = useState<PrereqEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [targets, setTargets] = useState<string[]>([]);
+  const [targets, setTargets] = useState<string[]>(initialTargets ?? []);
+
+  // Save-plan state — mirrors ScheduleResults exactly: idle → saving → saved,
+  // reverts after 3s. Auth gating via openLoginModal() if not signed in.
+  const { user, openLoginModal } = useAuth();
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
+    "idle",
+  );
 
   // Fetch all courses on mount
   useEffect(() => {
@@ -577,7 +598,7 @@ export default function SemesterPlanner({ state }: SemesterPlannerProps) {
 
       {/* Plan summary */}
       {plan.length > 0 && (
-        <div className="flex items-center gap-4 text-sm">
+        <div className="flex items-center gap-4 text-sm flex-wrap">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 rounded-full bg-teal-100 dark:bg-teal-900/40 flex items-center justify-center">
               <span className="text-sm font-bold text-teal-700 dark:text-teal-300">{totalSemesters}</span>
@@ -600,6 +621,70 @@ export default function SemesterPlanner({ state }: SemesterPlannerProps) {
             {targets.length} target{targets.length !== 1 ? "s" : ""} +{" "}
             {totalCourses - targets.length} prerequisite{totalCourses - targets.length !== 1 ? "s" : ""}
           </span>
+
+          {/* Save plan button — mirrors components/schedule/ScheduleResults.tsx
+              pattern: openLoginModal() when not signed in; idle/saving/saved
+              state; emerald confirmation, reverts after 3s. */}
+          <div className="ml-auto">
+            <button
+              type="button"
+              onClick={async () => {
+                if (!user) { openLoginModal(); return; }
+                setSaveStatus("saving");
+                try {
+                  const supabase = createClient();
+                  // Default name = comma-joined target codes, or fall back to
+                  // initialName when this is a "Duplicate to edit" flow.
+                  const fallback = targets.length > 0
+                    ? targets.join(", ")
+                    : "My Plan";
+                  const name = initialName?.trim() || fallback;
+                  const { error } = await supabase.from("saved_plans").insert({
+                    user_id: user.id,
+                    state,
+                    name,
+                    target_courses: targets,
+                    plan_data: { semesters },
+                  });
+                  if (error) throw error;
+                  setSaveStatus("saved");
+                  track("plan_save", {
+                    state,
+                    targets: targets.length,
+                    courses: totalCourses,
+                    semesters: totalSemesters,
+                  });
+                  setTimeout(() => setSaveStatus("idle"), 3000);
+                } catch {
+                  setSaveStatus("idle");
+                }
+              }}
+              disabled={saveStatus === "saving" || saveStatus === "saved"}
+              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
+                saveStatus === "saved"
+                  ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
+                  : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
+              }`}
+            >
+              {saveStatus === "saved" ? (
+                <>
+                  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                  Saved
+                </>
+              ) : saveStatus === "saving" ? (
+                "Saving..."
+              ) : (
+                <>
+                  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
+                  </svg>
+                  {user ? "Save plan" : "Sign in to save"}
+                </>
+              )}
+            </button>
+          </div>
         </div>
       )}
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -31,6 +31,10 @@ export type AnalyticsEvent =
   | "schedule_build_submit"
   | "schedule_results_view"
   | "schedule_save"
+  // Planner
+  | "plan_save"
+  | "plan_delete"
+  | "plan_duplicate"
   // Saved items
   | "course_bookmark_add"
   | "course_bookmark_remove"

--- a/supabase/migrations/017_saved_plans.sql
+++ b/supabase/migrations/017_saved_plans.sql
@@ -1,0 +1,56 @@
+-- 017_saved_plans.sql
+--
+-- User-owned degree-path plans for the SemesterPlanner.
+--
+-- Mirrors the saved_schedules / saved_courses / saved_transfers pattern
+-- from 006_user_accounts.sql: UUID PK, ON DELETE CASCADE to auth.users,
+-- state-scoped, RLS "users manage own", three covering indexes.
+--
+-- A plan stores the user's target courses (the input the planner is built
+-- around) plus a cached snapshot of the computed semester sequence. The
+-- snapshot lets /plan/[id] render instantly without re-running the planner
+-- and survives prereq-data updates that might change the live computation.
+--
+-- Plans are state-scoped (state NOT NULL) for PR 1. Cross-state plans are
+-- a later concern; nothing in the UI supports them today.
+--
+-- Plans are immutable from this PR's perspective: there is no UPDATE flow
+-- in the UI. Users delete and re-save, matching the convention of every
+-- other saved_* table. The RLS policy allows UPDATE so a future PR can
+-- add edit-in-place without a migration change.
+
+CREATE TABLE saved_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  state VARCHAR(2) NOT NULL,
+  name TEXT NOT NULL DEFAULT 'My Plan',
+  -- User input: the course codes ("BIOL 1010", "ENGL 1010") the planner was
+  -- asked to sequence. Stored as a TEXT[] for direct querying — useful when
+  -- the seat-watch cron (PR 3) needs to find "all plans containing this course".
+  target_courses TEXT[] NOT NULL DEFAULT '{}',
+  -- Cached planner output. JSONB shape mirrors buildPlan()'s return:
+  -- [{ semester: 1, courses: [{ code, title, credits, prereqs }] }, ...]
+  -- Cached for fast /plan/[id] render and to preserve the user's snapshot
+  -- even if prereq data later changes.
+  plan_data JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Indexes mirror saved_schedules: by-user (account dashboard listing),
+-- by-user-by-state (state-scoped views), by-user-by-created (DESC for
+-- "most recent first" on the dashboard).
+CREATE INDEX idx_saved_plans_user ON saved_plans(user_id);
+CREATE INDEX idx_saved_plans_user_state ON saved_plans(user_id, state);
+CREATE INDEX idx_saved_plans_user_created ON saved_plans(user_id, created_at DESC);
+
+-- A GIN index on target_courses lets the future seat-watch cron find all
+-- plans containing a given course code in O(log n) rather than scanning.
+-- Speculative-but-cheap; the cron is the next PR.
+CREATE INDEX idx_saved_plans_target_courses ON saved_plans USING GIN (target_courses);
+
+ALTER TABLE saved_plans ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own plans"
+  ON saved_plans FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## What changes for someone using the site

Two new things in the same PR — both built around the SemesterPlanner at `/[state]/plan`:

**1. Plans now persist.** A "Save plan" button appears next to the plan summary once you've added at least one course. Signed in? It saves. Not signed in? The existing sign-in modal appears. After saving, your plans show up under a new "Degree Plans" section on `/account`, and each plan opens at `/plan/{id}` with the same UI you used to build it — except now you can see when you saved it and a "Start fresh" link to begin a new one. Saving from `/plan/{id}` after edits creates a *new* plan rather than overwriting (matches how saved schedules and bookmarked courses already work).

**2. Seat counts appear next to every course in your plan.** Emerald badge = plenty of seats, amber = limited (1–10), red = "Full", en-dash = not offered this term. Each badge has a tooltip with exact counts and the date the data was scraped. If any course's data is more than 3 days stale, an amber banner above the flowchart says so honestly. This is the join the planner has been blind to until now — you can finally tell at a glance whether the courses your plan needs are actually available next term.

What this *doesn't* do yet: notify you when a seat opens. That's PR 3 in the sequence — this PR builds the foundation (saved plans + seat data) but the cron + Resend integration is intentionally out of scope.

## What changes on the technical front

Six commits, each independently reviewable:

| # | Commit | What it does |
|---|---|---|
| 1 | `feat(planner): saved_plans migration` | New `saved_plans` table mirroring `saved_schedules` exactly (UUID PK, ON DELETE CASCADE to `auth.users`, RLS "users manage own", three covering indexes + one GIN on `target_courses[]` for the future seat-watch cron) |
| 2 | `feat(planner): Save plan button` | New `initialTargets` + `initialName` props on SemesterPlanner; Save button mirrors `ScheduleResults`'s pattern; new `plan_save`/`plan_delete`/`plan_duplicate` analytics events |
| 3 | `feat(planner): Degree Plans section on /account` | New `SavedPlan` interface, parallel fetch in `app/account/page.tsx`, summary-card grid 3-col → 2/4-col responsive, new PlanRow with two-stage delete |
| 4 | `feat(planner): /plan/[id] route` | State-less URL (the plan is the noun); server component reads via RLS; 404 for both not-yours and not-found (don't confirm row existence to non-owners); banner explains the immutability model |
| 5 | `feat(planner): /api/{state}/sections-for-courses` | Bulk seat-availability endpoint. One query, in-memory filter to exact (prefix, number) pairs. Max 100 codes per request. 60s cache + 5min SWR. Returns `is_stale: true` when `created_at > 3 days` |
| 6 | `feat(planner): seat badges + 3-day staleness banner` | SeatBadge component (emerald/amber/red/en-dash), 250ms-debounced fetch effect, `anyStale` banner using the existing 3-day convention from CollegeTermSection |

**Design decisions (locked in during strategy discussion before any code):**

- **Auth-gated saves** (mirrors `saved_schedules`). No anonymous-save-then-claim flow in PR 1. Friction is real but the loop only works if you have an account anyway (PR 3 needs an email).
- **`/plan/[id]` state-less URLs**, breaking the per-state pattern intentionally. Plans are the natural cross-state object (a transfer student's plan can span WY → CO); per-state routing was built for content discovery, not user-owned data.
- **Immutable plans** (delete + re-save), matching every other `saved_*` table. Edit-in-place would have been the first mutable user-owned object in the app and required auto-save + concurrency infrastructure that nothing else needs.
- **Timestamped seat counts**, not real-time. Honest about scrape cadence. The 3-day staleness banner reuses the existing convention rather than inventing a new one.

**What's NOT in this PR (deferred to PR 2/3):**
- The seat-watch cron + Resend trigger. PR 1 makes plans persist and renders seats; PR 3 closes the loop with notifications.
- Edit-in-place. Users have a "Duplicate to edit" UX via the Save button on `/plan/{id}`.
- Cross-state plans. Schema is `state NOT NULL` for now; UI doesn't support multi-state targets yet.

## Verification done

- Typecheck clean (`npx tsc -p .`) on all 6 chunks
- Local dev server renders `/[state]/plan` without errors, course-add flow works end-to-end (chip + summary appear)
- Migration ordering: lands at `017_` after the existing `016_rpc_state_transfer_destinations.sql`
- RLS policy verified to match `saved_schedules` shape exactly

Browser-preview verification was hampered by the dev server running against the main checkout rather than this worktree — full UI exercise will need to happen against the merged branch on a Vercel preview deploy.

## Test plan
- [ ] Migration applies cleanly on a fresh Supabase
- [ ] Sign in, add a few courses on `/va/plan`, click Save → row appears in `saved_plans` with `target_courses` populated
- [ ] Visit `/account` → "Degree Plans" section shows the row with target preview, "Open" link, two-stage delete
- [ ] Click Open → `/plan/{id}` renders with banner + the same SemesterPlanner UI hydrated
- [ ] Hit `/api/va/sections-for-courses?codes=BIOL+1010,MATH+1100` directly → returns aggregate per-course summaries
- [ ] On a plan with real Fall-2026 courses, verify seat badges show, tooltips read correctly, staleness banner appears for old terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
