### PR TITLE
fix: unbreak program detail pages + legacy-slug redirects

### DIFF
--- a/.github/workflows/import-on-merge.yml
+++ b/.github/workflows/import-on-merge.yml
@@ -28,7 +28,7 @@ on:
       datatype:
         description: "Which import(s) to run"
         type: choice
-        options: [both, courses, transfers]
+        options: [both, courses, transfers, programs]
         default: both
 
 permissions:
@@ -76,12 +76,24 @@ jobs:
           echo "Importing state=$state, datatype=$dt"
 
       - name: Import courses
-        if: steps.args.outputs.datatype != 'transfers'
+        if: steps.args.outputs.datatype != 'transfers' && steps.args.outputs.datatype != 'programs'
         run: npx tsx scripts/import-courses.ts ${{ steps.args.outputs.flag }}
 
       - name: Import transfers
-        if: steps.args.outputs.datatype != 'courses'
+        if: steps.args.outputs.datatype != 'courses' && steps.args.outputs.datatype != 'programs'
         run: npx tsx scripts/import-transfers.ts ${{ steps.args.outputs.flag }}
+
+      # Programs (degree/certificate requirements) power the Degree-Path Planner
+      # at /{state}/college/{id}/program/{slug}. Before this step existed, program
+      # JSON landed in the repo on merge but never reached Supabase — and the
+      # JSON files are NOT traced into the Vercel function bundle (only
+      # data/*/prereqs.json is, per next.config.ts). So buildMajorPlan's
+      # Supabase-first read got nothing and the file fallback hit ENOENT,
+      # 404-ing every program detail page in every state. This wires the
+      # existing import-programs.ts into the same merge path as courses/transfers.
+      - name: Import programs
+        if: steps.args.outputs.datatype == 'both' || steps.args.outputs.datatype == 'programs'
+        run: npx tsx scripts/import-programs.ts ${{ steps.args.outputs.flag }}
 
       # Vercel auto-deploys on push to main, but that build races this import
       # workflow. The build typically finishes ~5 min after merge while the

