### PR TITLE
infra: enforce one-PR-per-worktree to stop shared-checkout races

### DIFF
--- a/.claude/hooks/pre-worktree-guard.sh
+++ b/.claude/hooks/pre-worktree-guard.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# PreToolUse hook: prevent branch work in the SHARED MAIN CHECKOUT.
+#
+# The repo root is shared by many concurrent Claude sessions. Creating or
+# switching a branch there races every other session: HEAD moves under you
+# (commits dangle and need cherry-pick rescue), the shared .claude/branch-lock
+# gets overwritten, and freshly scraped data files are reverted mid-run.
+# (Lost 3,512 IA transfer rows to exactly this on 2026-05-30.)
+#
+# This hook BLOCKS, in the main checkout only:
+#   - git checkout -b / git switch -c   (branch creation → use a worktree)
+#   - git checkout <branch> / switch <branch>  (HEAD move → don't; work in worktree)
+#   - git reset --hard / git clean -f   (nukes other sessions' uncommitted work)
+#
+# It ALLOWS everywhere:
+#   - the same ops inside a worktree (cwd or `cd` target under /worktrees/)
+#   - git checkout -- <file>, git checkout . , git restore  (file ops, not HEAD)
+#   - returning the main checkout to its resting state: checkout/switch main
+#   - git worktree add ...  (the correct way to start branch work)
+#
+# Exit 2 = block tool execution and surface the message to Claude.
+#
+# NOTE: deliberately NOT using `set -euo pipefail`. A hook must always reach
+# its explicit exit code; a no-match grep or SIGPIPE in a detection pipeline
+# must never abort the script early (that would yield exit 1 = non-blocking
+# error instead of the intended exit 2 = block).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PAYLOAD=$(cat)
+CMD=$(echo "$PAYLOAD" | /usr/bin/python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || true)
+PAYLOAD_CWD=$(echo "$PAYLOAD" | /usr/bin/python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)
+
+[ -z "$CMD" ] && exit 0
+
+# --- Is this a guarded operation at all? -----------------------------------
+# Branch creation, HEAD-switching, or tree-nuking. Exclude file-level checkout.
+is_guarded=0
+
+# git checkout -b / git switch -c  → branch creation
+if echo "$CMD" | grep -Eq 'git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c|switch[[:space:]]+--create)'; then
+  is_guarded=1; op="branch-create"
+fi
+
+# git reset --hard / git clean -f(d)  → destroys uncommitted work
+if echo "$CMD" | grep -Eq 'git[[:space:]]+reset[[:space:]]+(--hard|--mixed[[:space:]]+HEAD~|.*--hard)'; then
+  is_guarded=1; op="reset-hard"
+fi
+if echo "$CMD" | grep -Eq 'git[[:space:]]+clean[[:space:]]+-[a-z]*f'; then
+  is_guarded=1; op="clean"
+fi
+
+# git checkout <branch> / git switch <branch>  → HEAD move
+# (exclude: checkout -- , checkout . , restore, and returning to main)
+if echo "$CMD" | grep -Eq 'git[[:space:]]+(checkout|switch)[[:space:]]'; then
+  if ! echo "$CMD" | grep -Eq 'git[[:space:]]+checkout[[:space:]]+(-b|--[[:space:]]|\.|-- )'; then
+    if ! echo "$CMD" | grep -Eq 'git[[:space:]]+(checkout|switch)[[:space:]]+(-c|--create)'; then
+      # allow switching to main/master (resting state) and detaching to origin/main
+      if ! echo "$CMD" | grep -Eq 'git[[:space:]]+(checkout|switch)[[:space:]]+(main|master|origin/main)([[:space:]]|$)'; then
+        is_guarded=1; op="head-switch"
+      fi
+    fi
+  fi
+fi
+
+[ "$is_guarded" -eq 0 ] && exit 0
+
+# Always allow the correct primitive.
+echo "$CMD" | grep -Eq 'git[[:space:]]+worktree' && exit 0
+
+# --- Determine the effective directory the command runs in -----------------
+# 1. An explicit `cd <path>` in the command wins.
+# 2. Else the payload cwd (persisted shell dir).
+# 3. Else the repo root.
+target_dir=""
+cd_path=$(echo "$CMD" | grep -oE 'cd[[:space:]]+[^&|;]+' 2>/dev/null | head -1 | sed -E 's/^cd[[:space:]]+//' | sed -E 's/[[:space:]]+$//' | tr -d '"'"'"'' || true)
+if [ -n "$cd_path" ]; then
+  target_dir="$cd_path"
+elif [ -n "$PAYLOAD_CWD" ]; then
+  target_dir="$PAYLOAD_CWD"
+else
+  target_dir="$REPO_ROOT"
+fi
+
+# Fast path: anything under a worktrees/ directory is isolated → allow.
+case "$target_dir" in
+  *"/worktrees/"*|*"/worktrees") exit 0 ;;
+esac
+
+# Robust check: resolve the dir and ask git whether it's the main checkout.
+resolved="$target_dir"
+case "$resolved" in
+  /*) : ;;                          # absolute
+  *)  resolved="$REPO_ROOT/$resolved" ;;  # relative → anchor to repo root
+esac
+if [ -d "$resolved" ]; then
+  gd=$(cd "$resolved" 2>/dev/null && git rev-parse --git-dir 2>/dev/null || echo "")
+  gcd=$(cd "$resolved" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null || echo "")
+  # In a worktree, git-dir != git-common-dir → allow.
+  if [ -n "$gd" ] && [ "$gd" != "$gcd" ]; then
+    exit 0
+  fi
+fi
+
+# --- We're in the shared main checkout. Block. -----------------------------
+cat >&2 <<EOF
+╔══════════════════════════════════════════════════════════════════════════════
+║  🛑 BRANCH WORK IN THE SHARED MAIN CHECKOUT — BLOCKED ($op)
+║
+║  Command: $CMD
+║
+║  The repo root is shared by ~17 concurrent sessions. Creating/switching a
+║  branch or resetting here races all of them: your commits dangle, the shared
+║  branch-lock gets overwritten, and your scraped data files get reverted
+║  mid-run (this lost 3,512 IA transfer rows on 2026-05-30).
+║
+║  Do this PR's work in an ISOLATED worktree instead:
+║
+║      WT=\$(scripts/new-pr-worktree.sh <slug>)   # creates worktree + branch
+║      cd "\$WT"                                    # then scrape / commit here
+║
+║  Inside the worktree, the same git commands are safe — other sessions cannot
+║  touch your HEAD, index, or files. The main checkout stays on main.
+║
+║  If you are SURE you are already inside a worktree and this misfired, run the
+║  git command with an explicit `cd` into the worktree path in the same line.
+╚══════════════════════════════════════════════════════════════════════════════
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,10 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/pre-worktree-guard.sh"
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/pre-detach-guard.sh"
           },
           {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,16 @@ Before adding a new rule, recommendation, or reminder anywhere in this repo, ask
 
 CLAUDE.md is always in context; every line here costs per-session tokens. Keep it tight. Use skills and code comments for the bulky stuff.
 
-## Git — branch and worktree awareness
+## Git — ONE PR = ONE WORKTREE (non-negotiable)
+
+**The repo root is shared by ~17 concurrent Claude sessions. Never create a branch, scrape, or commit PR work in the main checkout.** Doing so races every other session: your commits dangle (cherry-pick rescues), the shared `.claude/branch-lock` gets overwritten ("expected someone-else's-branch"), and your freshly-scraped data files get reverted to HEAD mid-run. On 2026-05-30 this silently wiped 3,512 just-scraped IA transfer rows to `[]` between scrape and commit. A worktree has its own HEAD, index, and files — it is immune.
+
+**Start every unit of PR work with a worktree, then stay inside it:**
+```bash
+WT=$(scripts/new-pr-worktree.sh <slug>)   # creates .claude/worktrees/<slug> on claude/<slug> off origin/main,
+cd "$WT"                                    # copies .env.local, seeds branch-lock. Then scrape/commit/push HERE.
+```
+The main checkout stays on `main` and is read-only / coordination only. The `pre-worktree-guard.sh` hook blocks `checkout -b` / branch-switch / `reset --hard` / `clean -f` in the main checkout — if you hit it, you forgot to make a worktree; don't bypass, make one. Inside the worktree the same commands are safe.
 
 **Before touching any file, always confirm which branch you're on and whether a worktree is active.**
 

--- a/scripts/new-pr-worktree.sh
+++ b/scripts/new-pr-worktree.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# new-pr-worktree.sh — create an isolated worktree for one unit of PR work.
+#
+# WHY THIS EXISTS: the main checkout at the repo root is shared by many
+# concurrent Claude sessions. Doing branch work (checkout -b, scrape, commit)
+# there races every other session's git operations — HEAD moves under you
+# (dangling commits), .claude/branch-lock gets overwritten, and freshly
+# scraped data files get reverted to their committed state mid-run. A worktree
+# has its own HEAD, index, and files, so it is immune to all of that.
+#
+# RULE: one PR = one worktree. The main checkout is read-only / coordination.
+#
+# Usage:
+#   scripts/new-pr-worktree.sh <slug>            # branch claude/<slug>
+#   scripts/new-pr-worktree.sh <slug> <branch>   # custom branch name
+#
+# Prints the `cd` command to run next. After cd-ing in, all git/scrape/commit
+# work happens inside the worktree and cannot be clobbered by other sessions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+SLUG="${1:-}"
+if [ -z "$SLUG" ]; then
+  echo "Usage: scripts/new-pr-worktree.sh <slug> [branch-name]" >&2
+  echo "  e.g. scripts/new-pr-worktree.sh ia-transfers" >&2
+  exit 1
+fi
+
+BRANCH="${2:-claude/$SLUG}"
+WORKTREE=".claude/worktrees/$SLUG"
+ABS_WORKTREE="$REPO_ROOT/$WORKTREE"
+
+# Refuse to clobber an existing worktree.
+if [ -e "$ABS_WORKTREE" ]; then
+  echo "❌ $WORKTREE already exists. Pick a different slug or remove it first:" >&2
+  echo "   git worktree remove $WORKTREE" >&2
+  exit 1
+fi
+
+# Refuse if the branch is already checked out somewhere (git would error anyway,
+# but give a clearer message).
+if git worktree list --porcelain | grep -q "branch refs/heads/$BRANCH$"; then
+  echo "❌ Branch $BRANCH is already checked out in another worktree:" >&2
+  git worktree list | grep "\[$BRANCH\]" >&2 || true
+  exit 1
+fi
+
+echo "Fetching origin/main…" >&2
+git fetch origin main --quiet
+
+echo "Creating worktree $WORKTREE on new branch $BRANCH (off origin/main)…" >&2
+git worktree add -b "$BRANCH" "$ABS_WORKTREE" origin/main >&2
+
+# Carry over the gitignored local env so scrapers/build can talk to Supabase.
+if [ -f "$REPO_ROOT/.env.local" ]; then
+  cp "$REPO_ROOT/.env.local" "$ABS_WORKTREE/.env.local"
+  echo "Copied .env.local into the worktree." >&2
+fi
+
+# Seed the per-worktree branch lock so the branch guard is satisfied here.
+printf '%s\n' "$BRANCH" > "$ABS_WORKTREE/.claude/branch-lock"
+
+echo "" >&2
+echo "✅ Worktree ready. Do ALL work for this PR inside it:" >&2
+echo "" >&2
+# The one line the caller should run next (printed to stdout so it's copyable).
+echo "cd $ABS_WORKTREE"


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-facing. This is dev-infra that stops a class of silent data loss in our own workflow.

## The problem

The repo root is shared by ~17 concurrent Claude sessions. Doing branch work there races every other session's git operations:
- **HEAD moves under you** → commits land as dangling objects needing cherry-pick rescue (happened repeatedly this session: PRs #863, #876).
- **`.claude/branch-lock` gets overwritten** (it's a shared file) → the existing branch guard fires "expected someone-else's-branch", and rewriting the lock to bypass it is treating the symptom.
- **Freshly-scraped data files get reverted to HEAD mid-run** → on 2026-05-30 a concurrent `git checkout` wiped **3,512 just-scraped Iowa transfer rows to `[]`** in the window between scrape and commit.

The existing branch-lock only *detects* drift after the fact and is itself shared mutable state. The durable fix is **isolation**: a git worktree has its own HEAD, index, and working files.

## The fix

| File | Role |
|---|---|
| `scripts/new-pr-worktree.sh` | One command to start isolated work: `WT=$(scripts/new-pr-worktree.sh <slug>); cd "$WT"`. Creates the worktree on `claude/<slug>` off `origin/main`, copies `.env.local`, seeds the per-worktree branch-lock. |
| `.claude/hooks/pre-worktree-guard.sh` | PreToolUse hook that **blocks** `checkout -b` / branch-switch / `reset --hard` / `clean -f` **in the main checkout only**. Detects worktree via `git-dir != git-common-dir` and via cwd/`cd`-target under `/worktrees/`. Same commands stay allowed inside a worktree; also allows `checkout -- <file>`, `switch main`, and `git worktree add`. |
| `.claude/settings.json` | Registers the hook after `pre-git.sh`. |
| `CLAUDE.md` | Leads the git section with the non-negotiable one-PR-one-worktree rule + exact workflow. |

## Test plan
- [x] 10/10 hook unit tests pass (block: branch-create / head-switch / reset / clean in main; allow: same inside worktree, `checkout -- file`, `switch main`, `worktree add`, plain commit).
- [x] This PR itself was authored entirely inside a worktree created by the new helper — committed and pushed with zero branch-lock conflicts and no dangling commit. The fix proves itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)