### PR TITLE
feat(planner): SEO + indexing for /{state}/plan (Distribution PR 1)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -6,7 +6,7 @@ import StartingSoonCallout from "@/components/StartingSoonCallout";
 import NotifyBanner from "@/components/NotifyBanner";
 import StateContext from "@/components/StateContext";
 import { getCurrentTerm, getNextTerm } from "@/lib/terms";
-import { getAllStates, isValidState } from "@/lib/states/registry";
+import { getAllStates, hasPrereqsCoverage, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getArticlesByState, getStateTopicLinks, categoryLabel } from "@/lib/blog";
 import { getQualifyingProgramSlugs, getProgramBySlug } from "@/lib/programs";
@@ -252,6 +252,24 @@ export default async function HomePage({ params }: Props) {
                 Build a weekly schedule across multiple colleges and spot conflicts before you register.
               </p>
             </Link>
+            {/* Degree-path planner card (PR after the sticky-loop sequence).
+                Gated by prereq coverage — same condition as the header nav —
+                so the link only appears when the planner has real data to
+                map. Also acts as an internal link that helps the /[state]/plan
+                page get indexed by Google. */}
+            {hasPrereqsCoverage(state) && (
+              <Link
+                href={`/${state}/plan`}
+                className="group rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 transition hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-sm"
+              >
+                <h3 className="font-semibold text-gray-900 dark:text-slate-100 group-hover:text-teal-600 transition-colors mb-1">
+                  Course Planner
+                </h3>
+                <p className="text-sm text-gray-600 dark:text-slate-400">
+                  Pick courses you want to take and we&apos;ll sequence the prerequisites into semesters. Save your plan and we&apos;ll email you when seats open.
+                </p>
+              </Link>
+            )}
             <Link
               href={`/${state}/colleges`}
               className="group rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 transition hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-sm"

--- a/app/[state]/plan/PlannerClient.tsx
+++ b/app/[state]/plan/PlannerClient.tsx
@@ -8,6 +8,9 @@ import SemesterPlanner from "@/components/SemesterPlanner";
 interface PlannerClientProps {
   state: string;
   systemName?: string;
+  /** Full state name for the H1 search-intent phrase. Falls back to the
+   *  state slug uppercased when not passed (older callers). */
+  stateName?: string;
 }
 
 /** Reads ?targets= and ?name= from the URL so /plan/[id]'s 'Duplicate'
@@ -35,7 +38,14 @@ function PlannerWithParams({ state }: { state: string }) {
   );
 }
 
-export default function PlannerClient({ state, systemName }: PlannerClientProps) {
+export default function PlannerClient({
+  state,
+  systemName,
+  stateName,
+}: PlannerClientProps) {
+  // Header phrase: use stateName when supplied (search-intent shape);
+  // fall back to the state slug uppercased so older callers don't break.
+  const stateLabel = stateName ?? state.toUpperCase();
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
       {/* Header */}
@@ -53,13 +63,17 @@ export default function PlannerClient({ state, systemName }: PlannerClientProps)
       {/* Main content */}
       <main className="max-w-3xl mx-auto px-4 py-8">
         <div className="mb-8">
+          {/* H1 leads with state + 'Course Planner' — the search-intent
+              phrase. The previous H1 ('Semester Planner') buried both. */}
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
-            Semester Planner
+            {stateLabel} Community College Course Planner
           </h1>
           <p className="mt-2 text-sm text-slate-500 dark:text-slate-400 max-w-xl">
-            Add the courses you want to take and the planner will automatically
-            map out all prerequisites into a semester-by-semester sequence.
-            Take courses in the listed order to satisfy all requirements.
+            Add the courses you want to take at any {stateLabel} community
+            college. We&apos;ll automatically map out the prerequisites into
+            a semester-by-semester sequence so you know exactly what to take
+            and when. Save your plan and we&apos;ll email you when a seat
+            opens.
           </p>
         </div>
 

--- a/app/[state]/plan/page.tsx
+++ b/app/[state]/plan/page.tsx
@@ -14,10 +14,28 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
   const config = requireStateConfig(state);
