### PR TITLE
fix(deploy): cap Supabase fan-out during static prerender

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   getAvailableTerms,
   trimCoursesForClient,
 } from "@/lib/courses";
+import { runPooled } from "@/lib/concurrency";
 import { getCurrentTerm } from "@/lib/terms";
 import CollegeScorecardSection from "./CollegeScorecardSection";
 import CollegeTermSection from "./CollegeTermSection";
@@ -112,13 +113,23 @@ export default async function CollegeDetailPage(props: PageProps) {
   // Load courses for every term this college has data in. Doing this server-
   // side lets the client switch terms via the URL without triggering a fresh
   // server render, which would force the whole page out of ISR.
+  //
+  // Concurrency note: each loadCoursesForCollege call internally fires
+  // (count + N paginated fetches) capped at runPooled(..., 5). With ~4-6
+  // terms fanned out at once via a naked Promise.all, peak parallelism per
+  // college page was 4-6 × ~5 = ~20-30 simultaneous Supabase queries. Stack
+  // that across the build's 3 worker processes and pgbouncer saturates,
+  // producing the statement_timeout cascade visible on PRs #823 / #824 /
+  // #825 / #826. Cap term-fan-out to 2 to keep peak in-flight queries per
+  // page render at ~10.
   const allTerms = await getAvailableTerms(state);
   const termCoursePairs: { term: string; courses: CourseSection[] }[] =
-    await Promise.all(
-      allTerms.map(async (t) => ({
+    await runPooled(
+      allTerms.map((t) => async () => ({
         term: t,
         courses: await loadCoursesForCollege(institution.college_slug, t, state),
-      }))
+      })),
+      2,
     );
   const termsWithData = termCoursePairs
     .filter((p) => p.courses.length > 0)
@@ -151,9 +162,13 @@ export default async function CollegeDetailPage(props: PageProps) {
   > = {};
   const courseListingUrlByTerm: Record<string, string> = {};
 
+  // Same fan-out concern as the first Promise.all above: each iteration
+  // fires isDataStale (1 query) + getTopInstructors (1 query) per term;
+  // unbounded across N terms × 3 build workers × the parent loop's already
+  // running queries piles onto pgbouncer. Cap to 2.
   const union: CourseSection[] = [];
-  await Promise.all(
-    termsWithData.map(async (t) => {
+  await runPooled(
+    termsWithData.map((t) => async () => {
       const courses =
         termCoursePairs.find((p) => p.term === t)?.courses ?? [];
       // Only ship the default term's courses in the initial RSC payload.
@@ -179,7 +194,8 @@ export default async function CollegeDetailPage(props: PageProps) {
       // every course the college offers, regardless of which term
       // the user has selected.
       union.push(...courses);
-    })
+    }),
+    2,
   );
 
   // Shared transfer lookup, scoped to the union of courses across all terms

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -16,7 +16,12 @@ interface CacheEntry<T> {
 const cache = new Map<string, CacheEntry<unknown>>();
 const inflight = new Map<string, Promise<unknown>>();
 
-async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
+/** In-memory cache + concurrent-call dedup. Exported so other modules can
+ *  share the same cache keyspace and avoid repeated full-table paginations
+ *  during static prerender (see lib/transfer.ts getUniversitiesWithCounts,
+ *  which gets called 3× per transfer-hub page — generateStaticParams,
+ *  generateMetadata, page handler). */
+export async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
   const entry = cache.get(key) as CacheEntry<T> | undefined;
   if (entry && entry.expires > Date.now()) return entry.data;
 

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import type { TransferMapping, TransferMappingClient } from "./types";
 import { supabase } from "./supabase";
+import { cached } from "./courses";
 
 /**
  * Hard cap on mappings passed to the client on a single transfer-hub page.
@@ -345,6 +346,28 @@ export async function getUniversitiesWithCounts(state: string): Promise<
     directCount: number;
     electiveCount: number;
     totalCount: number; // direct + elective (i.e. "transferable" count)
+  }[]
+> {
+  // Memoize per state — this function is the heaviest read in the codebase
+  // (paginates the full transfers table for the state) and gets called 3×
+  // per transfer-hub page during static prerender: once in
+  // generateStaticParams, once in generateMetadata, once in the page handler.
+  // Without dedup, a build that renders ~100 transfer-hub pages fires 300+
+  // identical paginations and reliably hits Supabase's statement_timeout.
+  // The cache lives in-process so it survives the whole build cycle for a
+  // given Vercel worker.
+  return cached(`universities-with-counts:${state}`, () =>
+    _getUniversitiesWithCounts(state),
+  );
+}
+
+async function _getUniversitiesWithCounts(state: string): Promise<
+  {
+    slug: string;
+    name: string;
+    directCount: number;
+    electiveCount: number;
+    totalCount: number;
   }[]
 > {
   // Performance: column-projected Supabase query — same reason as


### PR DESCRIPTION
## What changes for someone using the site

**Users see nothing new.** This unblocks the Vercel deploy pipeline that's been failing on 4 of the 5 most recent commits before #827 (commits `abe6a0cc`, `0a29d1d0`, `73b50b36`, `88322e41`). Each of those PRs is sitting on `main` but their changes never reached prod because the build failed with `statement_timeout` errors during static page generation. PR #827 happened to deploy because pgbouncer was less contended at that moment — the next push could fail just as easily.

After this lands, builds become resilient against the same fan-out pattern that's killing them.

## What changes on the technical front

Three surgical fixes — no schema change, no new RPC, no ISR migration. Total diff: 3 files, +51/-7.

**Root cause** (per an explicit research pass before touching code):

1. `getUniversitiesWithCounts(state)` was called **three times per transfer-hub page render** — once in `generateStaticParams`, once in `generateMetadata`, once in the page handler. Each call paginates the full `transfers` table for that state (10–15K rows). With ~100 transfer-hub pages across ~10 states, that's **300+ identical full paginations** during one build.

2. The college page fired `Promise.all` over `allTerms.map(...)` with no concurrency cap, kicking off 4–6 parallel `loadCoursesForCollege` calls per page. Each *internally* fanned out further (count + N pages), pushing peak in-flight queries per page to ~20–30. Stack across 3 Vercel build workers × pgbouncer (~20–30 conn cap) and the pool saturates; slowest queries hit the 30s statement_timeout and the build fails.

**The three fixes:**

| File | Change | Why |
|---|---|---|
| `lib/courses.ts` | Export the existing private `cached()` helper | So other modules can share the same in-process memoization keyspace; no behavior change for current callers |
| `lib/transfer.ts` | Wrap `getUniversitiesWithCounts(state)` in `cached('universities-with-counts:STATE', ...)` | Collapses the 3-calls-per-page to 1-per-state-per-build. ~100 pages × 3 callers × 10 states → 10 paginations total |
| `app/[state]/college/[id]/page.tsx` | Replace two `Promise.all(...)` with `runPooled(..., 2)` | Caps term-fan-out to 2 concurrent at a time, bringing peak in-flight queries per page render from ~20–30 down to ~10 |

This mirrors the existing fix in commit `8391a60` (`lib/concurrency.ts`) which solved the same class of problem for `loadCoursesForCollege` *internally*; this PR extends the same discipline to the call sites that aggregate over its results.

## Trade-offs

- **+1–2s per page render** at build time from the `runPooled(2)` throttle. Invisible to users (static render); the build-resilience win is the point.
- **In-memory cache lifetime = 5 min** (the existing `cached()` TTL). That's much longer than a build cycle, so within a single `next build` run every state is queried exactly once. For prod RSC renders, the same dedup helps with cold-start traffic spikes.
- **Not addressed in this PR:** the underlying scale problem (155 colleges × multiple terms = a lot of build queries no matter how well throttled). A future PR could move some routes to ISR with on-demand revalidation, but that's a bigger conversation than "the deploy is broken right now."

## Test plan
- [x] Typecheck clean (`npx tsc --noEmit -p .`)
- [ ] Vercel build succeeds when this PR merges (the actual test)
- [ ] After merge: the previously-failed commits (`abe6a0cc`, `0a29d1d0`, `73b50b36`, `88322e41`) won't auto-redeploy, but the next PR pushed on top of this will be the first real signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