--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -13,12 +13,12 @@
  * never opts into dynamic rendering (cf. the college page's searchParams note).
  */
 
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { loadInstitutions } from "@/lib/institutions";
-import { buildMajorPlan } from "@/lib/programs/planner";
+import { buildMajorPlan, resolveCanonicalProgramSlug } from "@/lib/programs/planner";
 import { getScorecard, formatDollar, formatPercent } from "@/lib/scorecard";
 import { termLabel } from "@/lib/terms";
 import Breadcrumbs from "@/components/Breadcrumbs";
@@ -81,7 +81,15 @@ export default async function MajorPlanPage(props: PageProps) {
   if (!institution) notFound();
 
   const plan = await buildMajorPlan(state, id, slug);
-  if (!plan) notFound();
+  if (!plan) {
+    // The exact slug didn't resolve. It may be a legacy URL minted before a
+    // re-scrape reformatted the program title (which changes programSlug).
+    // Recover SEO/bookmark equity by redirecting to the current canonical slug
+    // when we can unambiguously identify the program; otherwise 404.
+    const canonical = await resolveCanonicalProgramSlug(state, id, slug).catch(() => null);
+    if (canonical) redirect(`/${state}/college/${id}/program/${canonical}`);
+    notFound();
+  }
 
   const collegeHref = `/${state}/college/${id}`;
   const transferHref = `/${state}/transfer`;

--- a/lib/programs/plan-shared.ts
+++ b/lib/programs/plan-shared.ts
@@ -24,10 +24,68 @@ export function countRealCourses(p: { requirement_groups: RequirementGroup[] }):
   return p.requirement_groups.flatMap((g) => g.courses).filter(isRealCourse).length;
 }
 
-/** Stable, unique-within-college slug for a program: title + credential. */
-export function programSlug(p: { title: string; credential: string }): string {
-  return `${p.title} ${p.credential}`
+/** Lowercase, dash-collapse, trim — the shared slugify used for program URLs. */
+export function slugifyText(s: string): string {
+  return s
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+/** Canonical, unique-within-college slug for a program: title + credential. */
+export function programSlug(p: { title: string; credential: string }): string {
+  return slugifyText(`${p.title} ${p.credential}`);
+}
+
+/**
+ * The *stable core* of a program slug: the program name with its trailing
+ * degree-type clause removed. CourseLeaf/Acalog titles encode the credential
+ * after an em/en-dash (e.g. "Accounting — Associate in Science"); re-scrapes
+ * sometimes re-parse that clause ("…— Certificate of Completion" → "…— AS"),
+ * which silently changes `programSlug` and 404s every previously-indexed URL.
+ * The part *before* the dash is stable across those re-parses, so we use it to
+ * recognize a legacy URL and redirect it to the current canonical slug.
+ */
+export function programCoreSlug(p: { title: string }): string {
+  const namePart = (p.title ?? "").split(/[—–]/)[0];
+  return slugifyText(namePart);
+}
+
+/**
+ * Resolve a (possibly legacy) program slug to a program. Exact `programSlug`
+ * match wins. Otherwise we look for the single program whose stable core slug
+ * is the longest unique prefix of the requested slug — that's a program whose
+ * title was reformatted since the URL was minted. Ambiguous matches (two
+ * programs sharing the same core) return null rather than guessing.
+ *
+ * Returns the matched program plus `isLegacy` (true when the requested slug is
+ * not already canonical, signaling the caller should 301/308-redirect).
+ */
+export function resolveProgramBySlug<T extends { title: string; credential: string }>(
+  programs: T[],
+  slug: string,
+): { program: T; canonicalSlug: string; isLegacy: boolean } | null {
+  const exact = programs.find((p) => programSlug(p) === slug);
+  if (exact) return { program: exact, canonicalSlug: slug, isLegacy: false };
+
+  let best: T | null = null;
+  let bestLen = -1;
+  let tie = false;
+  for (const p of programs) {
+    const core = programCoreSlug(p);
+    if (!core) continue;
+    if (slug === core || slug.startsWith(core + "-")) {
+      if (core.length > bestLen) {
+        best = p;
+        bestLen = core.length;
+        tie = false;
+      } else if (core.length === bestLen) {
+        tie = true;
+      }
+    }
+  }
+  if (best && !tie) {
+    return { program: best, canonicalSlug: programSlug(best), isLegacy: true };
+  }
+  return null;
 }

--- a/lib/programs/planner.ts
+++ b/lib/programs/planner.ts
@@ -29,12 +29,35 @@ import {
   isRealCourse,
   countRealCourses,
   programSlug,
+  resolveProgramBySlug,
   PLAN_MIN_COURSES,
 } from "@/lib/programs/plan-shared";
 import type { RequiredCourse } from "@/lib/types";
 
 // Re-export the pure helpers so existing `@/lib/programs/planner` imports work.
 export { isRealCourse, countRealCourses, programSlug, PLAN_MIN_COURSES };
+
+/**
+ * Resolve a possibly-legacy program slug to the current canonical slug, for the
+ * redirect path. Returns the canonical slug only when it differs from the
+ * requested one AND the target program is actually plannable (so we never
+ * redirect into another 404). Used by the detail page when an exact-slug
+ * lookup misses — e.g. a URL minted before a re-scrape reformatted the title.
+ */
+export async function resolveCanonicalProgramSlug(
+  state: string,
+  collegeId: string,
+  slug: string,
+): Promise<string | null> {
+  const institution = loadInstitutions(state).find((i) => i.id === collegeId);
+  if (!institution) return null;
+  const programs = await loadCollegePrograms(state, institution.college_slug);
+  const resolved = resolveProgramBySlug(programs, slug);
+  if (!resolved || !resolved.isLegacy) return null;
+  if (countRealCourses(resolved.program) < PLAN_MIN_COURSES) return null;
+  if (resolved.canonicalSlug === slug) return null;
+  return resolved.canonicalSlug;
+}
 
 export type TransferStatus = "direct" | "elective" | "no-credit";
 


### PR DESCRIPTION
## What this fixes

**Every program detail page on the site is broken** — visiting any `/{state}/college/{id}/program/{slug}` URL returns "Page not found". This affects all states with program data (CA, GA, VA, TN, NY, KY, etc.). The Degree-Path Planner feature shipped in PRs #809/#815 but has never actually been reachable on production.

Example broken URL (the one that surfaced this):
`/ca/college/san-jose-city-college/program/early-childhood-education-inclusion-specialist-certificate-of-achievement-level-2-certificate-of-completion-certificate`

## Root causes (two stacked bugs)

### Bug 1: Program data never reaches the Vercel function

`loadCollegePrograms()` reads Supabase first, falls back to local JSON. Both paths fail on prod:
- **Supabase:** `import-programs.ts` exists but was never wired into `import-on-merge.yml` — the `programs` table is empty.
- **Local JSON fallback:** `next.config.ts` `outputFileTracingIncludes` only bundles `data/*/prereqs.json`. The 127 MB of program JSON files are not traced, so `fs.readFileSync` throws ENOENT → caught → returns `[]` → `notFound()`.

The programs **list** page (`/programs`) only appeared to work because it served a stale ISR cache from build time.

**Fix:** Wire `import-programs.ts` into the merge workflow (same pattern as courses/transfers). After merge, a one-time `--all` backfill populates the table.

### Bug 2: Slug instability across re-scrapes

`programSlug()` derives from `title + credential`. PR #909 fixed the CourseLeaf parser, which changed titles from `"… — Certificate of Completion"` (credential `certificate`) to `"… — Associate in Science"` (credential `AS`). Every CA program slug changed silently, 404-ing all previously-indexed URLs.

**Fix:** New `resolveProgramBySlug()` matcher. The "core" of a program title (everything before the em-dash degree clause) is stable across re-parses. When an exact slug miss occurs, the matcher finds the program by its stable core and the page 308-redirects to the current canonical slug. Ambiguous matches (two programs sharing a core, e.g. "Accounting — AS" vs "Accounting — Certificate") return null rather than guessing, so they 404 cleanly.

Verified against the real SJCC data:
- Legacy slug `…certificate-of-completion-certificate` → redirects to `…associate-in-science-as` ✅
- Current slug `…associate-in-science-as` → renders directly ✅
- Bogus slug → 404 ✅

## After merge

Run the one-time backfill against prod Supabase:
```
npx tsx scripts/import-programs.ts --all
```

Then verify: `curl https://communitycollegepath.com/ga/college/albany-tech/program/administrative-support-assistant-certificate` should render "Your plan for this degree" instead of "Page not found".

## Files changed

| File | Change |
|---|---|
| `.github/workflows/import-on-merge.yml` | Add `programs` import step + `programs` datatype option |
| `lib/programs/plan-shared.ts` | Add `slugifyText`, `programCoreSlug`, `resolveProgramBySlug` |
| `lib/programs/planner.ts` | Add `resolveCanonicalProgramSlug` for the redirect path |
| `app/[state]/college/[id]/program/[slug]/page.tsx` | On 404, try legacy-slug resolve → redirect |

🤖 Generated with [Claude Code](https://claude.com/claude-code)