### PR TITLE
feat(planner): homepage card + save button + sweep fixes

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
+++ b/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { termLabel } from "@/lib/term-label";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/lib/hooks/useAuth";
 import type { MajorPlan, PlanCourse, PlanTerm, TransferStatus } from "@/lib/programs/planner";
 
 interface Props {
@@ -36,6 +38,8 @@ const PILL_MUTED =
 export default function PlanClient({ plan, transferHref }: Props) {
   const [uni, setUni] = useState<string>(plan.universities[0]?.slug ?? "__all__");
   const [view, setView] = useState<"requirements" | "sequence">("requirements");
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const { user, openLoginModal } = useAuth();
 
   const allCourses = useMemo(
     () => plan.groups.flatMap((g) => g.courses),
@@ -145,20 +149,69 @@ export default function PlanClient({ plan, transferHref }: Props) {
         </Link>
       </p>
 
-      {/* View toggle — only when a meaningful sequence is available */}
-      {plan.sequence && (
-        <div className="flex items-center gap-1 rounded-lg bg-gray-100 dark:bg-slate-800 p-1 w-fit">
-          <ToggleButton active={view === "requirements"} onClick={() => setView("requirements")}>
-            By requirement
-          </ToggleButton>
-          <ToggleButton active={view === "sequence"} onClick={() => setView("sequence")}>
-            Suggested sequence
-          </ToggleButton>
-        </div>
-      )}
+      {/* View toggle + save — row that only shows when meaningful */}
+      <div className="flex flex-wrap items-center gap-3">
+        {plan.sequence && (
+          <div className="flex items-center gap-1 rounded-lg bg-gray-100 dark:bg-slate-800 p-1">
+            <ToggleButton active={view === "requirements"} onClick={() => setView("requirements")}>
+              By requirement
+            </ToggleButton>
+            <ToggleButton active={view === "sequence"} onClick={() => setView("sequence")}>
+              Suggested sequence
+            </ToggleButton>
+          </div>
+        )}
+        {/* Save this plan — auth-gated, same pattern as SemesterPlanner save */}
+        <button
+          type="button"
+          onClick={async () => {
+            if (!user) { openLoginModal(); return; }
+            if (saveStatus !== "idle") return;
+            setSaveStatus("saving");
+            try {
+              const supabase = createClient();
+              const targetCourses = plan.groups
+                .flatMap((g) => g.courses)
+                .map((c) => c.code);
+              await supabase.from("saved_plans").insert({
+                user_id: user.id,
+                state: plan.state,
+                name: `${plan.program.title} — ${plan.collegeName}`,
+                target_courses: targetCourses,
+                plan_data: { groups: plan.groups },
+              });
+              setSaveStatus("saved");
+              setTimeout(() => setSaveStatus("idle"), 3000);
+            } catch {
+              setSaveStatus("idle");
+            }
+          }}
+          className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
+            saveStatus === "saved"
+              ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
+              : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
+          }`}
+        >
+          {saveStatus === "saved" ? (
+            <>
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+              </svg>
+              Saved
+            </>
+          ) : (
+            <>
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
+              </svg>
+              {user ? (saveStatus === "saving" ? "Saving…" : "Save this plan") : "Sign in to save"}
+            </>
+          )}
+        </button>
+      </div>
 
       {view === "sequence" && plan.sequence ? (
-        <SequenceView terms={plan.sequence.terms} uni={uni} coverage={plan.sequence.prereqCoverage} />
+        <SequenceView terms={plan.sequence.terms} uni={uni} coverage={plan.sequence.prereqCoverage} truncated={plan.sequence.truncated} />
       ) : (
         /* Requirement groups */
         <div className="space-y-6">
@@ -230,10 +283,12 @@ function SequenceView({
   terms,
   uni,
   coverage,
+  truncated,
 }: {
   terms: PlanTerm[];
   uni: string;
   coverage: number;
+  truncated: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -242,6 +297,12 @@ function SequenceView({
         ({Math.round(coverage * 100)}% of courses have prerequisite data). This is
         a starting point — your advisor sets the official sequence.
       </p>
+      {truncated && (
+        <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-sm text-amber-800 dark:text-amber-300">
+          This program has many prerequisites and needs more than 8 terms to fully
+          sequence. Showing the first 8 — talk to an advisor to map out the full path.
+        </div>
+      )}
       {terms.map((t) => (
         <section
           key={t.index}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,7 +160,7 @@ export default async function LandingPage() {
           <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-8">
             what you can do
           </div>
-          <div className="grid sm:grid-cols-3 gap-4">
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {[
               {
                 num: "01",
@@ -201,6 +201,20 @@ export default async function LandingPage() {
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
+                  />
+                ),
+              },
+              {
+                num: "04",
+                title: "Plan a degree",
+                body: "Pick a program, choose your transfer target, and see every required course — which ones count there, and what's open now.",
+                href: geoState ? `/${geoState}/colleges` : "/colleges",
+                cta: "Start planning",
+                icon: (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5"
                   />
                 ),
               },

--- a/lib/programs/planner.ts
+++ b/lib/programs/planner.ts
@@ -121,6 +121,8 @@ export interface PlanSequence {
   prereqCoverage: number;
   /** Credit ceiling used when packing courses into a term. */
   creditsPerTerm: number;
+  /** True when the full sequence exceeded MAX_DISPLAY_TERMS and was truncated. */
+  truncated: boolean;
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────
@@ -338,6 +340,8 @@ function rank(s: TransferStatus): number {
 const TERM_CREDIT_CAP = 16;
 /** Below this prereq coverage the ordering is noise — show only the checklist. */
 const SEQUENCE_MIN_COVERAGE = 0.25;
+/** Maximum terms to show — prevents 35-term sequences on over-prereqed programs. */
+const MAX_DISPLAY_TERMS = 8;
 
 /**
  * Order a program's courses into credit-capped terms using recorded
@@ -425,9 +429,13 @@ export function buildSequence(
     }
   }
 
+  const truncated = terms.length > MAX_DISPLAY_TERMS;
   return {
-    terms: terms.map((t, i) => ({ index: i + 1, courses: t.courses, credits: t.credits })),
+    terms: terms
+      .slice(0, MAX_DISPLAY_TERMS)
+      .map((t, i) => ({ index: i + 1, courses: t.courses, credits: t.credits })),
     prereqCoverage: coverage,
     creditsPerTerm: TERM_CREDIT_CAP,
+    truncated,
   };
 }

--- a/scripts/sd/scrape-southeast-tech.ts
+++ b/scripts/sd/scrape-southeast-tech.ts
@@ -56,6 +56,10 @@ interface CourseSection {
   prerequisite_courses: string[];
 }
 
+const SEASON_SUFFIX: Record<string, string> = {
+  fall: "FA", spring: "SP", summer: "SU", winter: "WI",
+};
+
 function parseTerm(label: string): { code: string; year: number } | null {
   const m = label.match(
     /^(\d{4})-(\d{4}) School Year - (Fall|Spring|Summer|Winter) Term/i,
@@ -65,7 +69,8 @@ function parseTerm(label: string): { code: string; year: number } | null {
   const endYear = parseInt(m[2], 10);
   const season = m[3].toLowerCase();
   const year = season === "fall" ? startYear : endYear;
-  return { code: `${season}-${year}`, year };
+  // Standard YYYYFA/YYYYSP/YYYYSU codes — matches every other state's format.
+  return { code: `${year}${SEASON_SUFFIX[season] ?? season.toUpperCase().slice(0,2)}`, year };
 }
 
 function parseCourseCode(raw: string): {


### PR DESCRIPTION
## What changes for someone using the site

Three things, in order of surface area:

### 1. Homepage now has a "Plan a degree" entry
The homepage has been the site's busiest page and had no entry to the planner — it showed Search / Transfer / Schedule and silently omitted the most complete feature. There's now a fourth card: **"Plan a degree"** — *"Pick a program, choose your transfer target, and see every required course — which ones count there, and what's open now."* It points to the state's colleges page (the natural first step to finding a college + program). The grid shifts from 3 columns to 2-on-tablet / 4-on-desktop to accommodate it.

### 2. Plan page has a "Save this plan" button
PR #827 shipped the `saved_plans` table, `/plan/[id]` shareable route, and the account dashboard — but left no UI on the actual plan page to trigger a save. There's now a compact **"Save this plan"** bookmark button alongside the view toggle. If you're logged in it inserts into `saved_plans`; if not it opens the sign-in modal with *"Sign in to save"*. Follows the same auth-gated pattern as the semester planner's save button. The saved name defaults to *"{program} — {college}"*.

### 3. Two fixes from the national sweep
The 116-plan sweep across 22 states found two bugs:
- **Sequence cap:** some programs (NY herkimer liberal arts: 35 terms; GA aviation: 15 terms) produced unreasonably long sequences. Capped at 8 terms with an amber advisory: *"This program has many prerequisites and needs more than 8 terms to fully sequence. Talk to an advisor."*
- **SD term codes:** the SD scraper was writing `summer-2026` / `fall-2026` while every other state uses `2026SU` / `2026FA`. Section lookup was failing silently. Fixed in the scraper; takes effect on next SD scrape.

## Test plan
- ✅ `tsc` clean · `eslint` clean.
- ✅ Sequence cap verified: NY herkimer (was 35) → 8 terms, `truncated=true`.
- ✅ SD scraper: `SEASON_SUFFIX` map added; normalised output confirmed.
- Homepage: renderable locally; the 4th card copy and grid layout are straightforward (no data dep).
- Save button: auth-gated; follows proven SemesterPlanner pattern exactly. Full test requires a logged-in Supabase session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)