### PR TITLE
fix(ct,ma): restore 48 CT + 926 MA prereqs lost to transient Acalog WAF block

### DIFF
--- a/data/ct/prereqs.json
+++ b/data/ct/prereqs.json
@@ -2270,6 +2270,324 @@
       "ENG 1030"
     ]
   },
+  "ENG 2245": {
+    "text": "ENG 1020 or ENG 1030 or permission of the instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2250": {
+    "text": "ENG 1250 or permission of instructor",
+    "courses": [
+      "ENG 1250"
+    ]
+  },
+  "ENG 2251": {
+    "text": "ENG 1250 or permission of instructor",
+    "courses": [
+      "ENG 1250"
+    ]
+  },
+  "ENG 2260": {
+    "text": "ENG 1020 or ENG 1030 , or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2288": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2300": {
+    "text": "ENG 1020 or ENG 1030 , or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2301": {
+    "text": "ENG 1020 or ENG 1030 , or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2302": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2320": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2340": {
+    "text": "ENG 1020 or ENG 1030",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2360": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2361": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2420": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2440": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2461": {
+    "text": "ENG 1020 - Composition II and Literature or ENG 1030 - Composition II and Non-fiction Texts or permission of the instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2520": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2540": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2560": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2600": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2610": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2620": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2640": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2660": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2680": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2700": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2711": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2712": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2713": {
+    "text": "ENG 1020 - Composition II and Literature or ENG 1030 - Composition II and Non-fiction Texts or permission of the instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2801": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2802": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2803": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2804": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2850": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2995": {
+    "text": "Students will need the permission of the instructor of record to register. To be eligible, students should have COMM 1010 and either ENG 1020 or ENG 1030 , and should have a GPA of at least 3.0",
+    "courses": [
+      "COMM 1010",
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ENG 2998": {
+    "text": "ENG 1020 or ENG 1030 or permission of instructor",
+    "courses": [
+      "ENG 1020",
+      "ENG 1030"
+    ]
+  },
+  "ESOL 0902": {
+    "text": "Placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": []
+  },
+  "ESOL 0905": {
+    "text": "Placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": []
+  },
+  "ESOL 0907": {
+    "text": "Placement into ESOL 0902, or through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0902"
+    ]
+  },
+  "ESOL 0912": {
+    "text": "ESOL 1502 with a C grade or higher or placement into the level through ESOL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 1502"
+    ]
+  },
+  "ESOL 1202": {
+    "text": "ESOL 0902 with a C grade or higher or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0902"
+    ]
+  },
+  "ESOL 1205": {
+    "text": "C or higher in ESOL 0905 or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0905"
+    ]
+  },
+  "ESOL 1207": {
+    "text": "C or higher in ESOL 0907 or through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0907"
+    ]
+  },
+  "ESOL 1209": {
+    "text": "C or higher in ESOL 0902 - Integrated Skills I: High Beginning or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0902"
+    ]
+  },
+  "ESOL 1212": {
+    "text": "ESOL 0902 - Integrated Skills I: High Beginning with a C grade or higher or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 0902"
+    ]
+  },
+  "ESOL 1302": {
+    "text": "ESOL 1202 with a C grade or higher or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 1202"
+    ]
+  },
+  "ESOL 1305": {
+    "text": "C or higher in ESOL 1202 or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 1202"
+    ]
+  },
+  "ESOL 1307": {
+    "text": "C or higher in ESOL 1202 or through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 1202"
+    ]
+  },
+  "ESOL 1309": {
+    "text": "C or higher in ESOL 1202 or placement into the level through ESL multiple measure placement method or permission of coordinator/ department chair",
+    "courses": [
+      "ESOL 1202"
+    ]
+  },
   "FTAD 1000": {
     "text": "M.D. Physical & Clearance to participate in physical fitness activities",
     "courses": []

--- a/data/ma/prereqs.json
+++ b/data/ma/prereqs.json
@@ -132,6 +132,21 @@
       "BUS 215"
     ]
   },
+  "ACC 151": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ACC 152": {
+    "text": "ACC 151",
+    "courses": [
+      "ACC 151"
+    ],
+    "source": "gcc"
+  },
   "ACC 201": {
     "text": "ACC 102",
     "courses": [
@@ -181,11 +196,117 @@
       "ACC 106"
     ]
   },