+  // Title leads with the search-intent phrase ("{State} Community College
+  // Course Planner") so the SERP snippet matches what users type when they
+  // search for this tool. The previous title led with "Semester Planner —"
+  // which buried the state and the noun ("course planner") behind a brand
+  // prefix.
+  const title = `${config.name} Community College Course Planner — Free Prerequisite Sequencer`;
+  const description = `Free degree planner for ${config.name} community college students. Add the courses you want to take and we'll automatically map prerequisites into a semester-by-semester sequence. Save your plan and get notified when seats open.`;
+  const url = `https://communitycollegepath.com/${state}/plan`;
   return {
-    title: `Semester Planner — ${config.branding.siteName}`,
-    description: `Plan your course sequence at ${config.name} community colleges. Automatically maps prerequisites into a semester-by-semester plan so you know exactly what to take and when.`,
-    robots: { index: false, follow: true },
+    title,
+    description,
+    // Was noindex; flipping now that the page is a real destination — PR #827
+    // turned plans into saved objects and PR #859 added seat-open
+    // notifications, so this URL is genuinely worth ranking for.
+    robots: { index: true, follow: true },
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
   };
 }
 
@@ -25,10 +43,37 @@ export default async function PlanPage({ params }: Props) {
   const { state } = await params;
   const config = requireStateConfig(state);
 
+  // Schema.org WebApplication markup tells Google this is an interactive
+  // tool, not a static article. Improves rich-result eligibility for
+  // "{state} community college planner" queries.
+  const webAppLd = {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: `${config.name} Community College Course Planner`,
+    description: `Free semester-by-semester degree planner for ${config.name} community college students. Maps prerequisites automatically; saves plans and notifies you when seats open.`,
+    url: `https://communitycollegepath.com/${state}/plan`,
+    applicationCategory: "EducationalApplication",
+    operatingSystem: "Any",
+    isAccessibleForFree: true,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    inLanguage: "en-US",
+    audience: {
+      "@type": "EducationalAudience",
+      educationalRole: "student",
+    },
+  };
+
   return (
-    <PlannerClient
-      state={state}
-      systemName={config.systemName}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
+      />
+      <PlannerClient
+        state={state}
+        systemName={config.systemName}
+        stateName={config.name}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## What changes for someone using the site

Two things:

**Visible immediately:** every state landing page (e.g. `/wy`, `/la`) now has a "Course Planner" card in the **What You Can Do** grid (alongside "Search All Courses", "Transfer Lookup", "Schedule Builder"). Same conditional gate as the header nav — only appears when the planner has real prereq data for that state.

**Visible in 1–3 weeks** (once Google re-crawls): the planner page itself becomes indexable. Until now, `/[state]/plan` was `robots: noindex` — invisible to search engines. The page now has:
- Search-intent-shaped title: `{State} Community College Course Planner — Free Prerequisite Sequencer`
- Description that surfaces the actual differentiator (save plan + email when seats open), not just "we sequence prereqs"
- `Schema.org WebApplication` JSON-LD with `EducationalApplication` category, `isAccessibleForFree: true`, student audience
- Canonical URL + Open Graph block (clean social cards if someone shares the link)

The H1 also changes from generic `Semester Planner` to `{StateName} Community College Course Planner`. Same content under the hood; the page itself just signals what it is more clearly.

## What changes on the technical front

Three small edits in one commit:

| File | Change |
|---|---|
| `app/[state]/plan/page.tsx` | `robots: index: true`, new title/description/canonical/OG, JSON-LD injection via `dangerouslySetInnerHTML` |
| `app/[state]/plan/PlannerClient.tsx` | New `stateName` prop, state-named H1, hero copy mentions save + notifications (the value prop) |
| `app/[state]/page.tsx` | New "Course Planner" card in the existing grid, gated by `hasPrereqsCoverage(state)` |

**Why "Course Planner" and not "Semester Planner":** people searching for this tool type "course planner" or "degree planner", not "semester planner". The latter is jargon community-college students don't use. The data layer keeps the `SemesterPlanner` component name (internal); only the user-facing label changed.

**Why the SEO play is the right first distribution move** (vs. in-app prompts, social posts): the planner is a real destination now, but Google has no idea it exists. After this PR, it has the *chance* to surface. SEO is slow but compounds; the marginal cost is ~50 lines and the upside is "free organic traffic forever."

## What this is *not*

- **Not new content.** Nobody types differently; the same planner loads at the same URL. The work is metadata + a single new card.
- **Not the only distribution PR.** Program-page "Open in planner" CTA and state-landing JSON-LD are real follow-ups if signal warrants. Both can ship independently from this.
- **Not measurable for ~2 weeks.** Google Search Console will tell us if anything works; check `site:communitycollegepath.com /plan` queries and impressions in 14 days.

## Test plan
- [x] Typecheck clean
- [ ] After merge: view `/wy/plan` source, confirm `<meta name="robots" content="index, follow">` and the JSON-LD `<script>` block render
- [ ] After merge: `/wy` shows the Course Planner card in the "What You Can Do" grid
- [ ] After merge: submit `/wy/plan` to Google Search Console for re-crawl; watch Search Performance for new queries in 14 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)
