### PR TITLE
fix(ca): pass required args to parseAssistArticulation in gen-direct-matches

### DIFF
--- a/scripts/ca/gen-direct-matches.ts
+++ b/scripts/ca/gen-direct-matches.ts
@@ -44,7 +44,8 @@ for (const file of files) {
 
   let parsed: ReturnType<typeof parseAssistArticulation>;
   try {
-    parsed = parseAssistArticulation(raw as Parameters<typeof parseAssistArticulation>[0]);
+    const agreementKey = file.replace(".json", "");
+    parsed = parseAssistArticulation(raw as Parameters<typeof parseAssistArticulation>[0], ccSlug, uniSlug, agreementKey);
   } catch { skipped++; continue; }
 
   for (const group of parsed.requirement_groups ?? []) {


### PR DESCRIPTION
## What broke

Vercel build failing with:

```
./scripts/ca/gen-direct-matches.ts:47:14
Type error: Expected 4 arguments, but got 1.
```

`parseAssistArticulation` requires 4 args (`rawResponse`, `ccSlug`, `universitySlug`, `agreementKey`) but `gen-direct-matches.ts` introduced in PR #872 was only passing 1.

## Fix

Pass the three additional args. `ccSlug` and `uniSlug` are already parsed from the filename on line 35; `agreementKey` is derived from the filename without extension (same convention used elsewhere).

One-line change. No data files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)