### PR TITLE
feat(sd): populate prereqs from Coursedog catalog — #819

### DIFF
--- a/data/sd/prereqs.json
+++ b/data/sd/prereqs.json
@@ -1,0 +1,696 @@
+{
+  "ACCT 111": {
+    "text": "ACCT 110. Minimum \"C\" grade required.",
+    "courses": [
+      "ACCT 110"
+    ]
+  },
+  "ACCT 212": {
+    "text": "ACCT 111.",
+    "courses": [
+      "ACCT 111"
+    ]
+  },
+  "ACCT 213": {
+    "text": "ACCT 212.",
+    "courses": [
+      "ACCT 212"
+    ]
+  },
+  "ACCT 218": {
+    "text": "ACCT 111.",
+    "courses": [
+      "ACCT 111"
+    ]
+  },
+  "ACCT 245": {
+    "text": "ACCT 1111",
+    "courses": [
+      "ACCT 1111"
+    ]
+  },
+  "AGT 210": {
+    "text": "AGT 110",
+    "courses": [
+      "AGT 110"
+    ]
+  },
+  "BUS 111": {
+    "text": "BUS 110",
+    "courses": [
+      "BUS 110"
+    ]
+  },
+  "BUS 203": {
+    "text": "BUS 143. Corequisite/Prerequisite: BUS 170.",
+    "courses": [
+      "BUS 143",
+      "BUS 170"
+    ]
+  },
+  "CA 135": {
+    "text": "CA 134, CA 140, CA 145, 165.",
+    "courses": [
+      "CA 134",
+      "CA 140",
+      "CA 145"
+    ]
+  },
+  "CA 150": {
+    "text": "CA 134, CA 140, CA 145, CA165.",
+    "courses": [
+      "CA 134",
+      "CA 140",
+      "CA 145",
+      "CA 165"
+    ]
+  },
+  "CA 166": {
+    "text": "CA 107, CA 134, CA 140, CA 145, CA 165.",
+    "courses": [
+      "CA 107",
+      "CA 134",
+      "CA 140",
+      "CA 145",
+      "CA 165"
+    ]
+  },
+  "CA 212": {
+    "text": "CA 135, CA 150, CA 155, CA 166",
+    "courses": [
+      "CA 135",
+      "CA 150",
+      "CA 155",
+      "CA 166"
+    ]
+  },
+  "CA 215": {
+    "text": "CA 135, CA 150, CA 155, CA 166",
+    "courses": [
+      "CA 135",
+      "CA 150",
+      "CA 155",
+      "CA 166"
+    ]
+  },
+  "CA 231": {
+    "text": "CA 135, CA 150, CA 155, CA 166",
+    "courses": [
+      "CA 135",
+      "CA 150",
+      "CA 155",
+      "CA 166"
+    ]
+  },
+  "CA 240": {
+    "text": "CA 135, CA 150, CA 155, CA 166",
+    "courses": [
+      "CA 135",
+      "CA 150",
+      "CA 155",
+      "CA 166"
+    ]
+  },
+  "CIS 170": {
+    "text": "CIS 143.",
+    "courses": [
+      "CIS 143"
+    ]
+  },
+  "CIS 203": {
+    "text": "CIS 143. Corequisite/Prerequisite: CIS 170.",
+    "courses": [
+      "CIS 143",
+      "CIS 170"
+    ]
+  },
+  "EC 113": {
+    "text": "EC 121 or EC 112",
+    "courses": [
+      "EC 121",
+      "EC 112"
+    ]
+  },
+  "EC 249": {
+    "text": "EC 100 and EC 105.",
+    "courses": [
+      "EC 100",
+      "EC 105"
+    ]
+  },
+  "ECM 103": {
+    "text": "ECM 101, ECM 151.",
+    "courses": [
+      "ECM 101",
+      "ECM 151"
+    ]
+  },
+  "ECM 122": {
+    "text": "ECM 121.",
+    "courses": [
+      "ECM 121"
+    ]
+  },
+  "ECM 157": {
+    "text": "ECM 101, ECM 121, ECM 151.",
+    "courses": [
+      "ECM 101",
+      "ECM 121",
+      "ECM 151"
+    ]
+  },
+  "ECM 253": {
+    "text": "ECM 252, ECM 255. Corequisite: ECM 257.",
+    "courses": [
+      "ECM 252",
+      "ECM 255",
+      "ECM 257"
+    ]
+  },
+  "ECM 257": {
+    "text": "ECM 255",
+    "courses": [
+      "ECM 255"
+    ]
+  },
+  "ECM 261": {
+    "text": "ECM 259.",
+    "courses": [
+      "ECM 259"
+    ]
+  },
+  "ENGL 201": {
+    "text": "ENGL 098 or qualifying placement score.",
+    "courses": [
+      "ENGL 098"
+    ]
+  },
+  "HV 232": {
+    "text": "HV 251",
+    "courses": [
+      "HV 251"
+    ]
+  },
+  "HV 259": {
+    "text": "HV 251",
+    "courses": [
+      "HV 251"
+    ]
+  },
+  "HV 290": {
+    "text": "Successful completion with a GPA of 2.0 or higherin all previous required technical courses.",
+    "courses": []
+  },
+  "IST 256": {
+    "text": "IST 222.",
+    "courses": [
+      "IST 222"
+    ]
+  },
+  "LPN 105": {
+    "text": "LPN 100 LPN 101, LPN 102, LPN 103. Corequisite: LPN 106, LPN 107, LPN 108",
+    "courses": [
+      "LPN 100",
+      "LPN 101",
+      "LPN 102",
+      "LPN 103",
+      "LPN 106",
+      "LPN 107",
+      "LPN 108"
+    ]
+  },
+  "LPN 106": {
+    "text": "LPN 100, LPN 101, LPN 102, LPN 103. Corequisite: LPN 107, LPN 105, LPN 108",
+    "courses": [
+      "LPN 100",
+      "LPN 101",
+      "LPN 102",
+      "LPN 103",
+      "LPN 107",
+      "LPN 105",
+      "LPN 108"
+    ]
+  },
+  "LPN 107": {
+    "text": "LPN 100, LPN 101, LPN 102, LPN 103. Corequisite: LPN 105, LPN 106, LPN 108",
+    "courses": [
+      "LPN 100",
+      "LPN 101",
+      "LPN 102",
+      "LPN 103",
+      "LPN 105",
+      "LPN 106",
+      "LPN 108"
+    ]
+  },
+  "LPN 108": {
+    "text": "LPN 100, LPN 101, LPN 102, LPN 103. Corequisite: LPN 105, LPN 106, LPN 107",
+    "courses": [
+      "LPN 100",
+      "LPN 101",
+      "LPN 102",
+      "LPN 103",
+      "LPN 105",
+      "LPN 106",
+      "LPN 107"
+    ]
+  },
+  "LPN 110": {
+    "text": "LPN 105, LPN 106, LPN 107, LPN 108. Corequisite: LPN 109, LPN 113",
+    "courses": [
+      "LPN 105",
+      "LPN 106",
+      "LPN 107",
+      "LPN 108",
+      "LPN 109",
+      "LPN 113"
+    ]
+  },
+  "LPN 113": {
+    "text": "LPN 105, LPN 106, LPN 107, LPN 108. Corequisite: LPN 109, LPN 110",
+    "courses": [
+      "LPN 105",
+      "LPN 106",
+      "LPN 107",
+      "LPN 108",
+      "LPN 109",
+      "LPN 110"
+    ]
+  },
+  "LPN 150": {
+    "text": "LPN 109, LPN 110, LPN 113",
+    "courses": [
+      "LPN 109",
+      "LPN 110",
+      "LPN 113"
+    ]
+  },
+  "MA 123": {
+    "text": "HS 101, HS 103.",
+    "courses": [
+      "HS 101",
+      "HS 103"
+    ]
+  },
+  "MA 210": {
+    "text": "HS 101, HS 103.",
+    "courses": [
+      "HS 101",
+      "HS 103"
+    ]
+  },
+  "MA 211": {
+    "text": "MA 111.",
+    "courses": [
+      "MA 111"
+    ]
+  },
+  "MA 240": {
+    "text": "MA 101, MA 103, MA 123.",
+    "courses": [
+      "MA 101",
+      "MA 103",
+      "MA 123"
+    ]
+  },
+  "MA 250": {
+    "text": "Successful completion of 64.5 credits prior to start of externship.",
+    "courses": []
+  },
+  "ML 171": {
+    "text": "Grade of C or higher in ML 104 and ML 105.",
+    "courses": [
+      "ML 104",
+      "ML 105"
+    ]
+  },
+  "ML 230": {
+    "text": "a grade of C or higher is required in ML 104, ML 105 and ML 141.",
+    "courses": [
+      "ML 104",
+      "ML 105",
+      "ML 141"
+    ]
+  },
+  "ML 272": {
+    "text": "A grade of C or higher in ML 171.",
+    "courses": [
+      "ML 171"
+    ]
+  },
+  "MOP 206": {
+    "text": "HS 101, HS 103, MA 123.",
+    "courses": [
+      "HS 101",
+      "HS 103",
+      "MA 123"
+    ]
+  },
+  "MOP 210": {
+    "text": "MOP 160.",
+    "courses": [
+      "MOP 160"
+    ]
+  },
+  "MOP 212": {
+    "text": "HS 101, HS 103.",
+    "courses": [
+      "HS 101",
+      "HS 103"
+    ]
+  },
+  "MOP 260": {
+    "text": "MOP 160.",
+    "courses": [
+      "MOP 160"
+    ]
+  },
+  "MOP 262": {
+    "text": "MOP 260.",
+    "courses": [
+      "MOP 260"
+    ]
+  },
+  "MOP 290": {
+    "text": "The student must meet department criteria to be eligible for internship.",
+    "courses": []
+  },
+  "OPRV 106": {
+    "text": "OPRV 105.",
+    "courses": [
+      "OPRV 105"
+    ]
+  },
+  "OPRV 142": {
+    "text": "OPRV 140",
+    "courses": [
+      "OPRV 140"
+    ]
+  },
+  "PL 143": {
+    "text": "PL 141",
+    "courses": [
+      "PL 141"
+    ]
+  },
+  "PL 156": {
+    "text": "PL 150",
+    "courses": [
+      "PL 150"
+    ]
+  },
+  "PL 172": {
+    "text": "PL 171",
+    "courses": [
+      "PL 171"
+    ]
+  },
+  "PSYC 130": {
+    "text": "HST 101.",
+    "courses": [
+      "HST 101"
+    ]
+  },
+  "RAD 120": {
+    "text": "RAD 110, RAD 140, RAD 150, HS 103",
+    "courses": [
+      "RAD 110",
+      "RAD 140",
+      "RAD 150",
+      "HS 103"
+    ]
+  },
+  "RAD 122": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "RAD 123": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 124": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 125": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 131": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 133": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "RAD 134": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 136": {
+    "text": "MA 101, MA 103, All previous technical courses.",
+    "courses": [
+      "MA 101",
+      "MA 103"
+    ]
+  },
+  "RAD 142": {
+    "text": "HS 103, RAD 110, RAD 140, RAD 150",
+    "courses": [
+      "HS 103",
+      "RAD 110",
+      "RAD 140",
+      "RAD 150"
+    ]
+  },
+  "RAD 152": {
+    "text": "HS 103, RAD 110, RAD 140, RAD 150",
+    "courses": [
+      "HS 103",
+      "RAD 110",
+      "RAD 140",
+      "RAD 150"
+    ]
+  },
+  "RAD 154": {
+    "text": "HS 103, RAD 150, RAD 152",
+    "courses": [
+      "HS 103",
+      "RAD 150",
+      "RAD 152"
+    ]
+  },
+  "RAD 211": {
+    "text": "RAD 120, RAD 142, RAD 152, RAD 160, RAD 170",
+    "courses": [
+      "RAD 120",
+      "RAD 142",
+      "RAD 152",
+      "RAD 160",
+      "RAD 170"
+    ]
+  },
+  "RAD 221": {
+    "text": "RAD 154, RAD 211, RAD 212, RAD 156",
+    "courses": [
+      "RAD 154",
+      "RAD 211",
+      "RAD 212",
+      "RAD 156"
+    ]
+  },
+  "RAD 222": {
+    "text": "RAD 154, RAD 211, RAD 212",
+    "courses": [
+      "RAD 154",
+      "RAD 211",
+      "RAD 212"
+    ]
+  },
+  "RAD 231": {
+    "text": "RAD 221, RAD 222",
+    "courses": [
+      "RAD 221",
+      "RAD 222"
+    ]
+  },
+  "RAD 232": {
+    "text": "RAD 221, RAD 222",
+    "courses": [
+      "RAD 221",
+      "RAD 222"
+    ]
+  },
+  "RN 210": {
+    "text": "RN 200, RN 201, RN 205. Corequisite: RN 211",
+    "courses": [
+      "RN 200",
+      "RN 201",
+      "RN 205",
+      "RN 211"
+    ]
+  },
+  "RN 220": {
+    "text": "RN 210, RN 211, RN 215. Corequisite: RN 221, RN 250",
+    "courses": [
+      "RN 210",
+      "RN 211",
+      "RN 215",
+      "RN 221",
+      "RN 250"
+    ]
+  },
+  "RTH 207": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "RTH 209": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "RTH 210": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "RTH 211": {
+    "text": "RTH 200, RTH 201, RTH 202, RTH 205, RTH 206, RTH 207, RTH 209, RTH 210, RTH 212",
+    "courses": [
+      "RTH 200",
+      "RTH 201",
+      "RTH 202",
+      "RTH 205",
+      "RTH 206",
+      "RTH 207",
+      "RTH 209",
+      "RTH 210",
+      "RTH 212"
+    ]
+  },
+  "RTH 213": {
+    "text": "All previous technical courses.",
+    "courses": []
+  },
+  "SD 120": {
+    "text": "SD 136",
+    "courses": [
+      "SD 136"
+    ]
+  },
+  "SD 157": {
+    "text": "Successful completion of all first semester SCADA classes or equivalent.",
+    "courses": []
+  },
+  "SD 205": {
+    "text": "successful completion of all SCADA courses previously required up to this point.",
+    "courses": []
+  },
+  "SD 225": {
+    "text": "successful completion of all SCADA courses previously required up to this point.",
+    "courses": []
+  },
+  "SD 239": {
+    "text": "successful completion of all SCADA courses previously required up to this point.",
+    "courses": []
+  },
+  "SD 259": {
+    "text": "successful completion of all SCADA courses previously required up to this point.",
+    "courses": []
+  },
+  "SD 270": {
+    "text": "successful completion of all SCADA courses previously required up to this point.",
+    "courses": []
+  },
+  "SLPA 111": {
+    "text": "SLPA 101, 104, 105 and 106.",
+    "courses": [
+      "SLPA 101"
+    ]
+  },
+  "SLPA 120": {
+    "text": "SLPA 101, 104, 105 and 106.",
+    "courses": [
+      "SLPA 101"
+    ]
+  },
+  "SLPA 200": {
+    "text": "SLPA 102, SLPA 103, SLPA 111",
+    "courses": [
+      "SLPA 102",
+      "SLPA 103",
+      "SLPA 111"
+    ]
+  },
+  "SLPA 205": {
+    "text": "SLPA 102, SLPA 103, SLPA 111, SLPA 112, SLPA 115",
+    "courses": [
+      "SLPA 102",
+      "SLPA 103",
+      "SLPA 111",
+      "SLPA 112",
+      "SLPA 115"
+    ]
+  },
+  "SLPA 210": {
+    "text": "SLPA 200, SLPA 202, SLPA 230, SLPA 205",
+    "courses": [
+      "SLPA 200",
+      "SLPA 202",
+      "SLPA 230",
+      "SLPA 205"
+    ]
+  },
+  "SLPA 211": {
+    "text": "SLPA 200, SLPA 202, SLPA 220, SLPA 230, SLPA 205",
+    "courses": [
+      "SLPA 200",
+      "SLPA 202",
+      "SLPA 220",
+      "SLPA 230",
+      "SLPA 205"
+    ]
+  },
+  "WBT 249": {
+    "text": "WBT 100 and EC 105.",
+    "courses": [
+      "WBT 100",
+      "EC 105"
+    ]
+  },
+  "WBT 251": {
+    "text": "WBT 151.",
+    "courses": [
+      "WBT 151"
+    ]
+  },
+  "WBT 260": {
+    "text": "EC 105, WBT 100, WBT 120, WBT 249",
+    "courses": [
+      "EC 105",
+      "WBT 100",
+      "WBT 120",
+      "WBT 249"
+    ]
+  },
+  "WMT 150": {
+    "text": "WMT 149",
+    "courses": [
+      "WMT 149"
+    ]
+  }
+}


### PR DESCRIPTION
South Dakota is the only program-state with an empty `prereqs.json`. This PR populates it with 98 courses that have prerequisite data, sourced from Mitchell Technical College's published Coursedog catalog.

## Result
- 98 unique courses in `data/sd/prereqs.json` with prerequisite requirements
- Data sourced from existing Coursedog catalog (no new scraping needed)
- Unblocks planner from using prerequisite info once additional colleges' data is acquired

## Note
Sequences don't render yet (current term has 0 sections, catalog-only coverage below 25% gate), but the data foundation is now in place.

Completes item 4 of issue #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)