### PR TITLE
fix(ny): type-correct mvcc-programs scraper — unblocks Vercel deploy

### DIFF
--- a/scripts/ny/scrape-mvcc-programs.ts
+++ b/scripts/ny/scrape-mvcc-programs.ts
@@ -22,6 +22,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as cheerio from "cheerio";
 import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { ProgramCredential, ProgramRequirement } from "../../lib/types.js";
 
 const BASE = "https://catalog.mvcc.edu/current/programs";
 const UA = "Mozilla/5.0 (compatible; CommunityCollegePathBot/1.0)";
@@ -50,13 +51,13 @@ function htmlToText(raw: string): string {
     .trim();
 }
 
-function detectCredential(title: string): string {
+function detectCredential(title: string): ProgramCredential {
   const t = title.toLowerCase();
   if (t.includes("a.a.s") || t.includes("associate in applied science")) return "AAS";
   if (t.includes("a.s.") || t.includes("associate in science")) return "AS";
   if (t.includes("a.a.") || t.includes("associate in arts")) return "AA";
-  if (t.includes("certificate")) return "Certificate";
-  return "Associate";
+  if (t.includes("certificate")) return "certificate";
+  return "other";
 }
 
 const BOILERPLATE = /^(none|not applicable|n\/a|no prerequisites?)\s*\.?\s*$/i;
@@ -92,15 +93,7 @@ async function main() {
     console.log(`  Loaded ${Object.keys(prereqs).length} existing prereqs`);
   }
 
-  const programs: Array<{
-    title: string;
-    credential: string;
-    catalog_url: string;
-    total_credits: number | null;
-    description: string;
-    requirement_groups: Array<{ name: string; courses: string[] }>;
-    matched_program_slug: string | null;
-  }> = [];
+  const programs: ProgramRequirement[] = [];
 
   let prereqsAdded = 0;
   const toProcess = limit > 0 ? unique.slice(0, limit) : unique;
@@ -172,11 +165,29 @@ async function main() {
       programs.push({
         title,
         credential,
+        program_code: null,
         catalog_url: url,
         total_credits: null,
+        gpa_minimum: null,
         description: "",
         requirement_groups: courseCodes.size > 0
-          ? [{ name: "Required Courses", courses: Array.from(courseCodes).sort() }]
+          ? [
+              {
+                name: "Required Courses",
+                credits_required: null,
+                choose_n: null,
+                courses: Array.from(courseCodes).sort().map((code) => {
+                  const m = code.match(/^([A-Z]{2,5})\s+([A-Z0-9]+)$/);
+                  return {
+                    prefix: m ? m[1] : code,
+                    number: m ? m[2] : "",
+                    title: "",
+                    credits: null,
+                    or_alternatives: [],
+                  };
+                }),
+              },
+            ]
           : [],
         matched_program_slug: null,
       });


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible directly — but **every PR merged since #868 (AK) hasn't actually reached prod** because Vercel's TypeScript step has been failing on this file since PR #857 landed. AK, the prereq batches (#866), planner SEO (#867), and NM (#869) are all "merged" on GitHub but absent from communitycollegepath.com. This unblocks the deploy pipeline so those changes (and future ones) ship.

## What changes on the technical front

`scripts/ny/scrape-mvcc-programs.ts` (introduced in #857) declared an ad-hoc local type for its `programs` array that didn't match the canonical `ProgramRequirement` / `RequirementGroup` / `RequiredCourse` types in `lib/types.ts`:

- Missing `program_code`, `gpa_minimum` on `ProgramRequirement`
- Missing `credits_required`, `choose_n` on `RequirementGroup`
- `courses` typed as `string[]` instead of `RequiredCourse[]`
- `detectCredential` returned `"Certificate"` / `"Associate"` — neither is in the `ProgramCredential` union (`"AA" | "AS" | "AAS" | "certificate" | "diploma" | "other"`)

The fix imports the canonical types, expands the pushed objects to the right shape, and narrows `detectCredential` to return `ProgramCredential` with valid union values.

The Vercel build log clearly showed compile succeeded and TypeScript failed at this single call site — the rest of the codebase was clean.

## Test plan

- [x] `npx tsc --noEmit` — no error on the file (was failing for ~3 hours of deploys before this)
- [ ] Post-merge: confirm Vercel deploy succeeds, then verify `/ak/colleges`, `/nm/colleges`, and `/plan` all render on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
