### PR TITLE
feat(planner): explicit Duplicate-to-edit button on /plan/[id]

### DIFF
--- a/app/[state]/plan/PlannerClient.tsx
+++ b/app/[state]/plan/PlannerClient.tsx
@@ -1,11 +1,38 @@
 "use client";
 
+import { Suspense } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import SemesterPlanner from "@/components/SemesterPlanner";
 
 interface PlannerClientProps {
   state: string;
   systemName?: string;
+}
+
+/** Reads ?targets= and ?name= from the URL so /plan/[id]'s 'Duplicate'
+ *  button can hand off a pre-populated draft. Lives in its own component
+ *  because Next 16 requires useSearchParams() under a Suspense boundary. */
+function PlannerWithParams({ state }: { state: string }) {
+  const params = useSearchParams();
+  // ?targets=BIOL+1010,MATH+1100 — '+' decoded as space by URL parsing.
+  // Split on comma, trim, drop empties. Length-limited so a pathological
+  // URL can't OOM the planner.
+  const rawTargets = params.get("targets") ?? "";
+  const initialTargets = rawTargets
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 100);
+  const initialName = (params.get("name") ?? "").slice(0, 200) || undefined;
+
+  return (
+    <SemesterPlanner
+      state={state}
+      initialTargets={initialTargets.length > 0 ? initialTargets : undefined}
+      initialName={initialName}
+    />
+  );
 }
 
 export default function PlannerClient({ state, systemName }: PlannerClientProps) {
@@ -36,7 +63,10 @@ export default function PlannerClient({ state, systemName }: PlannerClientProps)
           </p>
         </div>
 
-        <SemesterPlanner state={state} />
+        {/* Suspense boundary required by Next 16 for useSearchParams. */}
+        <Suspense fallback={<SemesterPlanner state={state} />}>
+          <PlannerWithParams state={state} />
+        </Suspense>
       </main>
     </div>
   );

--- a/app/plan/[id]/SavedPlanView.tsx
+++ b/app/plan/[id]/SavedPlanView.tsx
@@ -20,6 +20,17 @@ function formatDate(iso: string): string {
   });
 }
 
+/** Build the duplicate URL: /{state}/plan?targets=BIOL+1010,MATH+1100&name=...
+ *  Mirrors the parsing in app/[state]/plan/PlannerClient.tsx — '+' encodes a
+ *  space inside each course code; ',' separates codes. Name gets URI-encoded
+ *  via URLSearchParams. Returns a relative path so Next-Link can intercept. */
+function duplicateUrl(state: string, targets: string[], name: string): string {
+  if (targets.length === 0) return `/${state}/plan`;
+  const codes = targets.map((c) => c.replace(/ /g, "+")).join(",");
+  const sp = new URLSearchParams({ targets: codes, name: `${name} (copy)` });
+  return `/${state}/plan?${sp.toString()}`;
+}
+
 export default function SavedPlanView({
   planId,
   state,
@@ -61,21 +72,35 @@ export default function SavedPlanView({
           </p>
         </div>
 
-        {/* Source banner — explains immutability + offers a fresh-start link.
-            Saves on this page create a NEW saved_plans row (the Save button
-            always INSERTs, never UPDATEs); this banner makes that obvious. */}
-        <div className="mb-6 rounded-lg border border-teal-200 dark:border-teal-800/50 bg-teal-50 dark:bg-teal-900/20 px-4 py-3 text-sm text-teal-800 dark:text-teal-200 flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="font-medium">Viewing a saved plan.</span>
-          <span className="text-teal-700 dark:text-teal-300/80">
-            Add or remove courses below. Saving creates a new plan rather than
-            overwriting this one.
-          </span>
-          <Link
-            href={`/${state}/plan`}
-            className="ml-auto inline-flex items-center gap-1 underline underline-offset-2 hover:text-teal-900 dark:hover:text-teal-100"
-          >
-            Start fresh
-          </Link>
+        {/* Source banner — explains immutability + offers a duplicate/fresh
+            option. Saves on this page create a NEW saved_plans row (the Save
+            button always INSERTs, never UPDATEs); the explicit 'Duplicate to
+            edit' button makes the model less surprising. The same flow also
+            works inline: add/remove courses below, then click Save to create
+            a new plan from the modified state. */}
+        <div className="mb-6 rounded-lg border border-teal-200 dark:border-teal-800/50 bg-teal-50 dark:bg-teal-900/20 px-4 py-3 text-sm text-teal-800 dark:text-teal-200">
+          <p className="font-medium mb-1">Viewing a saved plan.</p>
+          <p className="text-teal-700 dark:text-teal-300/80 mb-3">
+            Plans are immutable — clicking Save below creates a new plan
+            rather than overwriting this one.
+          </p>
+          <div className="flex flex-wrap gap-2 items-center">
+            <Link
+              href={duplicateUrl(state, targetCourses, name)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-teal-600 hover:bg-teal-700 text-white px-3 py-1.5 text-xs font-medium transition"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.026a1.125 1.125 0 001.125 1.125h.375" />
+              </svg>
+              Duplicate to edit
+            </Link>
+            <Link
+              href={`/${state}/plan`}
+              className="inline-flex items-center gap-1 text-xs text-teal-700 dark:text-teal-300/80 underline underline-offset-2 hover:text-teal-900 dark:hover:text-teal-100"
+            >
+              Start a fresh plan instead
+            </Link>
+          </div>
         </div>
 
         <SemesterPlanner


### PR DESCRIPTION
## What changes for someone using the site

Builds on PR #827 (saved degree plans). When you open a saved plan at `/plan/{id}`, you now see a prominent **"Duplicate to edit"** button instead of the quiet "Start fresh" link. Clicking it drops you into `/{state}/plan` with the original plan's courses already filled in and the name pre-set to `<Original> (copy)`. From there you tweak and click Save → a new saved plan appears.

The implicit flow from PR #827 (add courses on `/plan/{id}` → click Save → new plan created) still works. This PR just makes the duplicate model explicit instead of leaving users to figure it out.

The banner copy is also clearer: *"Plans are immutable — clicking Save below creates a new plan rather than overwriting this one."*

## What changes on the technical front

Two small files:

**`app/plan/[id]/SavedPlanView.tsx`** — replaces the inline "Start fresh" link with a primary teal button + a secondary text link. New `duplicateUrl()` helper composes the query string: `+` encodes spaces inside course codes (`BIOL+1010`), `,` separates codes, name gets URI-encoded via `URLSearchParams`.

**`app/[state]/plan/PlannerClient.tsx`** — new inner `PlannerWithParams` component reads `?targets` and `?name` via `useSearchParams` and hands them to `SemesterPlanner` as `initialTargets` / `initialName`. Those props were added in PR #827 chunk 2 but nothing routed to them until now. Wrapped in `<Suspense>` as Next 16 requires.

**Length limits:** targets capped at 100 entries, name at 200 chars — pathological URLs can't OOM the planner.

**Verified on prod:** PR #827 just deployed; confirmed `/api/va/sections-for-courses?codes=ACC+212` returns real data (82 sections, `is_stale: true` for 2-week-old scrape) and `/plan/[id]` route matches correctly.

## Test plan
- [x] Typecheck clean (`npx tsc --noEmit -p .`)
- [ ] After merge: open a saved plan, click "Duplicate to edit", confirm the planner loads with the original targets and a `<name> (copy)` name in the upcoming save dialog
- [ ] After merge: edit one course, click Save, confirm a new row in `saved_plans` (and the original is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