+  "ADM 101": {
+    "text": "Placement into Math Module 80",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "ADM 110": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ADM 111": {
+    "text": "Completion of ADM 110",
+    "courses": [
+      "ADM 110"
+    ],
+    "source": "middlesex"
+  },
+  "AGR 115": {
+    "text": "None;Recomm: SCI 137",
+    "courses": [
+      "SCI 137"
+    ],
+    "source": "gcc"
+  },
+  "AGR 118": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "AHE 112": {
     "text": "AHE 110",
     "courses": [
       "AHE 110"
     ]
+  },
+  "AHP 107": {
+    "text": "Completion of AHP 113 with C or better; and completion of AHP 114",
+    "courses": [
+      "AHP 113",
+      "AHP 114"
+    ],
+    "source": "middlesex"
+  },
+  "AHP 113": {
+    "text": "Completion of AHP 111, AHP 112, and MAS 101- all with a C or better",
+    "courses": [
+      "AHP 111",
+      "AHP 112",
+      "MAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "AHP 114": {
+    "text": "Completion of AHP 111, AHP 112, and MAS 101- all with a C or better",
+    "courses": [
+      "AHP 111",
+      "AHP 112",
+      "MAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "AHP 115": {
+    "text": "Completion of AHP 111, AHP 112, and MAS 101- all with a C or better",
+    "courses": [
+      "AHP 111",
+      "AHP 112",
+      "MAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "AHP 116": {
+    "text": "Completion of AHP 103 and AHP 115- both with a C or better",
+    "courses": [
+      "AHP 103",
+      "AHP 115"
+    ],
+    "source": "middlesex"
+  },
+  "AHP 117": {
+    "text": "Completion of AHP 103 and AHP 115- both with a C or better",
+    "courses": [
+      "AHP 103",
+      "AHP 115"
+    ],
+    "source": "middlesex"
+  },
+  "AHS 101": {
+    "text": "ENG 101 or concurrent enrollment in ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "AHS 102": {
+    "text": "ENG 101 or concurrent enrollment in ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "AHS 108": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
   },
   "AHS 111": {
     "text": "AHS 111L",
@@ -213,6 +334,21 @@
       "MAT 018"
     ]
   },
+  "AHS 201": {
+    "text": "ENG 101; ART 121 or permission of the instructor.",
+    "courses": [
+      "ART 121",
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "AHS 207": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
   "AHS 230": {
     "text": "BIO 101 or BIO 105 or BIO 201 and BIO 202",
     "courses": [
@@ -221,6 +357,21 @@
       "BIO 201",
       "BIO 202"
     ]
+  },
+  "ANT 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ANT 104": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "ANT 255": {
     "text": "ANT 101 (min D-) or ANT 101 (min T) or ANT 114 (min D-) or ANT 114 (min T) or SOC 110 (min D-) or SOC 110 (min T) or HTH 102 (min D-) or HTH 102 (min T) or LAX 110 (min D-) or LAX 110 (min T)",
@@ -282,11 +433,40 @@
       "ART 104"
     ]
   },
+  "ART 121": {
+    "text": "ENG 094 or concurrent enrollment or satisfactory placement.Recomm: ENG 090 or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "ART 122": {
     "text": "ART 121 (min D-) or ART 121 (min D-) or ART 121 (min T) or ART 121 (min T)",
     "courses": [
       "ART 121"
     ]
+  },
+  "ART 123": {
+    "text": "ART 121",
+    "courses": [
+      "ART 121"
+    ],
+    "source": "gcc"
+  },
+  "ART 126": {
+    "text": "Completion of ART 121",
+    "courses": [
+      "ART 121"
+    ],
+    "source": "middlesex"
+  },
+  "ART 127": {
+    "text": "ART 126",
+    "courses": [
+      "ART 126"
+    ],
+    "source": "middlesex"
   },
   "ART 130": {
     "text": "ART 130L",
@@ -348,6 +528,94 @@
       "ENG 104"
     ]
   },
+  "ART 152": {
+    "text": "ENG 094 or concurrent enrollment or satisfactory placement.Recomm: ENG 090 or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ART 155": {
+    "text": "ENG 094 or satisfactory placementRecomm: ART 121 and ENG 090 or satisfactory placement",
+    "courses": [
+      "ART 121",
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ART 161": {
+    "text": "ENG 094, or satisfactory placementRecomm: ART 121 and ENG 090 or satisfactory placement",
+    "courses": [
+      "ART 121",
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ART 165": {
+    "text": "Completion of ART 104, ART 153, and ART 161",
+    "courses": [
+      "ART 104",
+      "ART 153",
+      "ART 161"
+    ],
+    "source": "middlesex"
+  },
+  "ART 171": {
+    "text": "Completion of ART 104 and ART 153",
+    "courses": [
+      "ART 104",
+      "ART 153"
+    ],
+    "source": "middlesex"
+  },
+  "ART 175": {
+    "text": "Completion of ART 104, ART 153, and ART 161",
+    "courses": [
+      "ART 104",
+      "ART 153",
+      "ART 161"
+    ],
+    "source": "middlesex"
+  },
+  "ART 181": {
+    "text": "Completion of ART 161, AND concurrent enrollment or completion of ART 165, ART 171, and ART 175",
+    "courses": [
+      "ART 161",
+      "ART 165",
+      "ART 171",
+      "ART 175"
+    ],
+    "source": "middlesex"
+  },
+  "ART 185": {
+    "text": "Completion of ART 161, and ART 171",
+    "courses": [
+      "ART 161",
+      "ART 171"
+    ],
+    "source": "middlesex"
+  },
+  "ART 188": {
+    "text": "Completion of two ART courses",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "ART 189": {
+    "text": "Completion of two ART courses",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "ART 194": {
+    "text": "Completion of ART 129 and ART 130",
+    "courses": [
+      "ART 129",
+      "ART 130"
+    ],
+    "source": "middlesex"
+  },
   "ART 205": {
     "text": "ART 205L",
     "courses": [
@@ -372,6 +640,14 @@
       "ART 206"
     ]
   },
+  "ART 218": {
+    "text": "Completion of ART 117 & ART 118",
+    "courses": [
+      "ART 117",
+      "ART 118"
+    ],
+    "source": "middlesex"
+  },
   "ART 230": {
     "text": "ART 130 and ART 230L",
     "courses": [
@@ -385,6 +661,80 @@
       "ART 230"
     ]
   },
+  "ART 235": {
+    "text": "ART 132",
+    "courses": [
+      "ART 132"
+    ],
+    "source": "gcc"
+  },
+  "ART 236": {
+    "text": "ART 121 and ART 132Recomm: ART 235",
+    "courses": [
+      "ART 121",
+      "ART 235"
+    ],
+    "source": "gcc"
+  },
+  "ART 237": {
+    "text": "ART 236",
+    "courses": [
+      "ART 236"
+    ],
+    "source": "gcc"
+  },
+  "ART 241": {
+    "text": "ART 121 and ART 132",
+    "courses": [
+      "ART 121",
+      "ART 132"
+    ],
+    "source": "gcc"
+  },
+  "ART 242": {
+    "text": "ART 241",
+    "courses": [
+      "ART 241"
+    ],
+    "source": "gcc"
+  },
+  "ART 243": {
+    "text": "ART 242",
+    "courses": [
+      "ART 242"
+    ],
+    "source": "gcc"
+  },
+  "ART 244": {
+    "text": "ART 144 or the permission of the instructor",
+    "courses": [
+      "ART 144"
+    ],
+    "source": "middlesex"
+  },
+  "ART 247": {
+    "text": "ART 121 and 132Recomm: ART 241",
+    "courses": [
+      "ART 121",
+      "ART 241"
+    ],
+    "source": "gcc"
+  },
+  "ART 251": {
+    "text": "ART 151Recomm: ART 152",
+    "courses": [
+      "ART 152"
+    ],
+    "source": "gcc"
+  },
+  "ART 252": {
+    "text": "ART 251 Recomm: ART 152",
+    "courses": [
+      "ART 152",
+      "ART 251"
+    ],
+    "source": "gcc"
+  },
   "ART 256": {
     "text": "ART 121 (min D-) or ART 121 (min D-) or ART 121 (min T) or ART 121 (min T) or ART 125 (min D-) or ART 125 (min D-) or ART 125 (min T) or ART 125 (min T)",
     "courses": [
@@ -397,6 +747,41 @@
     "courses": [
       "ART 252"
     ]
+  },
+  "ART 280": {
+    "text": "ART 161.",
+    "courses": [
+      "ART 161"
+    ],
+    "source": "gcc"
+  },
+  "ART 281": {
+    "text": "ART 161 and ART 121 or permissions of the Department Chair",
+    "courses": [
+      "ART 121",
+      "ART 161"
+    ],
+    "source": "gcc"
+  },
+  "ART 282": {
+    "text": "ART 281",
+    "courses": [
+      "ART 281"
+    ],
+    "source": "gcc"
+  },
+  "ART 290": {
+    "text": "Two 200-level courses coded ART",
+    "courses": [],
+    "source": "gcc"
+  },
+  "ASL 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "ASL 102": {
     "text": "ASL 101 (min C) or ASL 101 (min C) or ASL 101 (min T) or ASL 101 (min T)",
@@ -428,6 +813,14 @@
     "courses": [
       "BIO 101"
     ]
+  },
+  "BIO 102": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "BIO 104": {
     "text": "BIO 104L and BIO 104L and BIO 104L",
@@ -541,6 +934,13 @@
       "ELL 103"
     ]
   },
+  "BIO 116": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "BIO 120": {
     "text": "MAT 099 or ELL 103 or RDG 095 or ESL 098 or ENG 095 or MAT 099",
     "courses": [
@@ -551,11 +951,104 @@
       "ENG 095"
     ]
   },
+  "BIO 120H": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "BIO 120L": {
     "text": "BIO 120",
     "courses": [
       "BIO 120"
     ]
+  },
+  "BIO 124": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BIO 126": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BIO 126H": {
+    "text": "ENG 090, ENG 094 (COL 090), and a grade of C or better in MAT 095 (MAT 105) or MAT 095S,or satisfactory placement test scores.",
+    "courses": [
+      "COL 090",
+      "ENG 090",
+      "ENG 094",
+      "MAT 095",
+      "MAT 095S",
+      "MAT 105"
+    ],
+    "source": "gcc"
+  },
+  "BIO 127": {
+    "text": "BIO 126 or BIO 102",
+    "courses": [
+      "BIO 102",
+      "BIO 126"
+    ],
+    "source": "gcc"
+  },
+  "BIO 127H": {
+    "text": "BIO 126 or BIO 102; MAT 095 or MAT 095S.",
+    "courses": [
+      "BIO 102",
+      "BIO 126",
+      "MAT 095",
+      "MAT 095S"
+    ],
+    "source": "gcc"
+  },
+  "BIO 130": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BIO 130L": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement and BIO 130 concurrently or satisfactory completion.",
+    "courses": [
+      "BIO 130",
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BIO 131": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "BIO 132": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BIO 140": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "BIO 141": {
     "text": "BIO 141L",
@@ -569,6 +1062,13 @@
       "BIO 141"
     ]
   },
+  "BIO 145": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
   "BIO 154": {
     "text": "BIO 154L",
     "courses": [
@@ -580,6 +1080,14 @@
     "courses": [
       "BIO 154"
     ]
+  },
+  "BIO 194": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "BIO 195": {
     "text": "MAT 194 (min C) and ENG 095 or RDG 095 or ELL 103",
@@ -668,6 +1176,30 @@
       "BIO 207"
     ]
   },
+  "BIO 215": {
+    "text": "BIO 126 with a grade of C or better or a college level equivalent within the last ten years with a grade of C or better; ENG 090 and ENG 094 or satisfactory placement; MAT 120 or satisfactory placement.Recomm: MAT 107",
+    "courses": [
+      "BIO 126",
+      "ENG 090",
+      "ENG 094",
+      "MAT 107",
+      "MAT 120"
+    ],
+    "source": "gcc"
+  },
+  "BIO 216": {
+    "text": "BIO 126 with a grade of C or better or a college level equivalent within the last ten years with a grade of C or better; one of the following: BIO 215 (BIO 195) or a grade of B or better within the past 5 years in BIO 194; ENG 090, and ENG 094 or satisfactory placement; MAT 120 or satisfactory placement.",
+    "courses": [
+      "BIO 126",
+      "BIO 194",
+      "BIO 195",
+      "BIO 215",
+      "ENG 090",
+      "ENG 094",
+      "MAT 120"
+    ],
+    "source": "gcc"
+  },
   "BIO 217": {
     "text": "BIO 107 (min C) or BIO 107 (min T)",
     "courses": [
@@ -680,6 +1212,27 @@
       "BIO 117",
       "BIO 217"
     ]
+  },
+  "BIO 220": {
+    "text": "ENG 090, ENG 094, MAT 107 or concurrentenrollment in MAT 107; 2 lab sciences: either 2 fromGroup A or 1 from Group Aand 1 from Group B.  Group A: BIO 102, BIO 120, BIO 126, BIO127, GEO 102Group B: BIO 104, BIO 130 and BIO 130L, BIO 205,CHE 111,  PHY 101, PHY 111,SCI 138.",
+    "courses": [
+      "BIO 102",
+      "BIO 104",
+      "BIO 120",
+      "BIO 126",
+      "BIO 127",
+      "BIO 130",
+      "BIO 130L",
+      "BIO 205",
+      "CHE 111",
+      "ENG 090",
+      "ENG 094",
+      "MAT 107",
+      "PHY 101",
+      "PHY 111",
+      "SCI 138"
+    ],
+    "source": "gcc"
   },
   "BIO 229": {
     "text": "BIO 107 (min C) or BIO 107 (min C) or BIO 107 (min T) or BIO 107 (min T)",
@@ -747,6 +1300,41 @@
       "BIO 235"
     ]
   },
+  "BIO 240": {
+    "text": "Completion of ENG 101, BIO 131, and CHE 131; and completion of or concurrent enrollment in TMA 100",
+    "courses": [
+      "BIO 131",
+      "CHE 131",
+      "ENG 101",
+      "TMA 100"
+    ],
+    "source": "middlesex"
+  },
+  "BIO 250": {
+    "text": "Completion of BIO 240 or BIO 235",
+    "courses": [
+      "BIO 235",
+      "BIO 240"
+    ],
+    "source": "middlesex"
+  },
+  "BIO 252": {
+    "text": "Completion of BIO 131 and BIO 132 with a grade of C or better. Completion of CHE 151 with a grade of C or better",
+    "courses": [
+      "BIO 131",
+      "BIO 132",
+      "CHE 151"
+    ],
+    "source": "middlesex"
+  },
+  "BIO 255": {
+    "text": "Completion of CHE 160 and BIO 250",
+    "courses": [
+      "BIO 250",
+      "CHE 160"
+    ],
+    "source": "middlesex"
+  },
   "BIO 261": {
     "text": "BIO 195 (min C) or BIO 120 (min C) or BIO 207 (min C)",
     "courses": [
@@ -778,6 +1366,61 @@
       "BIO 263"
     ]
   },
+  "BIT 101": {
+    "text": "High school diploma, GED, or equivalent; Must be at least 18 years of age",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "BIT 103": {
+    "text": "Completion of or concurrent enrollment in TMA 100",
+    "courses": [
+      "TMA 100"
+    ],
+    "source": "middlesex"
+  },
+  "BIT 150": {
+    "text": "Completion of ENG 101, BIO 131, CHE 131, and TMA 100",
+    "courses": [
+      "BIO 131",
+      "CHE 131",
+      "ENG 101",
+      "TMA 100"
+    ],
+    "source": "middlesex"
+  },
+  "BIT 155": {
+    "text": "Completion of ENG 101, BIO 131, CHE 131 and TMA 100",
+    "courses": [
+      "BIO 131",
+      "CHE 131",
+      "ENG 101",
+      "TMA 100"
+    ],
+    "source": "middlesex"
+  },
+  "BIT 200": {
+    "text": "Completion of BIT 150 and BIT 155",
+    "courses": [
+      "BIT 150",
+      "BIT 155"
+    ],
+    "source": "middlesex"
+  },
+  "BIT 225": {
+    "text": "Completion of BIT 150 and BIT 155",
+    "courses": [
+      "BIT 150",
+      "BIT 155"
+    ],
+    "source": "middlesex"
+  },
+  "BIT 250": {
+    "text": "Completion of BIT 150",
+    "courses": [
+      "BIT 150"
+    ],
+    "source": "middlesex"
+  },
   "BME 100": {
     "text": "MAT 281 (min C) and CHM 201 (min C) and MAT 282",
     "courses": [
@@ -796,11 +1439,26 @@
       "ELL 103"
     ]
   },
+  "BUS 102": {
+    "text": "ENG 090, ENG 094  or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "BUS 105": {
     "text": "MAT 018C",
     "courses": [
       "MAT 018C"
     ]
+  },
+  "BUS 110": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
   },
   "BUS 111": {
     "text": "MAT 018C",
@@ -814,12 +1472,103 @@
       "BUS 111"
     ]
   },
+  "BUS 116": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "BUS 122": {
     "text": "MAT 018 or MAT 018C",
     "courses": [
       "MAT 018",
       "MAT 018C"
     ]
+  },
+  "BUS 130": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 131": {
+    "text": "Students must complete 12 credits at MCC in order to apply for this fellowship program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "BUS 135": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 140": {
+    "text": "Completion of at least 12 credits with the following course codes: ACC, BUS, CIS, ECO, or MOM; or permission of instructor.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "BUS 152": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80; or Completion of BUS 151 with a C or better",
+    "courses": [
+      "BUS 151",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 153": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 155": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BUS 156": {
+    "text": "BUS 155",
+    "courses": [
+      "BUS 155"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 159": {
+    "text": "Successful completion of BUS 157",
+    "courses": [
+      "BUS 157"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 164": {
+    "text": "ENG 094 or concurrent enrollment or satisfactory placement",
+    "courses": [
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BUS 164H": {
+    "text": "ENG 094 or concurrent enrollment or satisfactory placementRecomm: ENG 090 or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "BUS 172": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
   },
   "BUS 201": {
     "text": "ENG 095 or RDG 095 or ELL 103",
@@ -828,6 +1577,20 @@
       "RDG 095",
       "ELL 103"
     ]
+  },
+  "BUS 203": {
+    "text": "BUS 111 or permission of the instructor in the case of prior work experience",
+    "courses": [
+      "BUS 111"
+    ],
+    "source": "gcc"
+  },
+  "BUS 205": {
+    "text": "BUS 111",
+    "courses": [
+      "BUS 111"
+    ],
+    "source": "gcc"
   },
   "BUS 206": {
     "text": "BUS 107",
@@ -847,6 +1610,51 @@
       "BUS 107"
     ]
   },
+  "BUS 209": {
+    "text": "BUS 111",
+    "courses": [
+      "BUS 111"
+    ],
+    "source": "gcc"
+  },
+  "BUS 210": {
+    "text": "Eligible for ENG 101; and completion of BUS 110 or BUS 130",
+    "courses": [
+      "BUS 110",
+      "BUS 130",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 211": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 212": {
+    "text": "Completion of BUS 110 or BUS 130",
+    "courses": [
+      "BUS 110",
+      "BUS 130"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 213": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 214": {
+    "text": "Eligible for ENG 101; and completion of 12 credits in the student’s degree or certificate program with a GPA of 2.0 or higher",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "BUS 215": {
     "text": "MTH 075 (min XC-) or MTH 075 (min T) or MTH 079 (min XC-) or MTH 079 (min T) or MTH 085 (min XD-) or MTH 085 (min T) or MTH 013 (min XD-) or MTH 013 (min T) or MTH 095 (min XD-) or MTH 095 (min T) or MTH 099 (min XD-) or MTH 099 (min T) or MTH 014 (min XD-) or MTH 014 (min T) or MTH 104 (min D-) or MTH 104 (min T) or MTH 108 (min D-) or MTH 108 (min T) or MTH 113 (min D-) or MTH 113 (min T) or MTH 142 (min D-) or MTH 142 (min T)MTH 011 (min XC-) or MTH 011 (min T) and MTH 012 (min XC-) or MTH 012 (min T)",
     "courses": [
@@ -865,6 +1673,29 @@
       "MTH 012"
     ]
   },
+  "BUS 216": {
+    "text": "HSV 101 or POL 101 or BUS 111",
+    "courses": [
+      "BUS 111",
+      "HSV 101",
+      "POL 101"
+    ],
+    "source": "gcc"
+  },
+  "BUS 217": {
+    "text": "Completion of or concurrent enrollment in BUS 211",
+    "courses": [
+      "BUS 211"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 218": {
+    "text": "BUS 211 or co-enrolled in BUS 211",
+    "courses": [
+      "BUS 211"
+    ],
+    "source": "middlesex"
+  },
   "BUS 220": {
     "text": "ENG 097 (min XC-) or ENG 097 (min XC-) or ENG 097 (min T) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
     "courses": [
@@ -878,6 +1709,90 @@
       "ENG 104"
     ]
   },
+  "BUS 221": {
+    "text": "Eligible for ENG 109; eligible for MAT 080, Math Module 70 or 80; and completion of CAP 101",
+    "courses": [
+      "CAP 101",
+      "ENG 109",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 222": {
+    "text": "Completion of BUS 120 or BUS 221",
+    "courses": [
+      "BUS 120",
+      "BUS 221"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 223": {
+    "text": "Completion of BUS 220 or BUS 221; and completion of CAP 101",
+    "courses": [
+      "BUS 220",
+      "BUS 221",
+      "CAP 101"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 224": {
+    "text": "ENG 101, BUS 111",
+    "courses": [
+      "BUS 111",
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "BUS 226": {
+    "text": "BUS 164 or permission of instructor.",
+    "courses": [
+      "BUS 164"
+    ],
+    "source": "gcc"
+  },
+  "BUS 227": {
+    "text": "BUS 226.",
+    "courses": [
+      "BUS 226"
+    ],
+    "source": "gcc"
+  },
+  "BUS 228": {
+    "text": "BUS 227 or concurrent enrollment in BUS 227",
+    "courses": [
+      "BUS 227"
+    ],
+    "source": "gcc"
+  },
+  "BUS 240": {
+    "text": "Completion of BUS 110 or BUS 130",
+    "courses": [
+      "BUS 110",
+      "BUS 130"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 241": {
+    "text": "Completion of BUS 110",
+    "courses": [
+      "BUS 110"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 242": {
+    "text": "Completion of BUS 240",
+    "courses": [
+      "BUS 240"
+    ],
+    "source": "middlesex"
+  },
+  "BUS 243": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
   "BUS 260": {
     "text": "BUS 110 or ACC 260 or MGT 260 or MKT 260",
     "courses": [
@@ -886,6 +1801,149 @@
       "MGT 260",
       "MKT 260"
     ]
+  },
+  "CAD 131": {
+    "text": "Completion of CAD 110 and CAD 169",
+    "courses": [
+      "CAD 110",
+      "CAD 169"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 169": {
+    "text": "Completion of EGR 101 or current enrollment in CAD 110",
+    "courses": [
+      "CAD 110",
+      "EGR 101"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 180": {
+    "text": "Completion of CAD 169",
+    "courses": [
+      "CAD 169"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 205": {
+    "text": "Completion of or concurrent enrollment in CAD 131",
+    "courses": [
+      "CAD 131"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 220": {
+    "text": "Completion of or concurrent enrollment in CAD 131",
+    "courses": [
+      "CAD 131"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 221": {
+    "text": "CAD 220",
+    "courses": [
+      "CAD 220"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 225": {
+    "text": "Completion of CAD 169 and CAD 180",
+    "courses": [
+      "CAD 169",
+      "CAD 180"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 228": {
+    "text": "Completion CAD 225 and CAD 227",
+    "courses": [
+      "CAD 225",
+      "CAD 227"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 229": {
+    "text": "Completion of CAD 169, CAD 110 and CAD 230. Department approval of the internship position prior to enrollment",
+    "courses": [
+      "CAD 110",
+      "CAD 169",
+      "CAD 230"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 230": {
+    "text": "Completion of, or concurrent enrollment in, CAD 169 or CAD 110",
+    "courses": [
+      "CAD 110",
+      "CAD 169"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 231": {
+    "text": "Completion of CAD 230",
+    "courses": [
+      "CAD 230"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 232": {
+    "text": "Completion of CAD 169, CAD 110 and CAD 230. Department approval prior to enrollment",
+    "courses": [
+      "CAD 110",
+      "CAD 169",
+      "CAD 230"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 233": {
+    "text": "Completion of CAD 232",
+    "courses": [
+      "CAD 232"
+    ],
+    "source": "middlesex"
+  },
+  "CAD 270": {
+    "text": "Completion of or concurrent enrollment in CAD 169",
+    "courses": [
+      "CAD 169"
+    ],
+    "source": "middlesex"
+  },
+  "CAP 101": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "CAP 103": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "CAP 154": {
+    "text": "Completion of BUS 105 or CAP 101",
+    "courses": [
+      "BUS 105",
+      "CAP 101"
+    ],
+    "source": "middlesex"
+  },
+  "CAP 155": {
+    "text": "Completion of CAP 101",
+    "courses": [
+      "CAP 101"
+    ],
+    "source": "middlesex"
+  },
+  "CAP 156": {
+    "text": "Completion of CAP 101",
+    "courses": [
+      "CAP 101"
+    ],
+    "source": "middlesex"
   },
   "CET 210": {
     "text": "CET 210L and MAT 124",
@@ -919,6 +1977,102 @@
       "MAT 124",
       "PHY 221"
     ]
+  },
+  "CHE 105": {
+    "text": "ENG 090, ENG 094or satisfactory placement",
+    "courses": [
+      "ENG 090"
+    ],
+    "source": "gcc"
+  },
+  "CHE 111": {
+    "text": "ENG 090, ENG 094, MAT 120, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 120"
+    ],
+    "source": "gcc"
+  },
+  "CHE 111H": {
+    "text": "ENG 090 and ENG 094, MAT 120, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 120"
+    ],
+    "source": "gcc"
+  },
+  "CHE 112": {
+    "text": "CHE 111 with a grade of C or better; MAT 107 or satisfactory placement",
+    "courses": [
+      "CHE 111",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "CHE 121": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 131": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 132": {
+    "text": "Completion of CHE 131 with a C or better",
+    "courses": [
+      "CHE 131"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 151": {
+    "text": "Eligible for ENG 101; eligible for MAT 195; and completion of high school or college chemistry in the last five years",
+    "courses": [
+      "ENG 101",
+      "MAT 195"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 152": {
+    "text": "Completion of CHE 151 and MAT 195, both with a C or better",
+    "courses": [
+      "CHE 151",
+      "MAT 195"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 160": {
+    "text": "Completion of BIO 131, CHE 121 or CHE 131, and TMA 100",
+    "courses": [
+      "BIO 131",
+      "CHE 121",
+      "CHE 131",
+      "TMA 100"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 251": {
+    "text": "Completion of CHE 152 with a C or better",
+    "courses": [
+      "CHE 152"
+    ],
+    "source": "middlesex"
+  },
+  "CHE 252": {
+    "text": "Completion of CHE 251 with a grade of C or better",
+    "courses": [
+      "CHE 251"
+    ],
+    "source": "middlesex"
   },
   "CHM 101": {
     "text": "MAT 062 or MAT 089 or MAT 083 or MAT 087 or MAT 097 or MAT 063 and CHM 101L and CHM 101L and CHM 101L and CHM 101L and CHM 101L",
@@ -1070,6 +2224,44 @@
       "CIS 124",
       "MAT 102"
     ]
+  },
+  "CIS 140": {
+    "text": "ENG 090, ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "CIS 141": {
+    "text": "CIS 140",
+    "courses": [
+      "CIS 140"
+    ],
+    "source": "gcc"
+  },
+  "CIS 145": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "CIS 151": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "CIS 153": {
+    "text": "CIS 151 or permission of the instructor",
+    "courses": [
+      "CIS 151"
+    ],
+    "source": "gcc"
   },
   "CIS 155": {
     "text": "CIS 102",
@@ -1403,6 +2595,20 @@
       "CIT 270"
     ]
   },
+  "CMN 153": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "CMN 201": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
   "CMP 106": {
     "text": "OIT 100",
     "courses": [
@@ -1497,6 +2703,20 @@
       "ENG 111"
     ]
   },
+  "COM 106": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 110": {
+    "text": "Concurrent enrollment in or completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "COM 113": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 101 or ENG 101 or ENG 101 (min T) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T)",
     "courses": [
@@ -1509,6 +2729,20 @@
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "COM 115": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 116": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "COM 117": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
@@ -1523,6 +2757,27 @@
       "ENG 104"
     ]
   },
+  "COM 119": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 124": {
+    "text": "Concurrent enrollment in or completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 125": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "COM 126": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
     "courses": [
@@ -1536,12 +2791,40 @@
       "ENG 104"
     ]
   },
+  "COM 127": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "COM 142": {
     "text": "COM 113 (min D-) or COM 113 (min T) or ENG 113 (min D-) or ENG 113 (min T)",
     "courses": [
       "COM 113",
       "ENG 113"
     ]
+  },
+  "COM 143": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 150": {
+    "text": "Concurrent enrollment in or completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "COM 180": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "COM 205": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T) and COM 107 (min D-) or COM 107 (min T) or COM 108 (min D-) or COM 108 (min T) or COM 109 (min D-) or COM 109 (min T) or COM 110 (min D-) or COM 110 (min T) or COM 113 (min D-) or COM 113 (min T) or COM 117 (min D-) or COM 117 (min T) or COM 120 (min D-) or COM 120 (min T) or COM 121 (min D-) or COM 121 (min T) or COM 122 (min D-) or COM 122 (min T) or COM 126 (min D-) or COM 126 (min T) or COM 127 (min D-) or COM 127 (min T) or COM 131 (min D-) or COM 131 (min T) or COM 141 (min D-) or COM 141 (min T) or COM 142 (min D-) or COM 142 (min T) or COM 150 (min D-) or COM 150 (min T)",
@@ -1597,6 +2880,45 @@
       "ENG 104"
     ]
   },
+  "COM 221": {
+    "text": "Successful completion of COM 104 (Foundations of Media Production) and completion of 30 credits in the communication degree program with a GPA of 2.0 or higher",
+    "courses": [
+      "COM 104"
+    ],
+    "source": "middlesex"
+  },
+  "COM 222": {
+    "text": "Successful completion of COM 104 (Foundations of Media Production) and completion of 30 credits in the communication degree program with a GPA of 2.0 or higher",
+    "courses": [
+      "COM 104"
+    ],
+    "source": "middlesex"
+  },
+  "COM 223": {
+    "text": "Successful completion of COM 104 (Foundations of Media Production) and completion of 30 credits in the communication degree program with a GPA of 2.0 or higher",
+    "courses": [
+      "COM 104"
+    ],
+    "source": "middlesex"
+  },
+  "COM 228": {
+    "text": "Completion of COM 125 or completion of or concurrent enrollment in BUS 110 or BUS 130",
+    "courses": [
+      "BUS 110",
+      "BUS 130",
+      "COM 125"
+    ],
+    "source": "middlesex"
+  },
+  "COM 230": {
+    "text": "Completion of COM 104 OR COM 105 OR COM 121",
+    "courses": [
+      "COM 104",
+      "COM 105",
+      "COM 121"
+    ],
+    "source": "middlesex"
+  },
   "COM 250": {
     "text": "ENG 095 or RDG 095 or ELL 103",
     "courses": [
@@ -1610,6 +2932,13 @@
     "courses": [
       "COM 110"
     ]
+  },
+  "COM 292": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "COM 299": {
     "text": "COM 171",
@@ -1659,6 +2988,13 @@
       "ENG 104"
     ]
   },
+  "CRJ 105": {
+    "text": "CRJ 101 or permission of instructor",
+    "courses": [
+      "CRJ 101"
+    ],
+    "source": "gcc"
+  },
   "CRJ 107": {
     "text": "ENG 095 or ESL 098 or RDG 095 or ELL 103",
     "courses": [
@@ -1680,6 +3016,13 @@
       "CRJ 101"
     ]
   },
+  "CRJ 111": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "CRJ 112": {
     "text": "CRJ 100 (min D-) or CRJ 100 (min D-) or CRJ 100 (min T) or CRJ 100 (min T)",
     "courses": [
@@ -1693,11 +3036,33 @@
       "SOC 110"
     ]
   },
+  "CRJ 121": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "CRJ 122": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "CRJ 123": {
     "text": "CRJ 121",
     "courses": [
       "CRJ 121"
     ]
+  },
+  "CRJ 125": {
+    "text": "Eligible for ENG101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "CRJ 126": {
     "text": "CRJ 105",
@@ -1711,6 +3076,14 @@
       "CRJ 101"
     ]
   },
+  "CRJ 131": {
+    "text": "Completion of ENG 101 and CRJ 112",
+    "courses": [
+      "CRJ 112",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "CRJ 150": {
     "text": "CRJ 101 (min C) or ENG 095 (min C) or ENG 099 (min C)",
     "courses": [
@@ -1718,6 +3091,21 @@
       "ENG 095",
       "ENG 099"
     ]
+  },
+  "CRJ 153": {
+    "text": "Completion of ENG101 or concurrent enrollment or completion of SOC101",
+    "courses": [
+      "ENG 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
+  "CRJ 156": {
+    "text": "Completion of ENG101 or concurrent enrollment or completion of CR J153",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "CRJ 200": {
     "text": "CRJ 101 (min C) or ENG 095 (min C)",
@@ -1794,6 +3182,21 @@
       "SOC 110"
     ]
   },
+  "CRJ 231": {
+    "text": "Completion of CRJ 111 and ENG 101",
+    "courses": [
+      "CRJ 111",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "CRJ 241": {
+    "text": "Completion of CRJ112 or concurrent enrollment of CRJ112",
+    "courses": [
+      "CRJ 112"
+    ],
+    "source": "middlesex"
+  },
   "CRJ 275": {
     "text": "CRJ 101 and CRJ 103 and CRJ 107 and CRJ 211 and CRJ 225 and SOC 207",
     "courses": [
@@ -1804,6 +3207,13 @@
       "CRJ 225",
       "SOC 207"
     ]
+  },
+  "CRJ 291": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of the Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "CRJ 299": {
     "text": "ENG 111 (min C) and CRJ 101 (min C) and CRJ 103 (min C) and CRJ 107 (min C)",
@@ -1827,6 +3237,21 @@
     "courses": [
       "CSC 100"
     ]
+  },
+  "CSC 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "CSC 111": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
   },
   "CSC 113": {
     "text": "MAT 064 and CSC 113L and CSC 113L and CSC 113L and CSC 113L",
@@ -1859,6 +3284,63 @@
       "MAT 099"
     ]
   },
+  "CSC 151": {
+    "text": "Eligible for ENG 101; and eligible for MAT 290 or completion of CSC 101 with a C or better and eligible for Math Module 82",
+    "courses": [
+      "CSC 101",
+      "ENG 101",
+      "MAT 290"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 156": {
+    "text": "Eligible for ENG 101; and completion of or concurrent enrollment in CSC 101, CSC 151, or NST 165",
+    "courses": [
+      "CSC 101",
+      "CSC 151",
+      "ENG 101",
+      "NST 165"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 170": {
+    "text": "Completion of ENG 101 with a C- or better",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 188": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 201": {
+    "text": "MAT 201 and MAT 202 (or concurrent enrollment in MAT 202)",
+    "courses": [
+      "MAT 201",
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "CSC 201H": {
+    "text": "MAT 201 and MAT 202 (or concurrent enrollment in MAT202)",
+    "courses": [
+      "MAT 201",
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "CSC 202": {
+    "text": "Eligible for ENG 102; and completion of CSC 252 with a C or better",
+    "courses": [
+      "CSC 252",
+      "ENG 102"
+    ],
+    "source": "middlesex"
+  },
   "CSC 210": {
     "text": "MAT 125 and CSC 111 or CSC 113 and CSC 210L and CSC 210L and CSC 210L",
     "courses": [
@@ -1873,6 +3355,15 @@
     "courses": [
       "CSC 210"
     ]
+  },
+  "CSC 212": {
+    "text": "Completion of CSC 101 or CSC 151 and CSC 111",
+    "courses": [
+      "CSC 101",
+      "CSC 111",
+      "CSC 151"
+    ],
+    "source": "middlesex"
   },
   "CSC 220": {
     "text": "CSC 113 and CSC 220L",
@@ -1938,6 +3429,62 @@
       "CSC 239"
     ]
   },
+  "CSC 251": {
+    "text": "CSC 101 or permission of instructor.",
+    "courses": [
+      "CSC 101"
+    ],
+    "source": "gcc"
+  },
+  "CSC 252": {
+    "text": "CSC 101 or permission of instructor.",
+    "courses": [
+      "CSC 101"
+    ],
+    "source": "gcc"
+  },
+  "CSC 254": {
+    "text": "CSC 251 (or CIS 251); and MAT 107 or satisfactory placement",
+    "courses": [
+      "CIS 251",
+      "CSC 251",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "CSC 254H": {
+    "text": "CSC 251 (or CIS 251); and MAT 107 or satisfactory placement",
+    "courses": [
+      "CIS 251",
+      "CSC 251",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "CSC 255": {
+    "text": "Eligible for ENG 102; and completion of CSC 252 with a C or better",
+    "courses": [
+      "CSC 252",
+      "ENG 102"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 258": {
+    "text": "Eligible for ENG 102; and completion of CSC 255 with a C or better and eligible for MAT 290",
+    "courses": [
+      "CSC 255",
+      "ENG 102",
+      "MAT 290"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 272": {
+    "text": "Completion of CSC 170 with a C or better",
+    "courses": [
+      "CSC 170"
+    ],
+    "source": "middlesex"
+  },
   "CSC 284": {
     "text": "CSC 237 or MAT 194",
     "courses": [
@@ -1959,6 +3506,22 @@
       "CSC 285",
       "MAT 197"
     ]
+  },
+  "CSC 289": {
+    "text": "Eligible for ENG 101; and completion of CSC 151 with a C or better",
+    "courses": [
+      "CSC 151",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "CSC 290": {
+    "text": "Eligible for ENG 101; and completion of CSC 151 with a C or better",
+    "courses": [
+      "CSC 151",
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "CSC 299": {
     "text": "CSC 237 and CSC 239",
@@ -2124,6 +3687,33 @@
       "CSO 205"
     ]
   },
+  "CSW 058": {
+    "text": "64 continual training hours w/in 3 years of start date with any wilderness medical training program. Students must be 18 years of age to attend this course.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "CSW 066": {
+    "text": "must be hungry. If more of us valued food and cheer and song above hoarded gold, it would be a merrier world. J.R.R. Tolkien",
+    "courses": [],
+    "source": "gcc"
+  },
+  "CSW 086": {
+    "text": "Medical Insurance Billing (CSW 082) or previous knowledge. May be taken concurrently with CSW 082.",
+    "courses": [
+      "CSW 082"
+    ],
+    "source": "gcc"
+  },
+  "CSW 391": {
+    "text": "Students must have proficiency with mathematical operations with whole numbers, decimals, fractions and percents (or permission of instructor)",
+    "courses": [],
+    "source": "gcc"
+  },
+  "CSW 415": {
+    "text": "basic computer skills.",
+    "courses": [],
+    "source": "gcc"
+  },
   "CUL 101": {
     "text": "CUL 100 (min C-) or CUL 100 (min T)",
     "courses": [
@@ -2243,6 +3833,71 @@
       "DAS 100"
     ]
   },
+  "DAS 101": {
+    "text": "Admission into the Dental Assisting program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "DAS 102": {
+    "text": "Admission into the Dental Assisting program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "DAS 103": {
+    "text": "Completion of DAS 101 and DAS 105",
+    "courses": [
+      "DAS 101",
+      "DAS 105"
+    ],
+    "source": "middlesex"
+  },
+  "DAS 104": {
+    "text": "Admission into the Dental Assisting program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "DAS 105": {
+    "text": "Admission into the Dental Assisting program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "DAS 150": {
+    "text": "Completion of DAS 101, DAS 102, DAS 104, DAS 105, DHY 152",
+    "courses": [
+      "DAS 101",
+      "DAS 102",
+      "DAS 104",
+      "DAS 105",
+      "DHY 152"
+    ],
+    "source": "middlesex"
+  },
+  "DAS 151": {
+    "text": "Completion of DAS 101",
+    "courses": [
+      "DAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "DAS 152": {
+    "text": "Completion of DAS 101 and DAS 105",
+    "courses": [
+      "DAS 101",
+      "DAS 105"
+    ],
+    "source": "middlesex"
+  },
+  "DAS 153": {
+    "text": "Completion of DAS 101, DAS 102, DAS 104, DAS 105, DHY 152",
+    "courses": [
+      "DAS 101",
+      "DAS 102",
+      "DAS 104",
+      "DAS 105",
+      "DHY 152"
+    ],
+    "source": "middlesex"
+  },
   "DAS 200": {
     "text": "DAS 200L",
     "courses": [
@@ -2268,6 +3923,29 @@
       "ENG 102"
     ]
   },
+  "DHY 103": {
+    "text": "Completion of BIO 231 and BIO 232",
+    "courses": [
+      "BIO 231",
+      "BIO 232"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 104": {
+    "text": "Completion of BIO 231 and BIO 232",
+    "courses": [
+      "BIO 231",
+      "BIO 232"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 105": {
+    "text": "Completion of CHE 131",
+    "courses": [
+      "CHE 131"
+    ],
+    "source": "middlesex"
+  },
   "DHY 110": {
     "text": "DHY 110L and DHY 110L and DHY 110L",
     "courses": [
@@ -2279,6 +3957,79 @@
     "courses": [
       "DHY 110"
     ]
+  },
+  "DHY 150": {
+    "text": "Completion of DHY 100 with a C or better; completion of DHY 101",
+    "courses": [
+      "DHY 100",
+      "DHY 101"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 151": {
+    "text": "Completion of DHY 100 and DHY 105, both with a C or better; completion of DHY 101",
+    "courses": [
+      "DHY 100",
+      "DHY 101",
+      "DHY 105"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 152": {
+    "text": "Admission to the Dental Hygiene Program or the Dental Assisting Program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "DHY 153": {
+    "text": "Completion of DHY 100, DHY 104, and BIO 235, all with a C or better; completion of DHY 101",
+    "courses": [
+      "BIO 235",
+      "DHY 100",
+      "DHY 101",
+      "DHY 104"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 200": {
+    "text": "Completion of DHY 150 with a C or better; completion of DHY 151",
+    "courses": [
+      "DHY 150",
+      "DHY 151"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 201": {
+    "text": "Completion of DHY 150, DHY 152, and DHY 153, all with a C or better; completion of DHY 151",
+    "courses": [
+      "DHY 150",
+      "DHY 151",
+      "DHY 152",
+      "DHY 153"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 202": {
+    "text": "Completion of DHY 104 and BIO 235, both with a C or better",
+    "courses": [
+      "BIO 235",
+      "DHY 104"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 203": {
+    "text": "Completion of DHY 151",
+    "courses": [
+      "DHY 151"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 204": {
+    "text": "Completion of CHE 132 with a C or better; completion of DHY 151",
+    "courses": [
+      "CHE 132",
+      "DHY 151"
+    ],
+    "source": "middlesex"
   },
   "DHY 210": {
     "text": "DHY 120 and DHY 210L",
@@ -2310,6 +4061,78 @@
     "courses": [
       "DHY 222"
     ]
+  },
+  "DHY 251": {
+    "text": "Completion of DHY 200, DHY 203, and DHY 204, all with a C or better; completion of DHY 201",
+    "courses": [
+      "DHY 200",
+      "DHY 201",
+      "DHY 203",
+      "DHY 204"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 252": {
+    "text": "Completion of DHY 200 with a C or better; completion of MAT 177",
+    "courses": [
+      "DHY 200",
+      "MAT 177"
+    ],
+    "source": "middlesex"
+  },
+  "DHY 253": {
+    "text": "Completion of DHY 200 and DHY 203, both with a C or better; completion of DHY 201",
+    "courses": [
+      "DHY 200",
+      "DHY 201",
+      "DHY 203"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 130": {
+    "text": "Completion of DLT 110 and DLT 120, both with a C or better",
+    "courses": [
+      "DLT 110",
+      "DLT 120"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 140": {
+    "text": "Completion of DLT 110 and DLT 120, both with a C or better",
+    "courses": [
+      "DLT 110",
+      "DLT 120"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 210": {
+    "text": "Completion of DLT 130 with a C or better",
+    "courses": [
+      "DLT 130"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 220": {
+    "text": "Completion of DLT 140 with a C or better",
+    "courses": [
+      "DLT 140"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 230": {
+    "text": "Completion of DLT 130 with a C or better",
+    "courses": [
+      "DLT 130"
+    ],
+    "source": "middlesex"
+  },
+  "DLT 240": {
+    "text": "Completion of DLT 210 and DLT 220, both with a C or better",
+    "courses": [
+      "DLT 210",
+      "DLT 220"
+    ],
+    "source": "middlesex"
   },
   "DMP 120": {
     "text": "DMP 120L and DMP 120L and DMP 120L",
@@ -2598,6 +4421,62 @@
       "ECN 100"
     ]
   },
+  "ECO 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ECO 102": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ECO 113": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ECO 120": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ECO 129": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "ECO 140": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ECO 150": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
   "ECO 201": {
     "text": "MAT 097 or MAT 098 or RDG 095 or ESL 098 or ELL 103",
     "courses": [
@@ -2629,6 +4508,13 @@
     "courses": [
       "MAT 018C"
     ]
+  },
+  "EDU 100": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "EDU 101": {
     "text": "ENG 085 (min XC-) or ENG 085 (min T) or ENG 095 (min XD-) or ENG 095 (min T) or ENG 096 (min XD-) or ENG 096 (min T) or ENG 099 (min XD-) or ENG 099 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T) or SPA 203 (min D-) or SPA 203 (min T) and EDU 104 (min C) or EDU 104 (min T)",
@@ -2671,11 +4557,27 @@
       "SPA 203"
     ]
   },
+  "EDU 109": {
+    "text": "Completion of EDU 122 (formerly PSY 122) 101, and 102 with a C or better; concurrent registration of EDU 109 and 101 and/or 102 is permitted.*",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
   "EDU 110": {
     "text": "EDU 103",
     "courses": [
       "EDU 103"
     ]
+  },
+  "EDU 111": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "EDU 120": {
     "text": "ENG 085 (min XC-) or ENG 085 (min T) or SPA 203 (min D-) or SPA 203 (min T) or ENG 101 (min T) or ENG 101 (min D-) or ENG 095 (min C-) or ENG 095 (min T) and EDU 104 (min C) or EDU 104 (min T) or PSY 215 (min C) or PSY 215 (min T)",
@@ -2687,6 +4589,13 @@
       "EDU 104",
       "PSY 215"
     ]
+  },
+  "EDU 122": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "EDU 123": {
     "text": "EDU 124",
@@ -2700,6 +4609,46 @@
       "EDU 123"
     ]
   },
+  "EDU 133": {
+    "text": "EDU 144, EDU 201",
+    "courses": [
+      "EDU 144",
+      "EDU 201"
+    ],
+    "source": "gcc"
+  },
+  "EDU 144": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "EDU 150": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "EDU 153": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better and Completion of EDU 101 with a C or better",
+    "courses": [
+      "EDU 101",
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
+  "EDU 154": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
   "EDU 175": {
     "text": "ENG 101 (min C-) or ENG 101 (min T) or ENG 102 (min C-) or ENG 102 (min T) or ENG 104 (min C-) or ENG 104 (min T)",
     "courses": [
@@ -2707,6 +4656,14 @@
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "EDU 201": {
+    "text": "EDU 101 or EDU 144 with a grade of C- or higher or permission of department chair.",
+    "courses": [
+      "EDU 101",
+      "EDU 144"
+    ],
+    "source": "gcc"
   },
   "EDU 202": {
     "text": "ENG 095 (min C) or ENG 098 (min C)",
@@ -2780,6 +4737,21 @@
       "EDU 120"
     ]
   },
+  "EDU 215": {
+    "text": "Declared major in Early Childhood Education. EDU 101 with a C- or higher and a G.P.A. of2.5 or higher and permission of the department chair.",
+    "courses": [
+      "EDU 101"
+    ],
+    "source": "gcc"
+  },
+  "EDU 216": {
+    "text": "EDU 101, EDU 144, and permission of department chair",
+    "courses": [
+      "EDU 101",
+      "EDU 144"
+    ],
+    "source": "gcc"
+  },
   "EDU 220": {
     "text": "EDU 203 and EDU 204 and EDU 205",
     "courses": [
@@ -2808,6 +4780,24 @@
     "courses": [
       "EDU 104"
     ]
+  },
+  "EDU 251": {
+    "text": "Completion of EDU 104 and EDU 153 with a C or better",
+    "courses": [
+      "EDU 104",
+      "EDU 153"
+    ],
+    "source": "middlesex"
+  },
+  "EDU 252": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better and Completion of EDU 101 and EDU 153 with a C or better",
+    "courses": [
+      "EDU 101",
+      "EDU 122",
+      "EDU 153",
+      "PSY 122"
+    ],
+    "source": "middlesex"
   },
   "EDU 260": {
     "text": "ENG 101 (min C-) or ENG 101 (min T) and EDU 104 (min C) or EDU 104 (min T) and EDU 100 (min C) or EDU 100 (min T)",
@@ -2915,6 +4905,15 @@
       "EET 240"
     ]
   },
+  "EGR 101": {
+    "text": "Completion of or concurrent enrollment in ENG 101; placement above, completion of, or concurrent enrollment in MAT 195 or MAT 196",
+    "courses": [
+      "ENG 101",
+      "MAT 195",
+      "MAT 196"
+    ],
+    "source": "middlesex"
+  },
   "EGR 103": {
     "text": "EGR 103L and EGR 103L and EGR 103L and EGR 103L",
     "courses": [
@@ -2927,6 +4926,30 @@
       "EGR 103"
     ]
   },
+  "EGR 104": {
+    "text": "Completion of MAT080 or completion of or placement above module 82",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 105": {
+    "text": "MAT 107 or concurrent enrollment in MAT 107 or satisfactory placement; ENG 090 and ENG 094, or satisfactory placement.Recomm: Any 3-credit Behavioral and Social Sciences General Education Elective.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "EGR 107": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "EGR 111": {
     "text": "CHM 111 and MAT 131 and PHY 231",
     "courses": [
@@ -2935,12 +4958,36 @@
       "PHY 231"
     ]
   },
+  "EGR 114": {
+    "text": "MAT 108 or concurrent enrollment in MAT 108.",
+    "courses": [
+      "MAT 108"
+    ],
+    "source": "gcc"
+  },
   "EGR 121": {
     "text": "MAT 131 and PHY 231",
     "courses": [
       "MAT 131",
       "PHY 231"
     ]
+  },
+  "EGR 122": {
+    "text": "MAT108 or concurrent enrollment in MAT 108",
+    "courses": [
+      "MAT 108"
+    ],
+    "source": "gcc"
+  },
+  "EGR 124": {
+    "text": "MAT 107 or satisfactory placement into MAT 108 or concurrent enrollment in MAT 107. ENG 090 and ENG094 or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 107",
+      "MAT 108"
+    ],
+    "source": "gcc"
   },
   "EGR 203": {
     "text": "CHM 101 (min D-) or CHM 101 (min T) or CHM 113 (min D-) or CHM 113 (min T) or CHM 121 (min D-) or CHM 121 (min T)",
@@ -2949,6 +4996,21 @@
       "CHM 113",
       "CHM 121"
     ]
+  },
+  "EGR 205": {
+    "text": "MAT 201, PHY 111",
+    "courses": [
+      "MAT 201",
+      "PHY 111"
+    ],
+    "source": "gcc"
+  },
+  "EGR 206": {
+    "text": "EGR 205 or  permission of instructor",
+    "courses": [
+      "EGR 205"
+    ],
+    "source": "gcc"
   },
   "EGR 209": {
     "text": "MTH 112 (min D-) or MTH 112 (min T) or MTH 114 (min D-) or MTH 114 (min T) or MTH 211 (min D-) or MTH 211 (min T) or MTH 213 (min D-) or MTH 213 (min T) and EGR 221 (min D-) or EGR 221 (min T)",
@@ -2959,6 +5021,68 @@
       "MTH 213",
       "EGR 221"
     ]
+  },
+  "EGR 210": {
+    "text": "MAT 202, PHY 112",
+    "courses": [
+      "MAT 202",
+      "PHY 112"
+    ],
+    "source": "gcc"
+  },
+  "EGR 211": {
+    "text": "Completion of EGR 210",
+    "courses": [
+      "EGR 210"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 212": {
+    "text": "Completion of both EGR 210 and MAT 291",
+    "courses": [
+      "EGR 210",
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 213": {
+    "text": "MAT 202",
+    "courses": [
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "EGR 214": {
+    "text": "Completion of CHE 151 and MAT 291",
+    "courses": [
+      "CHE 151",
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 215": {
+    "text": "Completion of both MAT 291 and EGR 101",
+    "courses": [
+      "EGR 101",
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 216": {
+    "text": "Completion of both MAT291 and PHY 172",
+    "courses": [
+      "MAT 291",
+      "PHY 172"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 217": {
+    "text": "Completion of both CHE 151 and PHY 171",
+    "courses": [
+      "CHE 151",
+      "PHY 171"
+    ],
+    "source": "middlesex"
   },
   "EGR 221": {
     "text": "MTH 112 (min D-) or MTH 112 (min D-) or MTH 112 (min T) or MTH 112 (min T) or MTH 114 (min D-) or MTH 114 (min D-) or MTH 114 (min T) or MTH 114 (min T) or MTH 211 (min D-) or MTH 211 (min D-) or MTH 211 (min T) or MTH 211 (min T) or MTH 213 (min D-) or MTH 213 (min D-) or MTH 213 (min T) or MTH 213 (min T) and PHS 111 (min D-) or PHS 111 (min D-) or PHS 111 (min T) or PHS 111 (min T)",
@@ -2993,6 +5117,41 @@
       "PHY 231",
       "CHM 111"
     ]
+  },
+  "EGR 260": {
+    "text": "Completion of MAT 291 Calculus II for Science and PHY 172 Physics for Engineering &amp;Science II and Completion of or concurrent enrollment in MAT 292 Calculus III for Engineering and NST 101 Principle of Electric Circuits",
+    "courses": [
+      "MAT 291",
+      "MAT 292",
+      "NST 101",
+      "PHY 172"
+    ],
+    "source": "middlesex"
+  },
+  "EGR 261": {
+    "text": "Completion of NST 260 Electric Circuits Theory I and MAT 292 Calculus III for Science and completion of or concurrent enrollment in MAT 298 Differential Equations",
+    "courses": [
+      "MAT 292",
+      "MAT 298",
+      "NST 260"
+    ],
+    "source": "middlesex"
+  },
+  "EGT 109": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "EGT 112": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "ELE 110": {
     "text": "ELE 110L and ELE 110L and ELE 110L and ELE 110L",
@@ -3031,6 +5190,32 @@
       "ELE 240"
     ]
   },
+  "ELL 054": {
+    "text": "Placement by exam",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "ELL 055": {
+    "text": "Completion of ELL 054 with a C- or better or placement by exam",
+    "courses": [
+      "ELL 054"
+    ],
+    "source": "middlesex"
+  },
+  "ELL 074": {
+    "text": "Placement into ELL 054",
+    "courses": [
+      "ELL 054"
+    ],
+    "source": "middlesex"
+  },
+  "ELL 075": {
+    "text": "Placement by exam or successful completion of ELL 074",
+    "courses": [
+      "ELL 074"
+    ],
+    "source": "middlesex"
+  },
   "ELL 101": {
     "text": "ELL 101",
     "courses": [
@@ -3049,11 +5234,70 @@
       "ELL 102"
     ]
   },
+  "EMS 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "EMS 105": {
+    "text": "PMC majors only. Current EMT certification. ENG 090and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "EMS 202": {
+    "text": "Successful completion of EMS 105 or permission of instructor",
+    "courses": [
+      "EMS 105"
+    ],
+    "source": "gcc"
+  },
+  "EMS 203": {
+    "text": "Successful completion of EMS 202 or permission of instructor",
+    "courses": [
+      "EMS 202"
+    ],
+    "source": "gcc"
+  },
+  "EMS 204": {
+    "text": "Successful completion of EMS 203 or permission of instructor",
+    "courses": [
+      "EMS 203"
+    ],
+    "source": "gcc"
+  },
   "EMS 205": {
     "text": "BIO 108",
     "courses": [
       "BIO 108"
     ]
+  },
+  "EMS 210": {
+    "text": "Successful completion of EMS 204. Concurrent registration in EMS 211.",
+    "courses": [
+      "EMS 204",
+      "EMS 211"
+    ],
+    "source": "gcc"
+  },
+  "EMS 211": {
+    "text": "Successful completion of EMS 204. Concurrent registration in EMS 210",
+    "courses": [
+      "EMS 204",
+      "EMS 210"
+    ],
+    "source": "gcc"
+  },
+  "EMS 212": {
+    "text": "EMS 211",
+    "courses": [
+      "EMS 211"
+    ],
+    "source": "gcc"
   },
   "EMS 214": {
     "text": "EMS 208",
@@ -3099,6 +5343,11 @@
       "RDG 090"
     ]
   },
+  "ENG 092": {
+    "text": "Placement below 68 on the reading portion of the CPT or 245 on the reading portion of the Next Generation Accuplacer",
+    "courses": [],
+    "source": "middlesex"
+  },
   "ENG 095": {
     "text": "ENG 090 (min C) or ESL 099 (min C) or ELL 102 (min C)",
     "courses": [
@@ -3116,6 +5365,14 @@
       "ENG 099",
       "ENG 095"
     ]
+  },
+  "ENG 101D": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "ENG 101H": {
     "text": "ENG 095 (min C) or ENG 098 (min C) or ENG 101H (min C)",
@@ -3154,6 +5411,11 @@
     "courses": [
       "ENG 101"
     ]
+  },
+  "ENG 109": {
+    "text": "Placement into ENG 109 or completion of 092, with a B-, C+, C, or C-",
+    "courses": [],
+    "source": "middlesex"
   },
   "ENG 110": {
     "text": "ENG 101 (min C) or ENG 101H (min C)",
@@ -3201,6 +5463,13 @@
       "ENG 101"
     ]
   },
+  "ENG 119": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "ENG 120": {
     "text": "ENG 101 (min C) or ENG 101H (min C)",
     "courses": [
@@ -3208,11 +5477,124 @@
       "ENG 101H"
     ]
   },
+  "ENG 122": {
+    "text": "ENG 101 Recomm: Any Behavioral and Social Sciences General Education Electives or Natural or Physical Science General Education Elective.",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "ENG 125": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 130": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "ENG 131": {
     "text": "ENG 101",
     "courses": [
       "ENG 101"
     ]
+  },
+  "ENG 140": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 141": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 143": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 150": {
+    "text": "Eligibility for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 151": {
+    "text": "Completion of ENG 150",
+    "courses": [
+      "ENG 150"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 155": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 156": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 161": {
+    "text": "Eligible of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 180": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 185": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 190": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENG 195": {
+    "text": "ENG 101 and permission of the instructor.",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "ENG 200": {
+    "text": "Completion of ENG 102 and ENG 150",
+    "courses": [
+      "ENG 102",
+      "ENG 150"
+    ],
+    "source": "middlesex"
   },
   "ENG 203": {
     "text": "ELL 103 or ENG 095 or ENG 111",
@@ -3222,12 +5604,49 @@
       "ENG 111"
     ]
   },
+  "ENG 204": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
   "ENG 205": {
     "text": "ENG 102 (min C) or ENG 102H (min C)",
     "courses": [
       "ENG 102",
       "ENG 102H"
     ]
+  },
+  "ENG 206": {
+    "text": "ENG 112, ENG 114 or ENG 116",
+    "courses": [
+      "ENG 112",
+      "ENG 114",
+      "ENG 116"
+    ],
+    "source": "gcc"
+  },
+  "ENG 207": {
+    "text": "ENG 112, 114, or 116.",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 207H": {
+    "text": "ENG 112, 114, or 116.",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 210": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
   },
   "ENG 211": {
     "text": "ENG 102 (min D-) or ENG 102 (min D-) or ENG 102 (min T) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 104 (min T)",
@@ -3236,12 +5655,33 @@
       "ENG 104"
     ]
   },
+  "ENG 212": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
   "ENG 217": {
     "text": "ENG 102 (min D-) or ENG 102 (min D-) or ENG 102 (min T) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 104 (min T)",
     "courses": [
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "ENG 221": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 221H": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
   },
   "ENG 224": {
     "text": "ENG 102 (min D-) or ENG 102 (min D-) or ENG 102 (min T) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 104 (min T)",
@@ -3256,6 +5696,13 @@
       "ENG 102",
       "ENG 102H"
     ]
+  },
+  "ENG 228": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
   },
   "ENG 231": {
     "text": "ENG 102 (min D-) or ENG 102 (min D-) or ENG 102 (min T) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 104 (min T)",
@@ -3289,6 +5736,27 @@
       "ENG 104"
     ]
   },
+  "ENG 241H": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 243": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 244": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
   "ENG 246": {
     "text": "ENG 102 (min C)",
     "courses": [
@@ -3301,11 +5769,41 @@
       "ENG 215"
     ]
   },
+  "ENG 248": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
   "ENG 255": {
     "text": "ENG 215",
     "courses": [
       "ENG 215"
     ]
+  },
+  "ENG 256": {
+    "text": "ENG 112, ENG 114, or ENG 116",
+    "courses": [
+      "ENG 112",
+      "ENG 114",
+      "ENG 116"
+    ],
+    "source": "gcc"
+  },
+  "ENG 261": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "ENG 291": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of the Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "ENR 101": {
     "text": "MAT 194 (min C)",
@@ -3394,6 +5892,13 @@
       "ENV 101"
     ]
   },
+  "ENV 103": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "ENV 105": {
     "text": "MAT 093 or RDG 095 or ENG 095 or ELL 103",
     "courses": [
@@ -3402,6 +5907,14 @@
       "ENG 095",
       "ELL 103"
     ]
+  },
+  "ENV 108": {
+    "text": "Eligible for ENG 109; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 109",
+      "MAT 080"
+    ],
+    "source": "middlesex"
   },
   "ENV 110": {
     "text": "MAT 093 or RDG 095 or ENG 095 or ELL 103",
@@ -3447,6 +5960,34 @@
       "RDG 095",
       "ELL 103"
     ]
+  },
+  "ENV 122": {
+    "text": "Acceptance into the International Studies Fellowship Program for Belize (Spring application cycle) and all prerequisites contained therein. Priority is given to certified SCUBA divers, but seats for non-divers (snorkelers) are also available",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "ENV 131": {
+    "text": "Completion of ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ENV 141": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ENV 151": {
+    "text": "s Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
   },
   "ENV 165": {
     "text": "BIO 105 and ENV 165L",
@@ -3658,6 +6199,108 @@
       "EST 206"
     ]
   },
+  "ETH 101": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "ETH 102": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "ETH 103": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "ETH 105": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 101": {
+    "text": "Eligible for ENG 109; Completion of or concurrent enrollment in TMA 095 with a C or better, CAP 101, and EUT 111",
+    "courses": [
+      "CAP 101",
+      "ENG 109",
+      "EUT 111",
+      "TMA 095"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 111": {
+    "text": "Concurrent enrollment in EUT 101; concurrent enrollment in or completion of TMA 095 with a C or better and CAP 101",
+    "courses": [
+      "CAP 101",
+      "EUT 101",
+      "TMA 095"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 151": {
+    "text": "Completion of TMA 095 with a C or better; completion of CAP 101, EUT 101, and EUT 111",
+    "courses": [
+      "CAP 101",
+      "EUT 101",
+      "EUT 111",
+      "TMA 095"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 161": {
+    "text": "Completion of TMA 095 with a C or better; completion of CAP 101, EUT 101, and EUT 111",
+    "courses": [
+      "CAP 101",
+      "EUT 101",
+      "EUT 111",
+      "TMA 095"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 171": {
+    "text": "Completion of TMA 095 with C or better; completion of CAP 101, EUT 101, and EUT 111",
+    "courses": [
+      "CAP 101",
+      "EUT 101",
+      "EUT 111",
+      "TMA 095"
+    ],
+    "source": "middlesex"
+  },
+  "EUT 181": {
+    "text": "Concurrent enrollment in EUT 151, EUT 161 and EUT 171; and departmental permission",
+    "courses": [
+      "EUT 151",
+      "EUT 161",
+      "EUT 171"
+    ],
+    "source": "middlesex"
+  },
+  "EVS 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "EVS 118": {
+    "text": "ENG 090 and ENG 094 or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "FAS 120": {
     "text": "FAS 111",
     "courses": [
@@ -3689,6 +6332,13 @@
       "ECO 201",
       "FIN 106"
     ]
+  },
+  "FPS 101": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
   },
   "FPS 119": {
     "text": "ENG 095 (min C) or ESL 098 (min C) or ELL 103 (min C)",
@@ -3734,11 +6384,198 @@
       "ELL 103"
     ]
   },
+  "FPS 150": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 151": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80; and completion of FPS 100",
+    "courses": [
+      "FPS 100",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 152": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 153": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 160": {
+    "text": "Eligible for ENG 101; and completion of FPS 100",
+    "courses": [
+      "ENG 101",
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 200": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 201": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
+  "FPS 203": {
+    "text": "Completion of FPS 100",
+    "courses": [
+      "FPS 100"
+    ],
+    "source": "middlesex"
+  },
   "FRE 102": {
     "text": "FRE 101",
     "courses": [
       "FRE 101"
     ]
+  },
+  "FRE 201": {
+    "text": "FRE 102 or equivalent.",
+    "courses": [
+      "FRE 102"
+    ],
+    "source": "gcc"
+  },
+  "FRE 201H": {
+    "text": "FRE 102 or equivalent.",
+    "courses": [
+      "FRE 102"
+    ],
+    "source": "gcc"
+  },
+  "FRE 202": {
+    "text": "FRE 201 or equivalent.",
+    "courses": [
+      "FRE 201"
+    ],
+    "source": "gcc"
+  },
+  "FRE 202H": {
+    "text": "FRE 201 or equivalent.",
+    "courses": [
+      "FRE 201"
+    ],
+    "source": "gcc"
+  },
+  "FRE 255": {
+    "text": "FRE 202 or equivalent",
+    "courses": [
+      "FRE 202"
+    ],
+    "source": "gcc"
+  },
+  "FRE 256": {
+    "text": "FRE 202 or equivalent.",
+    "courses": [
+      "FRE 202"
+    ],
+    "source": "gcc"
+  },
+  "FRE 257": {
+    "text": "FRE 202 or equivalent",
+    "courses": [
+      "FRE 202"
+    ],
+    "source": "gcc"
+  },
+  "FST 151": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 152": {
+    "text": "ENG 090, ENG 094  or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 153": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 154": {
+    "text": "ENG 090, ENG 094 or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 155": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 157": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 158": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 159": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "FST 252": {
+    "text": "FST 151 and FST 155 or permission of instructor or program coordinator.",
+    "courses": [
+      "FST 151",
+      "FST 155"
+    ],
+    "source": "gcc"
+  },
+  "FST 253": {
+    "text": "FST 151 and FST 155 or permission of instructor or program coordinator.",
+    "courses": [
+      "FST 151",
+      "FST 155"
+    ],
+    "source": "gcc"
   },
   "GAT 125": {
     "text": "GAT 125L",
@@ -3879,6 +6716,37 @@
       "ELL 103"
     ]
   },
+  "GEO 102": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "GEO 104": {
+    "text": "ENG 090 or satisfactory placement.",
+    "courses": [
+      "ENG 090"
+    ],
+    "source": "gcc"
+  },
+  "GEO 109": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "GEO 205": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement; one lab science class coded BIO or GEO.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "GEY 121": {
     "text": "GEY 121L",
     "courses": [
@@ -3891,6 +6759,13 @@
       "GEY 121"
     ]
   },
+  "GGY 120": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "GIS 224": {
     "text": "MAT 181 (min C) or MAT 099 (min C)",
     "courses": [
@@ -3898,11 +6773,83 @@
       "MAT 099"
     ]
   },
+  "GOV 110": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "GOV 115": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "GOV 120": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "GWS 115": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "HIM 106": {
     "text": "AHS 129",
     "courses": [
       "AHS 129"
     ]
+  },
+  "HIM 107": {
+    "text": "Completion of MAS 101 and HIM 104",
+    "courses": [
+      "HIM 104",
+      "MAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "HIM 110": {
+    "text": "Completion of HIM 106 and HIM 107",
+    "courses": [
+      "HIM 106",
+      "HIM 107"
+    ],
+    "source": "middlesex"
+  },
+  "HIM 220": {
+    "text": "Completion of BUS 221, HIM 106, HIM 107, or admission into the PHIT program and Completion of PHO 103",
+    "courses": [
+      "BUS 221",
+      "HIM 106",
+      "HIM 107",
+      "PHO 103"
+    ],
+    "source": "middlesex"
+  },
+  "HIM 221": {
+    "text": "Completion of HIM 106, HIM 107, and PHO 102",
+    "courses": [
+      "HIM 106",
+      "HIM 107",
+      "PHO 102"
+    ],
+    "source": "middlesex"
+  },
+  "HIM 225": {
+    "text": "Completion of HIM 106 and HIM 107",
+    "courses": [
+      "HIM 106",
+      "HIM 107"
+    ],
+    "source": "middlesex"
   },
   "HIS 100": {
     "text": "ENG 095 (min C) or ENG 098 (min C)",
@@ -3927,6 +6874,14 @@
       "ELL 103"
     ]
   },
+  "HIS 102D": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "HIS 103": {
     "text": "ENG 095 or ESL 098 or RDG 095 or ELL 103",
     "courses": [
@@ -3942,6 +6897,22 @@
       "ENG 095",
       "ENG 098"
     ]
+  },
+  "HIS 105": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "HIS 106": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "HIS 108": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 095 (min T) or ENG 095 (min XC-) or ENG 101 (min D-) or ENG 101 (min D-) or ENG 101 (min T) or ENG 101 (min T) or ENG 104 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 102 (min T) or ENG 102 (min T) or ENG 102 (min D-) or ENG 102 (min D-)",
@@ -4008,6 +6979,36 @@
       "ENG 098"
     ]
   },
+  "HIS 127": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "HIS 131": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "HIS 133": {
+    "text": "ENG 101 or concurrent enrollment in ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "HIS 134": {
+    "text": "ENG 101 or concurrent enrollment in ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
   "HIS 151": {
     "text": "ENG 095 (min C) or ESL 098 (min C) or RDG 095 (min C) or ELL 103 (min C)",
     "courses": [
@@ -4025,6 +7026,52 @@
       "RDG 095",
       "ELL 103"
     ]
+  },
+  "HIS 218": {
+    "text": "ENG 101; Recomm: HIS 105, HIS 106, or HIS 131",
+    "courses": [
+      "ENG 101",
+      "HIS 105",
+      "HIS 106",
+      "HIS 131"
+    ],
+    "source": "gcc"
+  },
+  "HIS 219": {
+    "text": "ENG 101; and HIS 106.",
+    "courses": [
+      "ENG 101",
+      "HIS 106"
+    ],
+    "source": "gcc"
+  },
+  "HIS 219H": {
+    "text": "ENG 101; and HIS 106.Recomm: POL 101",
+    "courses": [
+      "ENG 101",
+      "HIS 106",
+      "POL 101"
+    ],
+    "source": "gcc"
+  },
+  "HIS 220": {
+    "text": "ENG 101; HIS 105 or HIS 106.Recomm: POL 101",
+    "courses": [
+      "ENG 101",
+      "HIS 105",
+      "HIS 106",
+      "POL 101"
+    ],
+    "source": "gcc"
+  },
+  "HIS 221": {
+    "text": "ENG 101; Recomm: HIS 105 or HIS 106",
+    "courses": [
+      "ENG 101",
+      "HIS 105",
+      "HIS 106"
+    ],
+    "source": "gcc"
   },
   "HIS 231": {
     "text": "ENG 111 (min C)",
@@ -4110,6 +7157,27 @@
       "HIT 130",
       "HIT 260"
     ]
+  },
+  "HON 201": {
+    "text": "ENG 101, permission of the Honors Program Coordinator .Recomm: College-level course in mathematics, the natural and physical sciences, or the social and behavioral sciences.",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "HON 202": {
+    "text": "ENG 101; Any 100-level Behavioral and Social Sciences general education elective",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "HON 203": {
+    "text": "ENG 101; Any 100-level Humanities and Fine Arts general education elective",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
   },
   "HON 204": {
     "text": "ENG 102 (min B+) or ENG 102 (min T)",
@@ -4202,6 +7270,76 @@
       "HSC 180L"
     ]
   },
+  "HST 121": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 122": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 124": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 130": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 131": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 132": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 139": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 290": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 291": {
+    "text": "Completion of ENG 101 with a B or better; completion of 12 college credits with a GPA of 3.2 or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HST 292": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "HSV 101": {
     "text": "ESL 098 (min C) or RDG 095 (min C) or ENG 095 (min C) or ELL 103 (min C)",
     "courses": [
@@ -4210,6 +7348,14 @@
       "ENG 095",
       "ELL 103"
     ]
+  },
+  "HSV 107": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "HSV 112": {
     "text": "PSY 101 (min C) or ESL 098 (min C) or RDG 095 (min C) or ENG 095 (min C) or ELL 103 (min C)",
@@ -4233,6 +7379,17 @@
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "HSV 115": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement; PSY 101 (or concurrent enrollment in PSY 101); and HSV 101 or HSV 107 (or concurrent enrollment in HSV 101 or HSV 107).",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "HSV 101",
+      "HSV 107",
+      "PSY 101"
+    ],
+    "source": "gcc"
   },
   "HSV 120": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
@@ -4286,6 +7443,27 @@
       "HSV 151"
     ]
   },
+  "HSV 168": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement; PSY 101 or concurrent enrollment in PSY 101; HSV 101 or HSV 107 or concurrent enrollment in HSV101 or HSV 107.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "HSV 101",
+      "HSV 107",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "HSV 172": {
+    "text": "HSV 115 or concurrent enrollment in HSV 115; HSV 107or concurrent enrollment in HSV 107; HSV 168 or concurrent enrollment in HSV 168, PSY 101 or concurrent enrollment in PSY 101; must be an Addiction Studies Certificate major or a Liberal Arts/Human Services Option major and have permission of the Human Services Program coordinator.",
+    "courses": [
+      "HSV 107",
+      "HSV 115",
+      "HSV 168",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
   "HSV 208": {
     "text": "PSY 110 (min D-) or PSY 110 (min D-) or PSY 110 (min T) or PSY 110 (min T) or SOC 110 (min D-) or SOC 110 (min D-) or SOC 110 (min T) or SOC 110 (min T) or HSV 120 (min D-) or HSV 120 (min D-) or HSV 120 (min T) or HSV 120 (min T)",
     "courses": [
@@ -4309,6 +7487,15 @@
       "HSV 208",
       "SOC 208"
     ]
+  },
+  "HSV 216": {
+    "text": "HSV 101 or POL 101 or BUS 111",
+    "courses": [
+      "BUS 111",
+      "HSV 101",
+      "POL 101"
+    ],
+    "source": "gcc"
   },
   "HSV 217": {
     "text": "HSV 101 and PSY 101 and PSY 215 and PSY 224",
@@ -4353,6 +7540,13 @@
       "HSV 227"
     ]
   },
+  "HSV 241": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
   "HSV 252": {
     "text": "HSV 262",
     "courses": [
@@ -4376,6 +7570,24 @@
     "courses": [
       "HSV 257"
     ]
+  },
+  "HSV 271": {
+    "text": "HSV 215 (or concurrent enrollment)",
+    "courses": [
+      "HSV 215"
+    ],
+    "source": "gcc"
+  },
+  "HSV 272": {
+    "text": "HSV 107, HSV 115, HSV 168, HSV 172 with a grade of Cor better, and HSV 215 or concurrent enrollment in HSV 215, must be an Addiction Studies Certificate major or a Liberal Arts Human Services Option major, and permission of the Human Services program coordinator.",
+    "courses": [
+      "HSV 107",
+      "HSV 115",
+      "HSV 168",
+      "HSV 172",
+      "HSV 215"
+    ],
+    "source": "gcc"
   },
   "HSV 288": {
     "text": "HSV 113 (min C) or HSV 113 (min C) or HSV 113 (min T) or HSV 113 (min T) and PSY 110 (min C) or PSY 110 (min C) or PSY 110 (min T) or PSY 110 (min T) and HSV 122 (min C) or HSV 122 (min C) or HSV 122 (min T) or HSV 122 (min T) and HSV 123 (min C) or HSV 123 (min C) or HSV 123 (min T) or HSV 123 (min T)",
@@ -4405,11 +7617,226 @@
       "HTH 102"
     ]
   },
+  "HUD 122": {
+    "text": "Must be currently enrolled in GCC, must have completed one academic semester at GCC, and must be appointed in the manner required by the GCC Assembly Bylaws.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "HUD 129": {
+    "text": "Open to Dual Enrollment Students only.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "HUD 135": {
+    "text": "ENG 090, ENG 094 or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "HUD 138": {
+    "text": "HUD 137 or MAT 090 or satisfactory placement or concurrent enrollment in MAT 003; Placement tests are used only for initial course placement; see catalog for details. Recomm: Consultation with an advisor to determine appropriate math placement.",
+    "courses": [
+      "HUD 137",
+      "MAT 003",
+      "MAT 090"
+    ],
+    "source": "gcc"
+  },
+  "HUM 102": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 104": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 108": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement, or concurrent enrollment",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "HUM 120": {
+    "text": "Students must have completed 12 credits in a degree program at MCC before participating in the course",
+    "courses": [],
+    "source": "middlesex"
+  },
   "HUM 121": {
     "text": "ENG 101",
     "courses": [
       "ENG 101"
     ]
+  },
+  "HUM 123": {
+    "text": "Students must complete 12 credits at MCC in order to apply for this fellowship program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 126": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 129": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 131": {
+    "text": "Students must complete 12 credits at MCC in order to apply for this fellowship program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 133": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 134": {
+    "text": "Completion of 12 credits in a degree program at MCC with a GPA of at least 2.5. Travel course participants must be at least 18 years old by the time of travel",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "HUM 135": {
+    "text": "Completion of ENG 101; and completion of PSY 101 or SOC 101",
+    "courses": [
+      "ENG 101",
+      "PSY 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 143": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 290": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 291": {
+    "text": "Completion of ENG 101 with a B or better; completion of 12 college credits with a GPA of 3.2 or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 292": {
+    "text": "Completion of ENG 101 with a B or better; completion of 12 college credits with a GPA of 3.2 or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUM 299": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUS 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUS 152": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "HUS 153": {
+    "text": "Completion of HUS 200 or HUS 201",
+    "courses": [
+      "HUS 200",
+      "HUS 201"
+    ],
+    "source": "middlesex"
+  },
+  "HUS 154": {
+    "text": "Completion of HUS 153",
+    "courses": [
+      "HUS 153"
+    ],
+    "source": "middlesex"
+  },
+  "HUS 201": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "IDS 104": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "IDS 105": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "IDS 109": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "IDS 116": {
+    "text": "IDS 103 or equivalent experience",
+    "courses": [
+      "IDS 103"
+    ],
+    "source": "middlesex"
+  },
+  "IDS 152": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "IDS 154": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "IDS 155": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "IDS 216": {
+    "text": "IDS 116",
+    "courses": [
+      "IDS 116"
+    ],
+    "source": "middlesex"
   },
   "INT 101": {
     "text": "ESL 098 (min C) or RDG 095 (min C) or ENG 095 (min C) or ELL 103 (min C)",
@@ -4428,6 +7855,85 @@
       "ELL 103"
     ]
   },
+  "ITC 101": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 111": {
+    "text": "Eligible for ENG 101; completion of ITC 101; placement above or completion of MAT080 or completion of Math Module 12, 73, or 82",
+    "courses": [
+      "ENG 101",
+      "ITC 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 201": {
+    "text": "Completion of NST 121, NST 231, and either ITC 281 or CSC 188",
+    "courses": [
+      "CSC 188",
+      "ITC 281",
+      "NST 121",
+      "NST 231"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 221": {
+    "text": "Completion of ITC 111 and ITC 281",
+    "courses": [
+      "ITC 111",
+      "ITC 281"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 240": {
+    "text": "Completion of ITC 111, ITC 282, and (ETH 101 or ETH 102 or ETH 103)",
+    "courses": [
+      "ETH 101",
+      "ETH 102",
+      "ETH 103",
+      "ITC 111",
+      "ITC 282"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 250": {
+    "text": "Completion of ITC 201. Completion of or concurrent enrollment in ITC 240 and either ITC 211 or ITC 221",
+    "courses": [
+      "ITC 201",
+      "ITC 211",
+      "ITC 221",
+      "ITC 240"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 281": {
+    "text": "Completion of NST 181",
+    "courses": [
+      "NST 181"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 282": {
+    "text": "Completion of ITC 281",
+    "courses": [
+      "ITC 281"
+    ],
+    "source": "middlesex"
+  },
+  "ITC 290": {
+    "text": "Completion of ITC 101, ITC 281, and NST 231. Department approval of a secured, approved internship position prior to enrollment",
+    "courses": [
+      "ITC 101",
+      "ITC 281",
+      "NST 231"
+    ],
+    "source": "middlesex"
+  },
   "ITL 102": {
     "text": "ITL 101",
     "courses": [
@@ -4439,6 +7945,83 @@
     "courses": [
       "JPN 101"
     ]
+  },
+  "JUS 101": {
+    "text": "ENG101 or concurrent enrollment in ENG101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "JUS 103": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 105": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 107": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 109": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 121": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 131": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "JUS 201": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ],
+    "source": "gcc"
+  },
+  "JUS 205": {
+    "text": "JUS 105, JUS 107",
+    "courses": [
+      "JUS 105",
+      "JUS 107"
+    ],
+    "source": "gcc"
+  },
+  "JUS 210": {
+    "text": "JUS 109 or permission of instructor",
+    "courses": [
+      "JUS 109"
+    ],
+    "source": "gcc"
   },
   "LAN 100": {
     "text": "LAN 100L",
@@ -4452,6 +8035,27 @@
       "LAN 100"
     ]
   },
+  "LAN 102": {
+    "text": "Completion of LAN 101 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 101"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 106": {
+    "text": "Completion of LAN 103 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 103"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 108": {
+    "text": "Completion of LAN 107 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 107"
+    ],
+    "source": "middlesex"
+  },
   "LAN 110": {
     "text": "LAN 110L",
     "courses": [
@@ -4464,6 +8068,90 @@
       "LAN 110"
     ]
   },
+  "LAN 112": {
+    "text": "Completion of LAN 111 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 111"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 122": {
+    "text": "Completion of LAN 121 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 121"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 132": {
+    "text": "Completion of LAN 131 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 131"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 142": {
+    "text": "Completion of LAN 141 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 141"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 146": {
+    "text": "Completion of LAN 145 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 145"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 152": {
+    "text": "Completion of LAN 151 with a C- or better, placement by exam, or one year of high school Spanish in the prior year",
+    "courses": [
+      "LAN 151"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 172": {
+    "text": "Completion of LAN 171 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 171"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 176": {
+    "text": "Completion of LAN 175 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 175"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 182": {
+    "text": "Completion of LAN 181 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 181"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 184": {
+    "text": "Completion of LAN 183 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 183"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 186": {
+    "text": "Completion of LAN 185 or placement by exam",
+    "courses": [
+      "LAN 185"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 192": {
+    "text": "Completion of LAN 191 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 191"
+    ],
+    "source": "middlesex"
+  },
   "LAN 200": {
     "text": "LAN 200L",
     "courses": [
@@ -4475,6 +8163,104 @@
     "courses": [
       "LAN 200"
     ]
+  },
+  "LAN 201": {
+    "text": "Completion of LAN 102 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 102"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 202": {
+    "text": "Completion of LAN 201 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 201"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 203": {
+    "text": "Completion of LAN 192 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 192"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 204": {
+    "text": "Completion of LAN 203 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 203"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 205": {
+    "text": "Completion of LAN 106 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 106"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 206": {
+    "text": "Completion of LAN 205 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 205"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 207": {
+    "text": "Completion of LAN 108 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 108"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 208": {
+    "text": "Completion of LAN 207 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 207"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 211": {
+    "text": "Completion of LAN 112 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 112"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 212": {
+    "text": "Completion of LAN 211 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 211"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 213": {
+    "text": "Completion of LAN 184 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 184"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 214": {
+    "text": "Completion of LAN 213 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 213"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 217": {
+    "text": "Completion of LAN 172 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 172"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 218": {
+    "text": "Completion of LAN 217 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 217"
+    ],
+    "source": "middlesex"
   },
   "LAN 220": {
     "text": "LAN 115 and LAN 220L",
@@ -4489,6 +8275,62 @@
       "LAN 220"
     ]
   },
+  "LAN 221": {
+    "text": "Completion of LAN 122 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 122"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 222": {
+    "text": "Completion of LAN 221 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 221"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 223": {
+    "text": "Completion of LAN 176 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 176"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 224": {
+    "text": "Completion of LAN 142 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 142"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 225": {
+    "text": "Completion of LAN 224 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 224"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 226": {
+    "text": "Completion of LAN 223 with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 223"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 232": {
+    "text": "Completion of LAN 132 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 132"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 233": {
+    "text": "Completion of LAN 232 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 232"
+    ],
+    "source": "middlesex"
+  },
   "LAN 235": {
     "text": "LAN 115 and LAN 235L",
     "courses": [
@@ -4502,11 +8344,60 @@
       "LAN 235"
     ]
   },
+  "LAN 251": {
+    "text": "Completion of LAN 152 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 152"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 252": {
+    "text": "Completion of LAN 251 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 251"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 281": {
+    "text": "Completion of LAN 182 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 182"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 282": {
+    "text": "Completion of LAN 281 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 281"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 285": {
+    "text": "Completion of LAN 186 with a C- or better or placement by exam",
+    "courses": [
+      "LAN 186"
+    ],
+    "source": "middlesex"
+  },
+  "LAN 286": {
+    "text": "LAN 285 Latin 3 and Roman Culture with a grade of C- or better or placement by exam",
+    "courses": [
+      "LAN 285"
+    ],
+    "source": "middlesex"
+  },
   "LAR 285": {
     "text": "LAR 101",
     "courses": [
       "LAR 101"
     ]
+  },
+  "LAT 102": {
+    "text": "LAT 101 or equivalent",
+    "courses": [
+      "LAT 101"
+    ],
+    "source": "gcc"
   },
   "LAW 214": {
     "text": "ENG 101",
@@ -4572,6 +8463,28 @@
     "courses": [
       "LEO 260"
     ]
+  },
+  "LGL 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "LGL 102": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "LGL 153": {
+    "text": "Completion of ENG101 or concurrent enrollment or completion of SOC101",
+    "courses": [
+      "ENG 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
   },
   "LIT 201": {
     "text": "ENG 111 (min C)",
@@ -4707,6 +8620,93 @@
       "LPN 142"
     ]
   },
+  "MAC 101": {
+    "text": "ENG 090, ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MAC 103": {
+    "text": "NoneRecomm: CIS140; ENG 101.",
+    "courses": [
+      "CIS 140",
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "MAC 105": {
+    "text": "MAC 112 or BIO 194 or BIO 216 (BIO 196) with a Cor better, within the last 5 years or concurrent enrollment in MAC 112 or BIO 194 or BIO 216.Recomm: CIS 140; ENG 101.",
+    "courses": [
+      "BIO 194",
+      "BIO 196",
+      "BIO 216",
+      "CIS 140",
+      "ENG 101",
+      "MAC 112"
+    ],
+    "source": "gcc"
+  },
+  "MAC 111": {
+    "text": "BIO 194 with a C or better within the last5 years; BIO 216 with a C or better within the last5 years; MAC 112 with a C or better.",
+    "courses": [
+      "BIO 194",
+      "BIO 216",
+      "MAC 112"
+    ],
+    "source": "gcc"
+  },
+  "MAC 112": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MAC 113": {
+    "text": "ENG 090 and ENG 094 or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MAC 115": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MAC 120": {
+    "text": "MOM 110 or concurrent enrollment in MOM 110 or permission of Instructor.",
+    "courses": [
+      "MOM 110"
+    ],
+    "source": "gcc"
+  },
+  "MAC 271": {
+    "text": "MAC 101, MAC 103, MAC 105, MAC 111, MAC 113, MAC 114, MAC 120; and MOM 110 or concurrent enrollment in MOM 110; and one of the following with a C or better within the last 5 years: MAC 112 or BIO 194 or BIO 215 & BIO 216 (BIO 196); and permission of Program Director.",
+    "courses": [
+      "BIO 194",
+      "BIO 196",
+      "BIO 215",
+      "BIO 216",
+      "MAC 101",
+      "MAC 103",
+      "MAC 105",
+      "MAC 111",
+      "MAC 112",
+      "MAC 113",
+      "MAC 114",
+      "MAC 120",
+      "MOM 110"
+    ],
+    "source": "gcc"
+  },
   "MAN 105": {
     "text": "ENG 090 or ESL 099 or ESL 098 or RDG 095 or ELL 103 and MAN 111",
     "courses": [
@@ -4748,6 +8748,84 @@
       "ENG 090",
       "ELL 103"
     ]
+  },
+  "MAS 101": {
+    "text": "Eligibility for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "MAS 106": {
+    "text": "Admission to the Medical Assisting program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "MAS 122": {
+    "text": "MAS 103 with a C or better",
+    "courses": [
+      "MAS 103"
+    ],
+    "source": "middlesex"
+  },
+  "MAS 150": {
+    "text": "Completion of MAS 106, MAS 107, and MAS 122, all with a C or better",
+    "courses": [
+      "MAS 106",
+      "MAS 107",
+      "MAS 122"
+    ],
+    "source": "middlesex"
+  },
+  "MAS 151": {
+    "text": "Completion of MAS 106, MAS 107, and MAS 122, all with a C or better",
+    "courses": [
+      "MAS 106",
+      "MAS 107",
+      "MAS 122"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 002": {
+    "text": "Completion of MAT 001",
+    "courses": [
+      "MAT 001"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 003": {
+    "text": "Completion of MAT 002",
+    "courses": [
+      "MAT 002"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 004": {
+    "text": "Completion of MAT 003",
+    "courses": [
+      "MAT 003"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 006": {
+    "text": "Eligible for ENG 101 and also have a HS GPA of 2.0 - 2.5",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 007": {
+    "text": "CPT Reading placement test score of 68 or above and placement into MAT 001 ( Mod 8 = 999-eligible for Module 70 or 80 ) or MAT 080",
+    "courses": [
+      "MAT 001",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 008": {
+    "text": "Placement into module 80",
+    "courses": [],
+    "source": "middlesex"
   },
   "MAT 018": {
     "text": "MAT 011",
@@ -4805,6 +8883,24 @@
       "MAT 028C"
     ]
   },
+  "MAT 107H": {
+    "text": "MAT 096 or MAT 120 or satisfactory placement or concurrent enrollment in MAT 003;Placement tests are used only for initial course placement; see catalog for details.Recomm: Consultation with an advisor to determine appropriate math placement.",
+    "courses": [
+      "MAT 003",
+      "MAT 096",
+      "MAT 120"
+    ],
+    "source": "gcc"
+  },
+  "MAT 108": {
+    "text": "A grade of C- or better in MAT 107 or satisfactory placement, ENG 090 and ENG 094, or satisfactory placement. Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
   "MAT 113": {
     "text": "MAT 018 or MAT 018C or MAT 045",
     "courses": [
@@ -4813,6 +8909,24 @@
       "MAT 045"
     ]
   },
+  "MAT 114": {
+    "text": "C- or higher in HUD 138 or MAT 095, or satisfactory placement into MAT 114; or satisfactory placement into HUD 138 and concurrent enrollment in MAT 003; Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "HUD 138",
+      "MAT 003",
+      "MAT 095"
+    ],
+    "source": "gcc"
+  },
+  "MAT 114H": {
+    "text": "HUD 138 or MAT 095 or satisfactory placement concurrent enrollment in MAT 003. Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "HUD 138",
+      "MAT 003",
+      "MAT 095"
+    ],
+    "source": "gcc"
+  },
   "MAT 115": {
     "text": "MAT 061 (min C) or MAT 078 (min C)",
     "courses": [
@@ -4820,12 +8934,30 @@
       "MAT 078"
     ]
   },
+  "MAT 116": {
+    "text": "C- or higher in HUD 138 or in MAT 095; or satisfactory placement into MAT 116; or satisfactory placement into HUD 138 and concurrent enrollment in MAT 003; must be an Early Childhood Education or Liberal Arts/Education Option major or have permission from a full-time math or education faculty person.  Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "HUD 138",
+      "MAT 003",
+      "MAT 095"
+    ],
+    "source": "gcc"
+  },
   "MAT 117": {
     "text": "MAT 063 or MAT 097",
     "courses": [
       "MAT 063",
       "MAT 097"
     ]
+  },
+  "MAT 120": {
+    "text": "C- or higher in HUD 138 or in MAT 095, or satisfactory placement into MAT 120; or satisfactory placement into HUD 138 and concurrent enrollment in MAT 003. Placement tests are used only for initial course placement; see catalog for details. Recomm: Consultation with an advisor to determine appropriate placement.",
+    "courses": [
+      "HUD 138",
+      "MAT 003",
+      "MAT 095"
+    ],
+    "source": "gcc"
   },
   "MAT 121": {
     "text": "MAT 102 or MAT 102C",
@@ -4906,6 +9038,13 @@
       "MAT 121"
     ]
   },
+  "MAT 165": {
+    "text": "Completion of MAT 195 with a C or better",
+    "courses": [
+      "MAT 195"
+    ],
+    "source": "middlesex"
+  },
   "MAT 171": {
     "text": "MAT 097 (min C) or MAT 098 (min C) or MAT 100 (min C) or MAT 133 (min C)",
     "courses": [
@@ -4932,6 +9071,14 @@
       "MAT 133"
     ]
   },
+  "MAT 177": {
+    "text": "Eligible for ENG 101; placement above or completion of MAT 080 with a C or better or completion of Math Module 12, 73, or 82",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
   "MAT 181": {
     "text": "MAT 097 (min C) or MAT 100 (min C) or MAT 133 (min C)",
     "courses": [
@@ -4939,6 +9086,14 @@
       "MAT 100",
       "MAT 133"
     ]
+  },
+  "MAT 182": {
+    "text": "Completion of MAT 100 or MAT 008 with a C or better, or completion of Math Module 85, or by placement into the class",
+    "courses": [
+      "MAT 008",
+      "MAT 100"
+    ],
+    "source": "middlesex"
   },
   "MAT 193": {
     "text": "MAT 097 (min C) or MAT 100 (min C) or MAT 133 (min C)",
@@ -4954,11 +9109,108 @@
       "MAT 099"
     ]
   },
+  "MAT 195": {
+    "text": "Completion of MAT 100 or MAT 008 with a C or better, or completion of Math Module 85, or by placement",
+    "courses": [
+      "MAT 008",
+      "MAT 100"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 196": {
+    "text": "Completion of MAT 100 or Math Module 85 with a course grade of B+ or better, or placement into MAT 195 or higher",
+    "courses": [
+      "MAT 100",
+      "MAT 195"
+    ],
+    "source": "middlesex"
+  },
   "MAT 197": {
     "text": "MAT 194 (min C)",
     "courses": [
       "MAT 194"
     ]
+  },
+  "MAT 201": {
+    "text": "A grade of C- or better in MAT 108 or satisfactory placement; ENG 090 and ENG 094, or satisfactory placement. Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 108"
+    ],
+    "source": "gcc"
+  },
+  "MAT 202": {
+    "text": "A grade of C- or better in MAT 201; ENG 090 or ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 201"
+    ],
+    "source": "gcc"
+  },
+  "MAT 202H": {
+    "text": "A grade of C- or better in MAT 201; ENG 090 or ENG094 (COL 090), or satisfactory placement test scores.",
+    "courses": [
+      "COL 090",
+      "ENG 090",
+      "ENG 094",
+      "MAT 201"
+    ],
+    "source": "gcc"
+  },
+  "MAT 203": {
+    "text": "A grade of C- or better in MAT 202; ENG 090 and ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "MAT 204": {
+    "text": "A grade of C- or better in MAT 203; ENG 090 and ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 203"
+    ],
+    "source": "gcc"
+  },
+  "MAT 204H": {
+    "text": "A grade of C- or better in MAT 203; ENG 090 and ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 203"
+    ],
+    "source": "gcc"
+  },
+  "MAT 205": {
+    "text": "A grade of C- or better in MAT 202; ENG 090 and ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "MAT 205H": {
+    "text": "A grade of C- or better in MAT 202; ENG 090 and ENG094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 202"
+    ],
+    "source": "gcc"
+  },
+  "MAT 206": {
+    "text": "MAT 201 and MAT 202 (or concurrent enrollment in MAT202)",
+    "courses": [
+      "MAT 201",
+      "MAT 202"
+    ],
+    "source": "gcc"
   },
   "MAT 231": {
     "text": "MAT 194 (min C)",
@@ -4972,6 +9224,15 @@
       "MAT 132"
     ]
   },
+  "MAT 250": {
+    "text": "Placement above or completion of MAT 190, MAT 195, or MAT 196 with C or better",
+    "courses": [
+      "MAT 190",
+      "MAT 195",
+      "MAT 196"
+    ],
+    "source": "middlesex"
+  },
   "MAT 251": {
     "text": "MAT 152 or MAT 152",
     "courses": [
@@ -4983,6 +9244,15 @@
     "courses": [
       "MAT 152"
     ]
+  },
+  "MAT 280": {
+    "text": "Placement above or completion of MAT 182, MAT195 or MAT196 with a C or better",
+    "courses": [
+      "MAT 182",
+      "MAT 195",
+      "MAT 196"
+    ],
+    "source": "middlesex"
   },
   "MAT 281": {
     "text": "MAT 197 (min C)",
@@ -5008,11 +9278,55 @@
       "MAT 282"
     ]
   },
+  "MAT 290": {
+    "text": "Placement above or completion of MAT195 and MAT165, or MAT196 or equivalent with a grade of C or better",
+    "courses": [
+      "MAT 165",
+      "MAT 195",
+      "MAT 196"
+    ],
+    "source": "middlesex"
+  },
   "MAT 291": {
     "text": "MAT 281 (min C)",
     "courses": [
       "MAT 281"
     ]
+  },
+  "MAT 292": {
+    "text": "Completion of MAT 291 with a C or better",
+    "courses": [
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 295": {
+    "text": "Completion of MAT 291 with a C or better",
+    "courses": [
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 296": {
+    "text": "Completion of MAT 295 with a C or better",
+    "courses": [
+      "MAT 295"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 297": {
+    "text": "Completion of MAT 291 with a C or better",
+    "courses": [
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "MAT 298": {
+    "text": "Completion of MAT 291 with a C or better",
+    "courses": [
+      "MAT 291"
+    ],
+    "source": "middlesex"
   },
   "MBW 120": {
     "text": "MBW 110 and MBW 120L",
@@ -5404,6 +9718,81 @@
       "MLT 112"
     ]
   },
+  "MLT 151": {
+    "text": "Completion of MLT 105 (CLS 101) and MLT 106 (CLS 102), both with a C or better",
+    "courses": [
+      "CLS 101",
+      "CLS 102",
+      "MLT 105",
+      "MLT 106"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 152": {
+    "text": "Completion of MLT 151 (MLT 101) with a C or better",
+    "courses": [
+      "MLT 101",
+      "MLT 151"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 153": {
+    "text": "Completion of MLT 105 (CLS 101) and MLT 106 (CLS 102), both with a C or better",
+    "courses": [
+      "CLS 101",
+      "CLS 102",
+      "MLT 105",
+      "MLT 106"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 154": {
+    "text": "Completion of MLT 151 (MLT 101) with a C or better",
+    "courses": [
+      "MLT 101",
+      "MLT 151"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 201": {
+    "text": "Completion of MLT 152 (MLT 102), MLT 153 (MLT 204), BIO 232, and CHE 132, all with a C or better",
+    "courses": [
+      "BIO 232",
+      "CHE 132",
+      "MLT 102",
+      "MLT 152",
+      "MLT 153",
+      "MLT 204"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 202": {
+    "text": "Completion of MLT 152, MLT 153, BIO 232, and CHE 132, all with a C or better",
+    "courses": [
+      "BIO 232",
+      "CHE 132",
+      "MLT 152",
+      "MLT 153"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 203": {
+    "text": "Completion of MLT 152, MLT 153, BIO 232, and CHE 132, all with a C or better",
+    "courses": [
+      "BIO 232",
+      "CHE 132",
+      "MLT 152",
+      "MLT 153"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 205": {
+    "text": "Completion of MLT 202 with a C or better",
+    "courses": [
+      "MLT 202"
+    ],
+    "source": "middlesex"
+  },
   "MLT 212": {
     "text": "MLT 118 and MLT 120 and MLT 124 and MLT 126 and MLT 212L and MLT 212L and MLT 212L",
     "courses": [
@@ -5470,6 +9859,58 @@
       "MLT 241",
       "MLT 242"
     ]
+  },
+  "MLT 252": {
+    "text": "Completion of MLT 201 with a C or better",
+    "courses": [
+      "MLT 201"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 253": {
+    "text": "Completion of MLT 203 with a C or better",
+    "courses": [
+      "MLT 203"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 254": {
+    "text": "Completion of MLT 201, MLT 202, and MLT 203, all with a C or better",
+    "courses": [
+      "MLT 201",
+      "MLT 202",
+      "MLT 203"
+    ],
+    "source": "middlesex"
+  },
+  "MLT 255": {
+    "text": "Completion of MLT 251 with a C or better",
+    "courses": [
+      "MLT 251"
+    ],
+    "source": "middlesex"
+  },
+  "MOM 110": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MOM 121": {
+    "text": "MOM 110 or Concurrent enrollment in MOM 110",
+    "courses": [
+      "MOM 110"
+    ],
+    "source": "gcc"
+  },
+  "MOM 122": {
+    "text": "MOM 110 or Concurrent enrollment in MOM 110",
+    "courses": [
+      "MOM 110"
+    ],
+    "source": "gcc"
   },
   "MTH 012": {
     "text": "MTH 011 (min XC-) or MTH 011 (min T) or MTH 075 (min XC-) or MTH 075 (min T)",
@@ -5646,6 +10087,14 @@
       "MUS 121"
     ]
   },
+  "MUS 127": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "MUS 128": {
     "text": "MUS 127 (min D-) or MUS 127 (min T)",
     "courses": [
@@ -5675,6 +10124,11 @@
       "RDG 090",
       "ELL 101"
     ]
+  },
+  "MUS 139": {
+    "text": "Permission of instructor or Program Coordinator; basic instrumental or vocal proficiency; the ability to read and play chord changes",
+    "courses": [],
+    "source": "gcc"
   },
   "MUS 141": {
     "text": "ESL 088 (min C) or ESL 089 (min C) or RDG 090 (min C) or ENG 090 (min C) or ELL 101 (min C)",
@@ -5714,11 +10168,33 @@
       "MUS 100"
     ]
   },
+  "MUS 153": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "MUS 154": {
+    "text": "ENG 094, or satisfactory placement, or concurrent enrollment in ENG 094",
+    "courses": [
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "MUS 158": {
     "text": "MUS 232",
     "courses": [
       "MUS 232"
     ]
+  },
+  "MUS 160": {
+    "text": "Completion of MUS 110; or permission of course instructor",
+    "courses": [
+      "MUS 110"
+    ],
+    "source": "middlesex"
   },
   "MUS 162": {
     "text": "MUS 161 (min D-) or MUS 161 (min T)",
@@ -5726,11 +10202,46 @@
       "MUS 161"
     ]
   },
+  "MUS 170": {
+    "text": "Completion of MUS 120; or permission of course instructor",
+    "courses": [
+      "MUS 120"
+    ],
+    "source": "middlesex"
+  },
   "MUS 172": {
     "text": "MUS 171 (min D-) or MUS 171 (min T)",
     "courses": [
       "MUS 171"
     ]
+  },
+  "MUS 180": {
+    "text": "Completion of MUS 130",
+    "courses": [
+      "MUS 130"
+    ],
+    "source": "middlesex"
+  },
+  "MUS 181": {
+    "text": "Completion of MUS 131",
+    "courses": [
+      "MUS 131"
+    ],
+    "source": "middlesex"
+  },
+  "MUS 182": {
+    "text": "Completion of MUS 132",
+    "courses": [
+      "MUS 132"
+    ],
+    "source": "middlesex"
+  },
+  "MUS 184": {
+    "text": "Completion of MUS 134",
+    "courses": [
+      "MUS 134"
+    ],
+    "source": "middlesex"
   },
   "MUS 192": {
     "text": "MUS 191 (min D-) or MUS 191 (min T)",
@@ -5774,6 +10285,21 @@
       "MUS 213"
     ]
   },
+  "MUS 220": {
+    "text": "MUS 103 or permission of instructor or Program Coordinator; basic proficiency in chordal accompaniment on guitar or piano",
+    "courses": [
+      "MUS 103"
+    ],
+    "source": "gcc"
+  },
+  "MUS 222": {
+    "text": "MUS 154 (MUS 221).",
+    "courses": [
+      "MUS 154",
+      "MUS 221"
+    ],
+    "source": "gcc"
+  },
   "MUS 223": {
     "text": "MUS 122 (min D-) or MUS 122 (min T)",
     "courses": [
@@ -5797,6 +10323,13 @@
     "courses": [
       "MUS 229"
     ]
+  },
+  "MUS 231": {
+    "text": "Non-music majors need permission of Music Program Coordinator; concurrent enrollment in MUS 230 for music majors",
+    "courses": [
+      "MUS 230"
+    ],
+    "source": "gcc"
   },
   "MUS 233": {
     "text": "MUS 103 (min C) or ENG 111 (min C)",
@@ -5861,6 +10394,15 @@
       "MUS 273"
     ]
   },
+  "MUS 280": {
+    "text": "MUS 130, MUS 180 and MUS 230",
+    "courses": [
+      "MUS 130",
+      "MUS 180",
+      "MUS 230"
+    ],
+    "source": "middlesex"
+  },
   "MUS 293": {
     "text": "MUS 192 (min D-) or MUS 192 (min T)",
     "courses": [
@@ -5872,6 +10414,34 @@
     "courses": [
       "MUS 293"
     ]
+  },
+  "NST 121": {
+    "text": "Completion of or concurrent enrollment in ITC 101",
+    "courses": [
+      "ITC 101"
+    ],
+    "source": "middlesex"
+  },
+  "NST 181": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "NST 231": {
+    "text": "Completion of NST 181",
+    "courses": [
+      "NST 181"
+    ],
+    "source": "middlesex"
+  },
+  "NST 235": {
+    "text": "Completion of NST 231",
+    "courses": [
+      "NST 231"
+    ],
+    "source": "middlesex"
   },
   "NTR 101": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
@@ -5928,6 +10498,158 @@
       "NUR 102"
     ]
   },
+  "NUR 103A": {
+    "text": "ENG 101 with a C or better.  HUD 138 or MAT 095 equivalent or a higher level math course with a C+ grade or better within the last seven (7) years of program start date.  Concurrent enrollment in either BIO 194 or BIO 216 or a C or better in BIO 194 taken within the last seven (7) years; or a C or better in BIO 215 and BIO 216 within the last seven (7) years.  Concurrent enrollment in PSY 101 or a C or better in PSY 101 within the last seven (7) years.  This course is limited to Practical Nursing majors only.",
+    "courses": [
+      "BIO 194",
+      "BIO 215",
+      "BIO 216",
+      "ENG 101",
+      "HUD 138",
+      "MAT 095",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 104": {
+    "text": "Concurrent enrollment in or completion of BIO 120 and PSY 101",
+    "courses": [
+      "BIO 120",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 105": {
+    "text": "NUR 103A (NUR 103) with a grade of C or better and successful completion of NUR 103C, BIO 194 OR BIO 215/BIO 216 with a C or better within the last seven (7) years,; PSY 101 with a C or better within the last seven (7) years",
+    "courses": [
+      "BIO 194",
+      "BIO 215",
+      "BIO 216",
+      "NUR 103",
+      "NUR 103A",
+      "NUR 103C",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 105C": {
+    "text": "NUR 103A with a grade of C or better and successful completion of NUR 103C; BIO 194 or BIO 215 and BIO 216 with a C or better within the last seven (7) years; PSY 101 with a C or better within the last seven (7) years. This course is limited to Practical Nursing majors only.Recomm: PSY 217 with a C or better",
+    "courses": [
+      "BIO 194",
+      "BIO 215",
+      "BIO 216",
+      "NUR 103A",
+      "NUR 103C",
+      "PSY 101",
+      "PSY 217"
+    ],
+    "source": "gcc"
+  },
+  "NUR 106A": {
+    "text": "Either components of NUR 101, namely, NUR 101A (with a grade of C+ or better) and NUR 101C, or the single course NUR 111, or concurrent enrollment in NUR 111; Either a grade of C+ or better in BIO 216 within the last 5 years or concurrent enrollment in BIO 216; Either a grade of C or better in SOC 101 or concurrent enrollment in SOC 101;Either a grade of C or better in PSY 217 or concurrent enrollment in PSY 217. This course is limited to AD Nursing majors only.",
+    "courses": [
+      "BIO 216",
+      "NUR 101",
+      "NUR 101A",
+      "NUR 101C",
+      "NUR 111",
+      "PSY 217",
+      "SOC 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 106C": {
+    "text": "Either both components of NUR 101, namely, NUR 101A(with a grade of C+ or better) and NUR 101C, or the singlecourse NUR 111, or concurrent enrollment in NUR 111; Eithera grade of C+ or better in BIO 216 within the last 5 yearsor concurrent enrollment in BIO 216; Either a grade of C orbetter in SOC 101 or concurrent enrollment in SOC 101;Either a grade of C or better in PSY 217 or concurrentenrollment in PSY 217. Concurrent enrollment in NUR 106A.This course is limited to AD Nursing majors only.Recomm: Concurrent enrollment in NUR 108A and NUR 108C",
+    "courses": [
+      "BIO 216",
+      "NUR 101",
+      "NUR 101A",
+      "NUR 101C",
+      "NUR 106A",
+      "NUR 108A",
+      "NUR 108C",
+      "NUR 111",
+      "PSY 217",
+      "SOC 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 107A": {
+    "text": "Successful completion of NUR 105C.  Concurrent enrollment in PSY 217 or PSY 217 with a C or better within the last seven (7) years.  This course is limited to Practical Nursing majors only.",
+    "courses": [
+      "NUR 105C",
+      "PSY 217"
+    ],
+    "source": "gcc"
+  },
+  "NUR 108C": {
+    "text": "Either both components of NUR 101, namely, NUR 101A (with a grade of C+ or better) and NUR 101C, or the singlecourse NUR 111, or concurrent enrollment in NUR 111; Eithera grade of C+ or better in BIO 216 within the last 5 yearsor concurrent enrollment in BIO 216; Either a grade of C orbetter in SOC 101 or concurrent enrollment in SOC 101;Either a grade of C or better in PSY 217 or concurrentin PSY 217. Concurrent enrollment in NUR 108A. This courseis limited to AD Nursing majors only.Recomm: Concurrent enrollment in NUR 106A and NUR 106C",
+    "courses": [
+      "BIO 216",
+      "NUR 101",
+      "NUR 101A",
+      "NUR 101C",
+      "NUR 106A",
+      "NUR 106C",
+      "NUR 108A",
+      "NUR 111",
+      "PSY 217",
+      "SOC 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 109A": {
+    "text": "NUR 107A with a C or better and successful completion of NUR 107C.  This course is limited to Practical Nursing majors only.",
+    "courses": [
+      "NUR 107A",
+      "NUR 107C"
+    ],
+    "source": "gcc"
+  },
+  "NUR 109C": {
+    "text": "NUR 107A with a C or better and successful completion of NUR 107C.  Concurrent enrollment in NUR 109A.  This course is limited to Practical Nursing majors only.",
+    "courses": [
+      "NUR 107A",
+      "NUR 107C",
+      "NUR 109A"
+    ],
+    "source": "gcc"
+  },
+  "NUR 110": {
+    "text": "Completion of NUR 104, NUR 105, and NUR 161, all with a C or better; completion of BIO 120 and PSY 101",
+    "courses": [
+      "BIO 120",
+      "NUR 104",
+      "NUR 105",
+      "NUR 161",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 111": {
+    "text": "Successful score on NUR 101 currency exam within 5years or completion of the GCC PNC Program within 5 years; ENG 101; BIO 215 (BIO 195); PSY 101",
+    "courses": [
+      "BIO 195",
+      "BIO 215",
+      "ENG 101",
+      "NUR 101",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "NUR 112": {
+    "text": "ENG 101; PSY 101: PSY 217; SOC 101; A grade of C+ or better in BIO 215 within the last 5 years or a grade of B or better in BIO 194 within the last 5 years; and a grade of C+ or better in BIO 216 within the last 5years.",
+    "courses": [
+      "BIO 194",
+      "BIO 215",
+      "BIO 216",
+      "ENG 101",
+      "PSY 101",
+      "PSY 217",
+      "SOC 101"
+    ],
+    "source": "gcc"
+  },
   "NUR 120": {
     "text": "BIO 203 and ENG 111",
     "courses": [
@@ -5942,6 +10664,56 @@
       "NUR 120",
       "PSY 101"
     ]
+  },
+  "NUR 155": {
+    "text": "Completion of NUR 101, NUR 102, and BIO 231, all with a C or better; completion of ENG 101, PSY 101",
+    "courses": [
+      "BIO 231",
+      "ENG 101",
+      "NUR 101",
+      "NUR 102",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 156": {
+    "text": "Completion of NUR 101, NUR 102, and BIO 231, all with a C or better; completion of ENG 101, PSY 101",
+    "courses": [
+      "BIO 231",
+      "ENG 101",
+      "NUR 101",
+      "NUR 102",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 160": {
+    "text": "Completion of NUR 101, NUR 102, and BIO 231, all with a C or better; completion of ENG 101, PSY 101",
+    "courses": [
+      "BIO 231",
+      "ENG 101",
+      "NUR 101",
+      "NUR 102",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 161": {
+    "text": "Concurrent enrollment in or completion of BIO 120 and PSY 101",
+    "courses": [
+      "BIO 120",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 162": {
+    "text": "Completion of NUR 110 and NUR 111, all with a C or better. Concurrent enrollment in or completion of PSY 124",
+    "courses": [
+      "NUR 110",
+      "NUR 111",
+      "PSY 124"
+    ],
+    "source": "middlesex"
   },
   "NUR 201": {
     "text": "BIO 202 and NUR 102 or NUR 106 and PSY 204 and BIO 207 and COM 104 or COM 105 or COM 106 or COM 107 and NUR 201C and SOC 105",
@@ -5958,6 +10730,20 @@
       "NUR 201C",
       "SOC 105"
     ]
+  },
+  "NUR 201A": {
+    "text": "NUR 106A (NUR 106) with a grade of C+ or better and successful completion of NUR 106C. NUR 108A (NUR 108) with a grade of C+ or better and successful completion of NUR108C. For students entering the ADN bridge program: NUR 112(which substitutes for the NUR 106 and NUR 108 requirement).For all students: either a grade of C+ or better in BIO 205or concurrent enrollment in BIO 205. This course is limited to AD Nursing majors only.",
+    "courses": [
+      "BIO 205",
+      "NUR 106",
+      "NUR 106A",
+      "NUR 106C",
+      "NUR 108",
+      "NUR 108A",
+      "NUR 108C",
+      "NUR 112"
+    ],
+    "source": "gcc"
   },
   "NUR 201C": {
     "text": "NUR 201",
@@ -5986,11 +10772,87 @@
       "BIO 207"
     ]
   },
+  "NUR 202A": {
+    "text": "NUR 201A (NUR 201) with a grade of C+ or better and successful completion of NUR 201C. NUR 203A (NUR 203) with a grade of C+ or better and successful completion of NUR203C.Either a grade of C or better in one of the following: ENG 112, ENG114, ENG 116 or concurrent enrollment in ENG 112, ENG114, ENG 116; Either a grade of C or better in one 3-4credit course from the list of Humanities and Fine Arts General Education electives or concurrent enrollment in one 3-4 credit course from the list of Humanities and Fine Arts General Education electives .This course is limited to AD Nursing majors only.",
+    "courses": [
+      "ENG 112",
+      "ENG 114",
+      "ENG 116",
+      "NUR 201",
+      "NUR 201A",
+      "NUR 201C",
+      "NUR 203",
+      "NUR 203A",
+      "NUR 203C"
+    ],
+    "source": "gcc"
+  },
   "NUR 202C": {
     "text": "NUR 202",
     "courses": [
       "NUR 202"
     ]
+  },
+  "NUR 203": {
+    "text": "Completion of NUR 110 and NUR 111, all with a C or better. Concurrent enrollment in or completion of PSY 124",
+    "courses": [
+      "NUR 110",
+      "NUR 111",
+      "PSY 124"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 203A": {
+    "text": "NUR 106A (NUR 106) with a grade of C+ or better andsuccessful completion of NUR 106C. NUR 108A (NUR 108) with agrade of C+ or better and successful completion of NUR 108C.For students entering the ADN bridge program: NUR 112 (whichsubstitutes for the NUR 106 and NUR 108 requirement). Forall students: either a grade of C+ or better in BIO 205 orconcurrent enrollment in BIO 205. This course is limited toAD Nursing majors only.Recomm: Concurrent enrollment in NUR 201A and NUR 201C.",
+    "courses": [
+      "BIO 205",
+      "NUR 106",
+      "NUR 106A",
+      "NUR 106C",
+      "NUR 108",
+      "NUR 108A",
+      "NUR 108C",
+      "NUR 112",
+      "NUR 201A",
+      "NUR 201C"
+    ],
+    "source": "gcc"
+  },
+  "NUR 203C": {
+    "text": "NUR 106A (NUR 106) with a grade of C+ or better andsuccessful completion of NUR 106C. NUR 108A (NUR 108) with agrade of C+ or better and successful completion of NUR 108C.For students entering the ADN bridge program: NUR 112 (whichsubstitutes for the NUR 106 and NUR 108 requirement). Forall students: either a grade of C+ or better in BIO 205 orconcurrent enrollment in BIO 205. Concurrent enrollment inNUR 203A. This course is limited to AD Nursing majors only.Recomm: Concurrent enrollment in NUR 201A and NUR 201C.",
+    "courses": [
+      "BIO 205",
+      "NUR 106",
+      "NUR 106A",
+      "NUR 106C",
+      "NUR 108",
+      "NUR 108A",
+      "NUR 108C",
+      "NUR 112",
+      "NUR 201A",
+      "NUR 201C"
+    ],
+    "source": "gcc"
+  },
+  "NUR 204": {
+    "text": "Completion of NUR 110 and NUR 111, all with a C or better. Concurrent enrollment in or completion of PSY 124",
+    "courses": [
+      "NUR 110",
+      "NUR 111",
+      "PSY 124"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 205": {
+    "text": "Completion of NUR 155, NUR 156, NUR 160, and BIO 232, all with a C or better; completion of ANT 101",
+    "courses": [
+      "ANT 101",
+      "BIO 232",
+      "NUR 155",
+      "NUR 156",
+      "NUR 160"
+    ],
+    "source": "middlesex"
   },
   "NUR 206": {
     "text": "NUR 201 and NUR 202",
@@ -5998,6 +10860,24 @@
       "NUR 201",
       "NUR 202"
     ]
+  },
+  "NUR 207": {
+    "text": "Completion of NUR 110 and NUR 111, all with a C or better. Concurrent enrollment in or completion of PSY 124",
+    "courses": [
+      "NUR 110",
+      "NUR 111",
+      "PSY 124"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 208": {
+    "text": "Completion of NUR 110 and NUR 111, all with a C or better. Concurrent enrollment in or completion of PSY 124",
+    "courses": [
+      "NUR 110",
+      "NUR 111",
+      "PSY 124"
+    ],
+    "source": "middlesex"
   },
   "NUR 220": {
     "text": "BIO 205 and PSY 213 and NUR 150",
@@ -6012,6 +10892,165 @@
     "courses": [
       "NUR 220"
     ]
+  },
+  "NUR 255": {
+    "text": "Completion of NUR 205, NUR 206, and BIO 235, all with a C or better; completion of MAT 177",
+    "courses": [
+      "BIO 235",
+      "MAT 177",
+      "NUR 205",
+      "NUR 206"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 256": {
+    "text": "Completion of NUR 205, NUR 206, and BIO 235, all with a C or better; completion of MAT 177",
+    "courses": [
+      "BIO 235",
+      "MAT 177",
+      "NUR 205",
+      "NUR 206"
+    ],
+    "source": "middlesex"
+  },
+  "NUR 260": {
+    "text": "Completion of NUR 205, NUR 206, and BIO 235, all with a C or better; completion of MAT 177",
+    "courses": [
+      "BIO 235",
+      "MAT 177",
+      "NUR 205",
+      "NUR 206"
+    ],
+    "source": "middlesex"
+  },
+  "OLP 111": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "OLP 112": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement test scores",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "OLP 116": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement; OLP 111 or concurrent enrollment in OLP 111.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 120": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement, OLP 210or past certification in either Wilderness First Responder (WFR) or Wilderness First Aid (WFA)and permission of OLP Program Coordinator.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "OLP 143": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement. OLP 111 or concurrent enrollment in OLP 111.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 147": {
+    "text": "OLP 143",
+    "courses": [
+      "OLP 143"
+    ],
+    "source": "gcc"
+  },
+  "OLP 148": {
+    "text": "Prior technical climbing experience and permission of OLP Program Coordinator.Recomm: Wilderness First Responder certification preferred. Prior experience leading groups on climbing experiences preferred.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "OLP 201": {
+    "text": "Any 100 level OLP course.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "OLP 210": {
+    "text": "OLP 111 or permission of OLP Program Coordinator.",
+    "courses": [
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 214": {
+    "text": "OLP 111 and  OLP 114; or permission of ADE/OLP Dept. Chair.",
+    "courses": [
+      "OLP 111",
+      "OLP 114"
+    ],
+    "source": "gcc"
+  },
+  "OLP 216": {
+    "text": "OLP 111, OLP 120 or concurrent enrollment in OLP 120.",
+    "courses": [
+      "OLP 111",
+      "OLP 120"
+    ],
+    "source": "gcc"
+  },
+  "OLP 230": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement, OLP 210 or past certification in either Wilderness First Responder (WFR) or Wilderness First Aid (WFA) and permission of OLP Program Coordinator.",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "OLP 210"
+    ],
+    "source": "gcc"
+  },
+  "OLP 231": {
+    "text": "OLP 111 or permission of OLP Program Coordinator.Recomm: Wilderness First Responder certification preferred. Prior experience leading groups on river paddling experiences preferred.",
+    "courses": [
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 234": {
+    "text": "OLP 111 or permission of OLP Program Coordinator.Recomm: Wilderness First Responder certification preferred. Prior experience leading groups on climbing experiences preferred.",
+    "courses": [
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 239": {
+    "text": "OLP 143",
+    "courses": [
+      "OLP 143"
+    ],
+    "source": "gcc"
+  },
+  "OLP 246": {
+    "text": "OLP 111 or concurrent enrollment in OLP 111 or permission of the OLP Program Coordinator.",
+    "courses": [
+      "OLP 111"
+    ],
+    "source": "gcc"
+  },
+  "OLP 250": {
+    "text": "OLP 112, OLP 120, OLP 143, and OLP 210, or concurrent enrollment in OLP 112, OLP 120, OLP 143, and OLP 210, or permission of instructor",
+    "courses": [
+      "OLP 112",
+      "OLP 120",
+      "OLP 143",
+      "OLP 210"
+    ],
+    "source": "gcc"
   },
   "OTA 110": {
     "text": "OTA 110L and OTA 110L and OTA 110L",
@@ -6067,6 +11106,137 @@
       "OTA 121"
     ]
   },
+  "PAR 102": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 110": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 130": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 132": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 133": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 134": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 135": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 136": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 138": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 198": {
+    "text": "Completion of PAR 110",
+    "courses": [
+      "PAR 110"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 199": {
+    "text": "Completion of PAR 110",
+    "courses": [
+      "PAR 110"
+    ],
+    "source": "middlesex"
+  },
+  "PAR 210": {
+    "text": "Completion of ENG 101 and PAR 110",
+    "courses": [
+      "ENG 101",
+      "PAR 110"
+    ],
+    "source": "middlesex"
+  },
+  "PCS 101": {
+    "text": "ENG 101 or concurrent enrollment",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "PCS 141": {
+    "text": "ENG 101 or concurrent enrollment",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "PCS 142": {
+    "text": "ENG 101, or concurrent enrollment in ENG 101. Recomm: PCS 141",
+    "courses": [
+      "ENG 101",
+      "PCS 141"
+    ],
+    "source": "gcc"
+  },
+  "PHI 103": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "PHI 104": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "PHI 110": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "PHL 101": {
     "text": "ESL 098 (min C) or RDG 095 (min C) or ENG 095 (min C) or ELL 103 (min C)",
     "courses": [
@@ -6085,6 +11255,13 @@
       "ENG 090",
       "ELL 101"
     ]
+  },
+  "PHL 108": {
+    "text": "Completion of DHY 200 with a C or better",
+    "courses": [
+      "DHY 200"
+    ],
+    "source": "middlesex"
   },
   "PHL 110": {
     "text": "ENG 095 (min C) or ENG 098 (min C)",
@@ -6115,6 +11292,13 @@
       "ENG 094"
     ]
   },
+  "PHL 299": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "PHM 171": {
     "text": "NUR 170 (min C+) or NUR 170 (min T) or NUR 170 (min C+) or NUR 170 (min T) or PNR 170 (min C+) or PNR 170 (min T) or PNR 170 (min C+) or PNR 170 (min T)",
     "courses": [
@@ -6130,6 +11314,27 @@
       "PNR 180",
       "NUR 270"
     ]
+  },
+  "PHO 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PHO 102": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PHO 103": {
+    "text": "Completion of PHO 101",
+    "courses": [
+      "PHO 101"
+    ],
+    "source": "middlesex"
   },
   "PHS 111": {
     "text": "MTH 111 (min D-) or MTH 111 (min D-) or MTH 111 (min T) or MTH 111 (min T) or MTH 112 (min D-) or MTH 112 (min D-) or MTH 112 (min T) or MTH 112 (min T) or MTH 113 (min D-) or MTH 113 (min D-) or MTH 113 (min T) or MTH 113 (min T) or MTH 114 (min D-) or MTH 114 (min D-) or MTH 114 (min T) or MTH 114 (min T)",
@@ -6149,6 +11354,20 @@
       "MTH 211",
       "MTH 213"
     ]
+  },
+  "PHY 101": {
+    "text": "MAT 107, or satisfactory placement beyond MAT 107, or permission of instructor",
+    "courses": [
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "PHY 102": {
+    "text": "PHY 101 or permission of instructor",
+    "courses": [
+      "PHY 101"
+    ],
+    "source": "gcc"
   },
   "PHY 105": {
     "text": "MAT 062 (min C) or MAT 089 (min C) or MAT 083 (min C) or MAT 087 (min C) and PHY 105L and ENG 094",
@@ -6186,6 +11405,45 @@
       "PHY 111A"
     ]
   },
+  "PHY 112": {
+    "text": "PHY 111; MAT 202 or concurrent enrollment in MAT 202",
+    "courses": [
+      "MAT 202",
+      "PHY 111"
+    ],
+    "source": "gcc"
+  },
+  "PHY 141": {
+    "text": "Eligible for ENG 101; Eligible for MAT 177",
+    "courses": [
+      "ENG 101",
+      "MAT 177"
+    ],
+    "source": "middlesex"
+  },
+  "PHY 150": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "PHY 151": {
+    "text": "Eligible for ENG 101; eligible for MAT 195",
+    "courses": [
+      "ENG 101",
+      "MAT 195"
+    ],
+    "source": "middlesex"
+  },
+  "PHY 152": {
+    "text": "PHY 151 with a grade of C or better or permission of a Science instructor",
+    "courses": [
+      "PHY 151"
+    ],
+    "source": "middlesex"
+  },
   "PHY 161": {
     "text": "MAT 151 and PHY 161L",
     "courses": [
@@ -6198,6 +11456,29 @@
     "courses": [
       "PHY 161"
     ]
+  },
+  "PHY 171": {
+    "text": "Completion of, or concurrent enrollment in MAT 290",
+    "courses": [
+      "MAT 290"
+    ],
+    "source": "middlesex"
+  },
+  "PHY 172": {
+    "text": "PHY 171 with a grade of C or better and completion of or concurrent enrollment in MAT 291",
+    "courses": [
+      "MAT 291",
+      "PHY 171"
+    ],
+    "source": "middlesex"
+  },
+  "PHY 173": {
+    "text": "PHY 171 with a grade of C or better and completion of or concurrent enrollment in MAT 291",
+    "courses": [
+      "MAT 291",
+      "PHY 171"
+    ],
+    "source": "middlesex"
   },
   "PHY 201": {
     "text": "MAT 197 (min C)",
@@ -6347,6 +11628,54 @@
       "PMT 113"
     ]
   },
+  "POL 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "POL 103": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "POL 105": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "POL 116": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "POL 203": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "POL 203H": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "PSC 101": {
     "text": "ESL 098 or RDG 095 or ESL 099 or ENG 090 or ELL 103",
     "courses": [
@@ -6380,6 +11709,21 @@
       "RDG 095"
     ]
   },
+  "PSY 101D": {
+    "text": "ENG 090 and ENG 094, or satisfactoryplacement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "PSY 108": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "PSY 110": {
     "text": "ENG 097 (min XC-) or ENG 097 (min T) or ENG 098 (min XC-) or ENG 098 (min T) or ENG 095 (min XC-) or ENG 095 (min T) or ENG 096 (min XC-) or ENG 096 (min T) or ENG 099 (min XC-) or ENG 099 (min T) or ENG 101 (min D-) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min T)",
     "courses": [
@@ -6393,6 +11737,66 @@
       "ENG 104"
     ]
   },
+  "PSY 120": {
+    "text": "Completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 121": {
+    "text": "Completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 123": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 124": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 125": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 128": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 135": {
+    "text": "Completion of ENG 101; and completion of PSY 101 or SOC 101",
+    "courses": [
+      "ENG 101",
+      "PSY 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 138": {
+    "text": "PSY 101 or SOC 101; and placement above or completion of MAT 080 with a C or better or completion of Math Module 12, 73, or 82",
+    "courses": [
+      "MAT 080",
+      "PSY 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
   "PSY 142": {
     "text": "MTH 085 (min XC-) or MTH 085 (min XC-) or MTH 085 (min T) or MTH 085 (min T) or MTH 013 (min XC-) or MTH 013 (min XC-) or MTH 013 (min T) or MTH 013 (min T) or MTH 099 (min XC-) or MTH 099 (min XC-) or MTH 099 (min T) or MTH 099 (min T) or MTH 014 (min XD-) or MTH 014 (min XD-) or MTH 014 (min T) or MTH 014 (min T) or MTH 104 (min D-) or MTH 104 (min D-) or MTH 104 (min T) or MTH 104 (min T) or MTH 108 (min D-) or MTH 108 (min D-) or MTH 108 (min T) or MTH 108 (min T) or MTH 113 (min D-) or MTH 113 (min D-) or MTH 113 (min T) or MTH 113 (min T) and PSY 110 (min C-) or PSY 110 (min C-) or PSY 110 (min T) or PSY 110 (min T)",
     "courses": [
@@ -6405,6 +11809,78 @@
       "MTH 113",
       "PSY 110"
     ]
+  },
+  "PSY 150": {
+    "text": "Completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 151": {
+    "text": "Completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 153": {
+    "text": "Completion of PSY 101 and ENG 101",
+    "courses": [
+      "ENG 101",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 155": {
+    "text": "Completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 157": {
+    "text": "Successful completion of PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 160": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 162": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 166": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 167": {
+    "text": "PSY 101 and at least one additional psychology elective, 15 credits in the program and a GPA of 2.0 or above",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "PSY 171": {
+    "text": "Completion of PSY 101 or SOC 101",
+    "courses": [
+      "PSY 101",
+      "SOC 101"
+    ],
+    "source": "middlesex"
   },
   "PSY 200": {
     "text": "PSY 110 (min C-) or PSY 110 (min C-) or PSY 110 (min T) or PSY 110 (min T)",
@@ -6460,6 +11936,25 @@
       "PSY 110"
     ]
   },
+  "PSY 212": {
+    "text": "PSY 101; PSY 210 or MAT 114 or permission of Social Sciences department chair",
+    "courses": [
+      "MAT 114",
+      "PSY 101",
+      "PSY 210"
+    ],
+    "source": "gcc"
+  },
+  "PSY 212H": {
+    "text": "PSY 101; PSY 210 or MAT 114 or permission of SocialSciences department chair. Recomm: ENG 101",
+    "courses": [
+      "ENG 101",
+      "MAT 114",
+      "PSY 101",
+      "PSY 210"
+    ],
+    "source": "gcc"
+  },
   "PSY 213": {
     "text": "PSY 101 (min C)",
     "courses": [
@@ -6491,6 +11986,13 @@
     "courses": [
       "PSY 110"
     ]
+  },
+  "PSY 217D": {
+    "text": "PSY 101 or permission of instructor",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
   },
   "PSY 218": {
     "text": "PSY 110 (min C-) or PSY 110 (min C-) or PSY 110 (min T) or PSY 110 (min T)",
@@ -6560,6 +12062,13 @@
       "PSY 101"
     ]
   },
+  "PSY 241": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
   "PSY 245": {
     "text": "ENG 101 or MAT 115 or PSY 101 or SOC 101",
     "courses": [
@@ -6582,6 +12091,20 @@
       "SWK 103",
       "PHL 255"
     ]
+  },
+  "PSY 277": {
+    "text": "PSY 101 or permission of instructor",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "PSY 292": {
+    "text": "Completion of ENG 101 with a B or better; completion of 12 college credits with a GPA of 3.2 or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   },
   "PTA 102": {
     "text": "PTA 102 and BIO 232 and PTA 101 and PTA 103 and PTA 103L and PTA 102L and PTA 102L",
@@ -6707,6 +12230,103 @@
       "PTA 204"
     ]
   },
+  "RAD 101": {
+    "text": "Eligible for ENG 101; completion of or concurrent enrollment in MAT 177",
+    "courses": [
+      "ENG 101",
+      "MAT 177"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 102": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 104": {
+    "text": "Completion of RAD 101; Completion of MAT 177",
+    "courses": [
+      "MAT 177",
+      "RAD 101"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 105": {
+    "text": "Completion of RAD 101 and RAD 103",
+    "courses": [
+      "RAD 101",
+      "RAD 103"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 106": {
+    "text": "Completion of RAD 101 and RAD 103",
+    "courses": [
+      "RAD 101",
+      "RAD 103"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 107": {
+    "text": "Completion of RAD 103",
+    "courses": [
+      "RAD 103"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 108": {
+    "text": "Completion of RAD 107",
+    "courses": [
+      "RAD 107"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 201": {
+    "text": "Completion of RAD 105 and RAD 106",
+    "courses": [
+      "RAD 105",
+      "RAD 106"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 202": {
+    "text": "Completion of RAD 104 and RAD 106",
+    "courses": [
+      "RAD 104",
+      "RAD 106"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 203": {
+    "text": "Completion of RAD 108",
+    "courses": [
+      "RAD 108"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 204": {
+    "text": "Completion of RAD 202",
+    "courses": [
+      "RAD 202"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 205": {
+    "text": "Completion of RAD 201",
+    "courses": [
+      "RAD 201"
+    ],
+    "source": "middlesex"
+  },
+  "RAD 206": {
+    "text": "Completion of RAD 203",
+    "courses": [
+      "RAD 203"
+    ],
+    "source": "middlesex"
+  },
   "RCP 105": {
     "text": "RCP 105L and RCP 105L and RCP 105L and RCP 105L and RCP 105L",
     "courses": [
@@ -6828,6 +12448,22 @@
       "RDL 142"
     ]
   },
+  "REE 121": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "REE 126": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "REL 111": {
     "text": "ESL 099 or ELL 103 or ENG 090 or ESL 098 or ELL 103 or RGD 095",
     "courses": [
@@ -6883,12 +12519,28 @@
       "BIO 207"
     ]
   },
+  "SCI 103": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
   "SCI 105": {
     "text": "ENG 099 (min C) and MAT 062",
     "courses": [
       "ENG 099",
       "MAT 062"
     ]
+  },
+  "SCI 110": {
+    "text": "Eligible for ENG 101; placement above or completion of MAT 080 or completion of Math Module 12, 73, or 82",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
   },
   "SCI 114": {
     "text": "SCI 114L",
@@ -6902,6 +12554,66 @@
       "SCI 114"
     ]
   },
+  "SCI 117": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "SCI 121": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 122": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 130": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 137": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.Recomm: Any of the following: BIO 102, BIO 124, SCI 138, any course coded AGR.",
+    "courses": [
+      "BIO 102",
+      "BIO 124",
+      "ENG 090",
+      "ENG 094",
+      "SCI 138"
+    ],
+    "source": "gcc"
+  },
+  "SCI 138": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "SCI 138H": {
+    "text": "MAT 090 or MAT 090S, ENG 090, ENG 094,satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094",
+      "MAT 090",
+      "MAT 090S"
+    ],
+    "source": "gcc"
+  },
   "SCI 150": {
     "text": "ENG 095 or RDG 095 or ESL 098 or ELL 103 or MAT 093",
     "courses": [
@@ -6912,6 +12624,34 @@
       "MAT 093"
     ]
   },
+  "SCI 201": {
+    "text": "Eligible for MAT 080, Math Module 70 or 80; a college lab science with a C or better; and permission of the course instructor",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 202": {
+    "text": "Completion of SCI 201",
+    "courses": [
+      "SCI 201"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 203": {
+    "text": "Completion of SCI 202",
+    "courses": [
+      "SCI 202"
+    ],
+    "source": "middlesex"
+  },
+  "SCI 204": {
+    "text": "Completion of SCI 203",
+    "courses": [
+      "SCI 203"
+    ],
+    "source": "middlesex"
+  },
   "SCI 221": {
     "text": "BIO 195 or PHY 201 or ENR 101",
     "courses": [
@@ -6920,6 +12660,46 @@
       "ENR 101"
     ]
   },
+  "SGT 101": {
+    "text": "SGT majors only",
+    "courses": [],
+    "source": "gcc"
+  },
+  "SGT 122": {
+    "text": "SGT 101, SGT 120, SGT majors only",
+    "courses": [
+      "SGT 101",
+      "SGT 120"
+    ],
+    "source": "gcc"
+  },
+  "SGT 201": {
+    "text": "SGT 122, SGT 124, SGT majors only",
+    "courses": [
+      "SGT 122",
+      "SGT 124"
+    ],
+    "source": "gcc"
+  },
+  "SGT 210": {
+    "text": "SGT 122, SGT 124; concurrent enrollment in SGT 201; SGT majors only",
+    "courses": [
+      "SGT 122",
+      "SGT 124",
+      "SGT 201"
+    ],
+    "source": "gcc"
+  },
+  "SGT 220": {
+    "text": "SGT 201, SGT 210; concurrent enrollment in SGT 221 and concurrent enrollment in SGT 223; SGT majors only",
+    "courses": [
+      "SGT 201",
+      "SGT 210",
+      "SGT 221",
+      "SGT 223"
+    ],
+    "source": "gcc"
+  },
   "SOC 101": {
     "text": "ESL 098 or RDG 095 or ELL 103",
     "courses": [
@@ -6927,6 +12707,14 @@
       "RDG 095",
       "ELL 103"
     ]
+  },
+  "SOC 106": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement;",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
   },
   "SOC 109": {
     "text": "ESL 098 or ELL 103 or RDG 095",
@@ -6949,17 +12737,120 @@
       "ENG 104"
     ]
   },
+  "SOC 120": {
+    "text": "Students must have completed 12 credits in a degree program at MCC before participating in the course",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 121": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 123": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 125": {
+    "text": "Completion of SOC 110; GPA of 2.0 or above; students must obtain an approved internship with the Community Leadership Coordinator before the semester begins",
+    "courses": [
+      "SOC 110"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 126": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 129": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 130": {
+    "text": "Students must complete 12 credits at MCC in order to apply for this fellowship program",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 133": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 134": {
+    "text": "Completion of 12 credits in a degree program at MCC with a GPA of at least 2.5. Travel course participants must be at least 18 years old by the time of travel",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "SOC 143": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 150": {
+    "text": "Completion of SOC 101",
+    "courses": [
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 154": {
+    "text": "Completion of SOC 101",
+    "courses": [
+      "SOC 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 156": {
+    "text": "Completion of ENG 101 or concurrent enrollment or completion of CRJ 153",
+    "courses": [
+      "CRJ 153",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
   "SOC 200": {
     "text": "ENG 094 (min C)",
     "courses": [
       "ENG 094"
     ]
   },
+  "SOC 201": {
+    "text": "SOC 101 or SOC 106",
+    "courses": [
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
   "SOC 203": {
     "text": "SOC 101 (min C)",
     "courses": [
       "SOC 101"
     ]
+  },
+  "SOC 204": {
+    "text": "SOC 101, SOC 106, EDU 111, EDU 101, or PSY 101",
+    "courses": [
+      "EDU 101",
+      "EDU 111",
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "SOC 206": {
+    "text": "SOC 101 or SOC 106",
+    "courses": [
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
   },
   "SOC 207": {
     "text": "PSY 101 or SOC 101",
@@ -6994,6 +12885,15 @@
       "SOC 110"
     ]
   },
+  "SOC 220H": {
+    "text": "SOC 101 or SOC 106 or PSY 101;",
+    "courses": [
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
   "SOC 227": {
     "text": "SOC 101 or PSY 101 or SOC 109",
     "courses": [
@@ -7008,11 +12908,127 @@
       "SOC 110"
     ]
   },
+  "SOC 290": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 293": {
+    "text": "Completion of ENG 101 with a B or better; completion of 12 college credits with a GPA of 3.2 or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 294": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 296": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of the Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SOC 299": {
+    "text": "Completion of ENG 101 with a B or better; or by permission of Honors Director",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "SON 102": {
+    "text": "Completion of SON 100 with a C or better",
+    "courses": [
+      "SON 100"
+    ],
+    "source": "middlesex"
+  },
+  "SON 104": {
+    "text": "Completion of SON 101 with a C or better",
+    "courses": [
+      "SON 101"
+    ],
+    "source": "middlesex"
+  },
+  "SON 107": {
+    "text": "Completion of SON 100 with a C or better",
+    "courses": [
+      "SON 100"
+    ],
+    "source": "middlesex"
+  },
+  "SON 109": {
+    "text": "Completion of SON 122",
+    "courses": [
+      "SON 122"
+    ],
+    "source": "middlesex"
+  },
   "SON 113": {
     "text": "BIO 204",
     "courses": [
       "BIO 204"
     ]
+  },
+  "SON 121": {
+    "text": "Completion of SON 100, SON 101, and SON 103, all with a C or better",
+    "courses": [
+      "SON 100",
+      "SON 101",
+      "SON 103"
+    ],
+    "source": "middlesex"
+  },
+  "SON 122": {
+    "text": "Completion of SON 121",
+    "courses": [
+      "SON 121"
+    ],
+    "source": "middlesex"
+  },
+  "SON 202": {
+    "text": "Completion of SON 221",
+    "courses": [
+      "SON 221"
+    ],
+    "source": "middlesex"
+  },
+  "SON 207": {
+    "text": "Completion of SON 100, SON 101, and SON 103, all with a C or better",
+    "courses": [
+      "SON 100",
+      "SON 101",
+      "SON 103"
+    ],
+    "source": "middlesex"
+  },
+  "SON 209": {
+    "text": "Completion of SON 122",
+    "courses": [
+      "SON 122"
+    ],
+    "source": "middlesex"
+  },
+  "SON 210": {
+    "text": "Completion of SON 221",
+    "courses": [
+      "SON 221"
+    ],
+    "source": "middlesex"
+  },
+  "SON 211": {
+    "text": "Completion of SON 221",
+    "courses": [
+      "SON 221"
+    ],
+    "source": "middlesex"
   },
   "SON 213": {
     "text": "MIG 105 and SON 223",
@@ -7020,6 +13036,20 @@
       "MIG 105",
       "SON 223"
     ]
+  },
+  "SON 221": {
+    "text": "Completion of SON 122",
+    "courses": [
+      "SON 122"
+    ],
+    "source": "middlesex"
+  },
+  "SON 222": {
+    "text": "Completion of SON 221",
+    "courses": [
+      "SON 221"
+    ],
+    "source": "middlesex"
   },
   "SON 223": {
     "text": "SON 123 and SON 216 and SON 221",
@@ -7029,6 +13059,55 @@
       "SON 221"
     ]
   },
+  "SON 228": {
+    "text": "Completion of SON 222",
+    "courses": [
+      "SON 222"
+    ],
+    "source": "middlesex"
+  },
+  "SON 251": {
+    "text": "Completion of SON 122",
+    "courses": [
+      "SON 122"
+    ],
+    "source": "middlesex"
+  },
+  "SON 252": {
+    "text": "Completion of SON 251 with a C or better",
+    "courses": [
+      "SON 251"
+    ],
+    "source": "middlesex"
+  },
+  "SPA 102": {
+    "text": "SPA 101 or equivalent.",
+    "courses": [
+      "SPA 101"
+    ],
+    "source": "gcc"
+  },
+  "SPA 102H": {
+    "text": "SPA 101 or equivalent.",
+    "courses": [
+      "SPA 101"
+    ],
+    "source": "gcc"
+  },
+  "SPA 201": {
+    "text": "SPA 102 or equivalent.",
+    "courses": [
+      "SPA 102"
+    ],
+    "source": "gcc"
+  },
+  "SPA 202": {
+    "text": "SPA 201 or equivalent.",
+    "courses": [
+      "SPA 201"
+    ],
+    "source": "gcc"
+  },
   "SPA 210": {
     "text": "ENG 101 (min D-) or ENG 101 (min D-) or ENG 101 (min T) or ENG 101 (min T) or ENG 102 (min D-) or ENG 102 (min D-) or ENG 102 (min T) or ENG 102 (min T) or ENG 104 (min D-) or ENG 104 (min D-) or ENG 104 (min T) or ENG 104 (min T)",
     "courses": [
@@ -7036,6 +13115,20 @@
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "SPA 255": {
+    "text": "SPA 202 or equivalent",
+    "courses": [
+      "SPA 202"
+    ],
+    "source": "gcc"
+  },
+  "SPA 257": {
+    "text": "SPA 202 or equivalent",
+    "courses": [
+      "SPA 202"
+    ],
+    "source": "gcc"
   },
   "SPM 101": {
     "text": "BUS 101",
@@ -7179,11 +13272,142 @@
       "SWK 101"
     ]
   },
+  "THE 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "THE 105": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "THE 106": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "THE 109": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "THE 112": {
+    "text": "Completion of THE 101 or THE 102",
+    "courses": [
+      "THE 101",
+      "THE 102"
+    ],
+    "source": "middlesex"
+  },
+  "THE 117": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "THE 122": {
+    "text": "Completion of one THE course",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 127": {
+    "text": "A minimum of three technical theatre courses",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 133": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "THE 135": {
+    "text": "Completion of THE 101 and THE 145",
+    "courses": [
+      "THE 101",
+      "THE 145"
+    ],
+    "source": "middlesex"
+  },
+  "THE 140": {
+    "text": "Completion of THE 101 and MUS 132; or permission of course instructor",
+    "courses": [
+      "MUS 132",
+      "THE 101"
+    ],
+    "source": "middlesex"
+  },
   "THE 142": {
     "text": "THE 141 (min D-) or THE 141 (min T)",
     "courses": [
       "THE 141"
     ]
+  },
+  "THE 145": {
+    "text": "Completion of THE 101",
+    "courses": [
+      "THE 101"
+    ],
+    "source": "middlesex"
+  },
+  "THE 152": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 153": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 154": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 155": {
+    "text": "Audition / interview at the end of the previous semester",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "THE 213": {
+    "text": "THE 113",
+    "courses": [
+      "THE 113"
+    ],
+    "source": "gcc"
+  },
+  "THE 225": {
+    "text": "ENG 112, 114, or 116, and either THE 101, 113, 105, or permission of the instructor",
+    "courses": [
+      "ENG 112",
+      "THE 101"
+    ],
+    "source": "gcc"
+  },
+  "THE 225H": {
+    "text": "ENG 112, 114, or 116, and either THE 101, 113, 105, or permission of the instructor",
+    "courses": [
+      "ENG 112",
+      "THE 101"
+    ],
+    "source": "gcc"
   },
   "THE 243": {
     "text": "THE 142 (min D-) or THE 142 (min T)",
@@ -7283,6 +13507,20 @@
     "courses": [
       "THR 298"
     ]
+  },
+  "TMA 095": {
+    "text": "Eligibility for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "TMA 100": {
+    "text": "Eligibility for MAT 080, Math Modules 70 or 80",
+    "courses": [
+      "MAT 080"
+    ],
+    "source": "middlesex"
   },
   "VEA 182": {
     "text": "VET 110 (min C) or VET 110 (min T)",
@@ -7558,5 +13796,933 @@
       "ENG 102",
       "ENG 104"
     ]
+  },
+  "gcc:ACC 203": {
+    "text": "ACC 152; CIS 140 or permission of instructor",
+    "courses": [
+      "ACC 152",
+      "CIS 140"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ART 131": {
+    "text": "ENG 094 or concurrent enrollment or satisfactory placement.Recomm: ENG 090 or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ART 132": {
+    "text": "ART 121 and ART 131",
+    "courses": [
+      "ART 121",
+      "ART 131"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ART 151": {
+    "text": "ENG 094 or satisfactory placementRecomm: ART 121 and ENG 090 or satisfactory placement",
+    "courses": [
+      "ART 121",
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ASL 102": {
+    "text": "ASL 101 or equivalent, or permission of instructor",
+    "courses": [
+      "ASL 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:BIO 104": {
+    "text": "ENG 090, ENG 094 or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:BIO 120": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:BIO 205": {
+    "text": "BIO 126 or BIO 215",
+    "courses": [
+      "BIO 126",
+      "BIO 215"
+    ],
+    "source": "gcc"
+  },
+  "gcc:BUS 105": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:BUS 111": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:CRJ 103": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:CRJ 107": {
+    "text": "CRJ 101 and 103, or permission of instructor",
+    "courses": [
+      "CRJ 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:CRJ 109": {
+    "text": "CRJ 101 or permission of instructor",
+    "courses": [
+      "CRJ 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:CRJ 110": {
+    "text": "CRJ 109 or permission of instructor",
+    "courses": [
+      "CRJ 109"
+    ],
+    "source": "gcc"
+  },
+  "gcc:CRJ 219": {
+    "text": "CRJ 101, 103, or permission of instructor",
+    "courses": [
+      "CRJ 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:EDU 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:EDU 123": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement.",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:EGR 223": {
+    "text": "CHE 111, PHY 112",
+    "courses": [
+      "CHE 111",
+      "PHY 112"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ENG 112": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ENG 116": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:ENG 205": {
+    "text": "ENG 112, 114, or 116",
+    "courses": [
+      "ENG 112"
+    ],
+    "source": "gcc"
+  },
+  "gcc:FRE 102": {
+    "text": "FRE 101 or equivalent.",
+    "courses": [
+      "FRE 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:GEO 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:HIS 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:HIS 102": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:HSV 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:HSV 215": {
+    "text": "HSV 115",
+    "courses": [
+      "HSV 115"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MAT 117": {
+    "text": "C- or higher in HUD 138 or in MAT 095, or satisfactory placement into MAT 117; or satisfactory placement into HUD 138 with concurrent enrollment in MAT 003. Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "HUD 138",
+      "MAT 003",
+      "MAT 095"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MAT 151": {
+    "text": "A grade of C- or better in MAT 107 or satisfactory placement, ENG 090and ENG 094, or satisfactory placement. Placement tests are used only for initial course placement; see catalog for details.",
+    "courses": [
+      "ENG 094",
+      "MAT 107"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MUS 151": {
+    "text": "Permission of instructor or Department Chair; basic instrumental or vocal proficiency; the ability to read and play chord changes.",
+    "courses": [],
+    "source": "gcc"
+  },
+  "gcc:MUS 208": {
+    "text": "MUS 103 or permission of instructor; basic music reading skills; basic instrumental proficiency",
+    "courses": [
+      "MUS 103"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MUS 223": {
+    "text": "MUS 154 (MUS 221) or permission of department chair.",
+    "courses": [
+      "MUS 154",
+      "MUS 221"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MUS 224": {
+    "text": "MUS 138, MUS 153, MUS 154 (MUS 221), MUS 222 or concurrent enrollment in MUS 222), and MUS 223 or concurrent enrollment in MUS 223. Recomm: MUS 220 and MUS 139",
+    "courses": [
+      "MUS 138",
+      "MUS 139",
+      "MUS 153",
+      "MUS 154",
+      "MUS 220",
+      "MUS 221",
+      "MUS 222",
+      "MUS 223"
+    ],
+    "source": "gcc"
+  },
+  "gcc:MUS 230": {
+    "text": "None.Recomm: concurrent enrollment in MUS 231",
+    "courses": [
+      "MUS 231"
+    ],
+    "source": "gcc"
+  },
+  "gcc:NUR 101C": {
+    "text": "Either ENG 101 or concurrent enrollment in ENG 101. Either a grade of C+ or better in BIO 215 within the last 5 years, or concurrent enrollment in BIO 215, or a grade of B or better in BIO 194within the last 5 years. Either a grade of C or better in PSY 101 or concurrent enrollment in PSY 101.Concurrent enrollment in NUR 101A. This course is limited to AD Nursing majors only.",
+    "courses": [
+      "BIO 215",
+      "ENG 101",
+      "NUR 101A",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:NUR 201C": {
+    "text": "NUR 106A (NUR 106) with a grade of C+ or better andsuccessful completion of NUR 106C. NUR 108A (NUR 108)  witha grade of C+ or better and successful completion of NUR108C. For students entering the ADN bridge program: NUR 112(which substitutes for the NUR 106 and NUR 108 requirement).For all students: either a grade of C+ or better in BIO 205or concurrent enrollment in BIO 205. Concurrent enrollmentin NUR 201A. This course is limited to AD Nursing majorsonly.Recomm: Concurrent enrollment in NUR 203A and NUR 203C",
+    "courses": [
+      "BIO 205",
+      "NUR 106",
+      "NUR 106A",
+      "NUR 106C",
+      "NUR 108",
+      "NUR 108A",
+      "NUR 108C",
+      "NUR 112",
+      "NUR 201A",
+      "NUR 203A",
+      "NUR 203C"
+    ],
+    "source": "gcc"
+  },
+  "gcc:NUR 202C": {
+    "text": "NUR 201A (NUR 201) with a grade of C+ or better andsuccessful completion of NUR 201C. NUR 203A (NUR 203) with agrade of C+ or better and successful completion of NUR 203C.Either a grade of C or better in one of the following: ENG112, ENG 114, or ENG 116 or concurrent enrollment in ENG112, ENG 114, or ENG 116; Either a grade of C or better inone 3-4 credit course from the list of Humanities and FineArts General Education electives or concurrent enrollment inone 3-4 credit course from the list of Humanities and FineArts General Education electives. Concurrent enrollment inNUR 202A. This course is limited to AD Nursing majors only.Recomm: Concurrent enrollment in NUR 205",
+    "courses": [
+      "ENG 112",
+      "ENG 114",
+      "ENG 116",
+      "NUR 201",
+      "NUR 201A",
+      "NUR 201C",
+      "NUR 203",
+      "NUR 203A",
+      "NUR 203C",
+      "NUR 205"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PHY 111": {
+    "text": "MAT 201 or concurrent enrollment in MAT 201",
+    "courses": [
+      "MAT 201"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 209": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 210": {
+    "text": "ENG 112, 114 or 116; PSY 101. Recomm: MAT 120",
+    "courses": [
+      "ENG 112",
+      "MAT 120",
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 215": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 217": {
+    "text": "PSY 101 or permission of instructor",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 220": {
+    "text": "SOC 101 or SOC 106 or PSY 101. Recomm: SOC 101 or SOC 106, PSY 101, ENG 101",
+    "courses": [
+      "ENG 101",
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "gcc:PSY 225": {
+    "text": "PSY 101 or permission of instructor.",
+    "courses": [
+      "PSY 101"
+    ],
+    "source": "gcc"
+  },
+  "gcc:SOC 101": {
+    "text": "ENG 090 and ENG 094, or satisfactory placement",
+    "courses": [
+      "ENG 090",
+      "ENG 094"
+    ],
+    "source": "gcc"
+  },
+  "gcc:SOC 203": {
+    "text": "SOC 101 or SOC 106 or PSY 101.",
+    "courses": [
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "gcc:SOC 208": {
+    "text": "SOC 101 or SOC 106",
+    "courses": [
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "gcc:SOC 210": {
+    "text": "SOC 101 or SOC 106 or PSY 101",
+    "courses": [
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "gcc:SOC 220": {
+    "text": "SOC 101 or SOC 106 or PSY 101;",
+    "courses": [
+      "PSY 101",
+      "SOC 101",
+      "SOC 106"
+    ],
+    "source": "gcc"
+  },
+  "middlesex:ART 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 122": {
+    "text": "Completion of ART 121",
+    "courses": [
+      "ART 121"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 123": {
+    "text": "Completion of ART 121",
+    "courses": [
+      "ART 121"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 130": {
+    "text": "Completion of ART 129",
+    "courses": [
+      "ART 129"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 152": {
+    "text": "Completion of ART 113 and ART 121",
+    "courses": [
+      "ART 113",
+      "ART 121"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 161": {
+    "text": "Completion of ART 104 and ART 153",
+    "courses": [
+      "ART 104",
+      "ART 153"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 230": {
+    "text": "Completion of ART 129",
+    "courses": [
+      "ART 129"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ART 251": {
+    "text": "Completion of ART 113 and ART 121",
+    "courses": [
+      "ART 113",
+      "ART 121"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 105": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 108": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 112": {
+    "text": "Completion of ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 115": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 120": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 132": {
+    "text": "Completion of BIO 131 with a C or better",
+    "courses": [
+      "BIO 131"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 231": {
+    "text": "Completion of or concurrent enrollment in ENG 101; completion of BIO 131 in the last five years with a C or better or 73% or better on the A & P Prerequisite Exam",
+    "courses": [
+      "BIO 131",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 232": {
+    "text": "Completion of BIO 231 with a C or better",
+    "courses": [
+      "BIO 231"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 235": {
+    "text": "Completion of BIO 131 or BIO 231 in the last five years with a C or better",
+    "courses": [
+      "BIO 131",
+      "BIO 231"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BIO 261": {
+    "text": "Completion of, or enrollment in BIO 132",
+    "courses": [
+      "BIO 132"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 105": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 140": {
+    "text": "Eligible for ENG 109",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 224": {
+    "text": "Completion of BUS 220 or BUS 223 or BUS 320",
+    "courses": [
+      "BUS 220",
+      "BUS 223",
+      "BUS 320"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 226": {
+    "text": "Completion of BUS 220 or BUS 221",
+    "courses": [
+      "BUS 220",
+      "BUS 221"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 227": {
+    "text": "Completion of BUS 220 or BUS 221",
+    "courses": [
+      "BUS 220",
+      "BUS 221"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:BUS 228": {
+    "text": "Completion of COM 125 or completion of or concurrent enrollment in BUS 110 or BUS 130",
+    "courses": [
+      "BUS 110",
+      "BUS 130",
+      "COM 125"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:COM 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:COM 102": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:CRJ 112": {
+    "text": "Eligible for ENG 101; and completion of either CRJ 111 or CSC 170; or concurrent enrollment in CSC 170",
+    "courses": [
+      "CRJ 111",
+      "CSC 170",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:CRJ 121": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:CRJ 123": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:CSC 101": {
+    "text": "Eligible for ENG 109; and eligible for Math Module 82",
+    "courses": [
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:CSC 252": {
+    "text": "Eligible for ENG 102; and completion of CSC 151 with a C or better",
+    "courses": [
+      "CSC 151",
+      "ENG 102"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EDU 101": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EDU 102": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EDU 103": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EDU 104": {
+    "text": "Eligible for ENG 101 and completion of EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EDU 110": {
+    "text": "Completion of PSY 122 or EDU 122 with a C or better",
+    "courses": [
+      "EDU 122",
+      "PSY 122"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EGR 210": {
+    "text": "Completion of PHY 171; Concurrent enrollment in or completion of MAT 291",
+    "courses": [
+      "MAT 291",
+      "PHY 171"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:EGR 213": {
+    "text": "CHE 151, MAT 291,EGR 210",
+    "courses": [
+      "CHE 151",
+      "EGR 210",
+      "MAT 291"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENG 101": {
+    "text": "Placement into ENG 101 or completion of ENG 088, ENG 089, or ENG 092 with a B or better; or completion of ENG 099 or ENG 109 with a C- or better",
+    "courses": [
+      "ENG 088",
+      "ENG 089",
+      "ENG 092",
+      "ENG 099",
+      "ENG 109"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENG 102": {
+    "text": "Completion of ENG 101 with a C- or better",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENG 110": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENG 113": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENV 110": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENV 113": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:ENV 115": {
+    "text": "Eligible for ENG 109; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 109",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:HIM 106": {
+    "text": "Completion of MAS 101 and HIM 104",
+    "courses": [
+      "HIM 104",
+      "MAS 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:HUM 121": {
+    "text": "Completion of 12 credits in a degree program at MCC",
+    "courses": [],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 099": {
+    "text": "Placement by Aleks assessment score or eligibility for MAT290 or completion of MAT165 with a C- or higher",
+    "courses": [
+      "MAT 165",
+      "MAT 290"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 120": {
+    "text": "Eligible for ENG 101; placement above or completion of MAT 080 with a C or better, or completion of Math Modules 12, 73, or 82",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 130": {
+    "text": "Eligible for ENG 101; and placement above or completion of MAT 080 with a C or better or completion of Math Module 12 or 85",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 131": {
+    "text": "Eligible for ENG 101; and placement above or completion of MAT 080 with a C or better or completion of Math Module 12 or 85",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 201": {
+    "text": "Completion of or concurrent enrollment in MAT 100 (Module 82 or higher) or higher level math course",
+    "courses": [
+      "MAT 100"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 202": {
+    "text": "Completion of MAT 201",
+    "courses": [
+      "MAT 201"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 203": {
+    "text": "Completion of MAT 202",
+    "courses": [
+      "MAT 202"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 204": {
+    "text": "Completion of MAT 203",
+    "courses": [
+      "MAT 203"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MAT 291": {
+    "text": "Completion of MAT 290 with a C or better",
+    "courses": [
+      "MAT 290"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MLT 251": {
+    "text": "Completion of MLT 201, MLT 202, MLT 203, all with C or better",
+    "courses": [
+      "MLT 201",
+      "MLT 202",
+      "MLT 203"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:MUS 230": {
+    "text": "Completion of MUS 130 and MUS 180",
+    "courses": [
+      "MUS 130",
+      "MUS 180"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:NUR 105": {
+    "text": "Concurrent enrollment in or completion of BIO 120 and PSY 101",
+    "courses": [
+      "BIO 120",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:NUR 111": {
+    "text": "Completion of NUR 104, NUR 105, and NUR 161, all with a C or better; completion of BIO 120 and PSY 101",
+    "courses": [
+      "BIO 120",
+      "NUR 104",
+      "NUR 105",
+      "NUR 161",
+      "PSY 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:NUR 206": {
+    "text": "Completion of NUR 155, NUR 156, NUR 160, and BIO 232, all with a C or better; completion of ANT 101",
+    "courses": [
+      "ANT 101",
+      "BIO 232",
+      "NUR 155",
+      "NUR 156",
+      "NUR 160"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:PHL 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:PHY 105": {
+    "text": "Eligible for ENG 101; and eligible for MAT 080, Math Module 70 or 80",
+    "courses": [
+      "ENG 101",
+      "MAT 080"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:PSY 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:SOC 101": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:SOC 106": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
+  },
+  "middlesex:SOC 110": {
+    "text": "Eligible for ENG 101",
+    "courses": [
+      "ENG 101"
+    ],
+    "source": "middlesex"
   }
 }


### PR DESCRIPTION
## What changes for someone using the site

The semester planner prereq chains for CT and MA courses are restored. A cron run this morning hit transient AWS WAF blocks on two Acalog catalogs, scraping 0 courses from both and merging the degraded data into main (#903, #893). This reverses that damage:

- **CT**: 48 ENG 2xxx prereqs deleted by #903 restored → 626→**674** entries
- **MA**: 926 Middlesex prereqs deleted by #893 restored → 1020→**1946** entries (Middlesex WAF block was transient; re-run today worked)

## What changes on the technical front

Acalog is sometimes hosted behind AWS WAF which sends an HTTP 202 challenge response to server-side fetches (no JS = no cookie solve = 0 results with no error raised). The scrapers don't detect this — they see an empty course list, write `{}`, and the cron opens a PR deleting everything. Two catalogs hit it simultaneously this morning.

CT is still failing (still WAF-blocked today), so CT is restored from the pre-cron-903 baseline (commit 98c4eec9). Middlesex resolved itself and the re-run succeeded.

Follow-up needed: add WAF detection (check for `x-amzn-waf-action: challenge` response header or empty result with HTTP 200 body = `{}`) and either abort the write or fall back to Playwright. Tracked in #886 (forthcoming).

## Test plan

- [x] CT: 674 entries, spot-check `ENG 2245` → `"ENG 1020 or ENG 1030 or permission..."` present
- [x] MA: 1946 entries, spot-check `MUS 108` present (was in dropped set)
- [ ] Post-merge: confirm CT and MA planner prereqs resolve correctly on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)
