### PR TITLE
feat(ca): Phase B scraper enhancements — 429 backoff, --receiver flag, ASSIST_FIXTURES_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ data/ny/.step-partial/
 
 # Tailwind CLI compiled output — source is app/tailwind.source.css
 app/globals.css
+data/ca/assist-fixtures-phaseb/

--- a/scripts/ca/scrape-assist-receivers.ts
+++ b/scripts/ca/scrape-assist-receivers.ts
@@ -134,6 +134,7 @@ function flag(name: string): string | undefined {
 }
 const PHASE = (flag("phase") ?? "all").toLowerCase(); // a | b | all
 const CC_FILTER = flag("cc"); // restrict to one CC slug for smoke-testing
+const RECEIVER_FILTER = flag("receiver")?.toUpperCase(); // restrict Phase B to a single receiver code (UCB, UCLA, …)
 const CONCURRENCY = Math.max(1, parseInt(flag("concurrency") ?? "3", 10));
 const DELAY_MS = Math.max(0, parseInt(flag("delay") ?? "200", 10));
 
@@ -333,6 +334,7 @@ async function phaseA(
 interface PhaseBResult {
   fetched: number;
   skipped: number;
+  rateLimited: number;
   errors: string[];
 }
 
@@ -349,10 +351,12 @@ async function phaseB(
 ): Promise<PhaseBResult> {
   fs.mkdirSync(FIXTURES_DIR, { recursive: true });
 
-  // Filter to top-5 UC receivers only
-  const targets = coverage.filter((e) =>
-    TOP_RECEIVERS.has(e.receiverCode.toUpperCase()),
-  );
+  // Filter to top-5 UC receivers by default; --receiver=UCB narrows further.
+  const targets = coverage.filter((e) => {
+    const code = e.receiverCode.toUpperCase();
+    if (RECEIVER_FILTER) return code === RECEIVER_FILTER;
+    return TOP_RECEIVERS.has(code);
+  });
   const totalMajors = targets.reduce((s, e) => s + e.majorCount, 0);
   console.log(
     `Phase B: ${targets.length} (CC×receiver) pairs, ${totalMajors} major reports`,
@@ -368,9 +372,49 @@ async function phaseB(
 
   let fetched = 0;
   let skipped = 0;
+  let rateLimited = 0;
   const errors: string[] = [];
   const t0 = Date.now();
   let processed = 0;
+
+  // Shared adaptive throttle. ASSIST's articulation-detail endpoint
+  // rate-limits per-IP (allows ~50 calls in a burst, then HTTP 429 with no
+  // Retry-After header; triggered an IP-level cooldown in the original
+  // smoke test). When ANY worker hits a 429 we double the per-call delay
+  // (capped at 5s) and pause for a minute before retrying — and the slow-
+  // down sticks for all workers. After a sustained quiet window we slowly
+  // halve the delay back down toward DELAY_MS.
+  let currentDelayMs = DELAY_MS;
+  let lastBackoffAt = 0;
+  const HARD_FLOOR_MS = DELAY_MS;
+  const HARD_CEILING_MS = 5000;
+  const PAUSE_ON_429_MS = 60_000;
+
+  async function fetchWithBackoff(p: string, label: string): Promise<string | null> {
+    const MAX_ATTEMPTS = 4;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        return await apiGetText(session, p);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const is429 = msg.includes("HTTP 429");
+        if (!is429) {
+          errors.push(`${label} (attempt ${attempt}): ${msg}`);
+          return null;
+        }
+        rateLimited++;
+        currentDelayMs = Math.min(HARD_CEILING_MS, currentDelayMs * 2);
+        lastBackoffAt = Date.now();
+        const pauseMs = PAUSE_ON_429_MS * attempt;
+        console.log(
+          `  [B] 429 on ${label} (attempt ${attempt}/${MAX_ATTEMPTS}) — pausing ${Math.round(pauseMs / 1000)}s, new delay=${currentDelayMs}ms`,
+        );
+        await sleep(pauseMs);
+      }
+    }
+    errors.push(`${label}: HTTP 429 after ${MAX_ATTEMPTS} attempts — giving up`);
+    return null;
+  }
 
   async function worker() {
     while (queue.length > 0) {
@@ -388,31 +432,34 @@ async function phaseB(
         continue;
       }
 
-      try {
-        const text = await apiGetText(
-          session,
-          `/api/articulation/Agreements?Key=${encodeURIComponent(item.major.key)}`,
-        );
+      const text = await fetchWithBackoff(
+        `/api/articulation/Agreements?Key=${encodeURIComponent(item.major.key)}`,
+        filename,
+      );
+      if (text) {
         fs.writeFileSync(out, text);
         fetched++;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        errors.push(`${filename}: ${msg}`);
       }
       processed++;
       if (processed % 250 === 0) {
         const elapsed = (Date.now() - t0) / 1000;
         const rate = processed / elapsed;
         console.log(
-          `  [B] ${processed} processed (${fetched} fetched, ${skipped} skipped, ${rate.toFixed(1)}/s, ${queue.length} remaining)`,
+          `  [B] ${processed} processed (${fetched} fetched, ${skipped} skipped, ${rateLimited} 429s, ${rate.toFixed(1)}/s, delay=${currentDelayMs}ms, ${queue.length} remaining)`,
         );
       }
-      await sleep(DELAY_MS);
+      if (
+        currentDelayMs > HARD_FLOOR_MS &&
+        Date.now() - lastBackoffAt > 60_000
+      ) {
+        currentDelayMs = Math.max(HARD_FLOOR_MS, Math.floor(currentDelayMs / 2));
+      }
+      await sleep(currentDelayMs);
     }
   }
 
   await Promise.all(Array.from({ length: CONCURRENCY }, worker));
-  return { fetched, skipped, errors };
+  return { fetched, skipped, rateLimited, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -511,6 +558,7 @@ async function main() {
     console.log(`\nPhase B complete:`);
     console.log(`  fetched: ${result.fetched}`);
     console.log(`  skipped (already on disk): ${result.skipped}`);
+    console.log(`  rate-limit retries: ${result.rateLimited}`);
     console.log(`  errors: ${result.errors.length}`);
     if (result.errors.length > 0 && result.errors.length <= 20) {
       for (const e of result.errors) console.log(`    ${e}`);

--- a/scripts/import-assist-articulation.ts
+++ b/scripts/import-assist-articulation.ts
@@ -27,7 +27,12 @@ if (!supabaseUrl || !supabaseKey) {
 }
 
 const supabase = createClient(supabaseUrl, supabaseKey);
-const fixturesDir = path.join(process.cwd(), "scripts", "ca", "fixtures", "articulation");
+// Override via ASSIST_FIXTURES_DIR so a Phase B run that wrote to a
+// different (e.g. gitignored) directory can be imported without moving
+// files. Defaults to the spike fixtures dir for back-compat.
+const fixturesDir =
+  process.env.ASSIST_FIXTURES_DIR ??
+  path.join(process.cwd(), "scripts", "ca", "fixtures", "articulation");
 
 interface ImportResult {
   filename: string;


### PR DESCRIPTION
## What changes for someone using the site

**Nothing user-visible yet.** This PR ships the infrastructure to fetch ASSIST.org's per-major course-by-course articulation detail (Phase B of the receiver-coverage work tracked since #721/#882) reliably. The actual fetch hasn't been completed at scale — once we run the full Phase B and import the data, the receiver section on `/ca/transfer` can deep-link into course-level pathways instead of just showing aggregate counts and bouncing users to ASSIST.org.

## What changes on the technical front

`scripts/ca/scrape-assist-receivers.ts` Phase B was originally written without 429-handling because the smoke test (PR #721) tripped ASSIST's IP-level cooldown after ~50 calls and we deferred. This PR makes the worker loop adaptive:

- **\`fetchWithBackoff()\`** retries up to 4 attempts on HTTP 429. Each retry sleeps \`60s × attempt\` and doubles the per-call delay (capped at 5s) for ALL workers — the rate limit is per-IP, not per-connection. After 60s of no 429s, the delay halves back toward the floor to reclaim throughput.
- **\`--receiver=UCB\`** new CLI flag narrows Phase B to one university (default is still the top-5 UCs). Useful for "just this receiver, see how it goes" runs.
- **\`ASSIST_FIXTURES_DIR\` env var** is also honored by \`scripts/import-assist-articulation.ts\` so a Phase B run that wrote to a different (e.g. gitignored) directory can be imported without moving files.
- **\`.gitignore\`** added \`data/ca/assist-fixtures-phaseb/\` so a multi-hour run doesn't try to commit ~900 MB of JSON.

## Validation

Smoke-tested with De Anza × UCB (95 majors): 95/95 fetched, 6 retry-after-429s, 0 final errors. Then kicked off the full UCB × all 114 CCs run — got ~104 fixtures in (Allan Hancock + De Anza complete) in ~10 minutes before deciding to ship the infrastructure now and run the full scrape later when there's time for it to grind through (realistic ETA was 6–12 hours due to 429 cooldown clusters at the start of each new CC).

Dry-run import on the 104 partial fixtures: all parse cleanly — 192 groups, 1,021 requirements.

## Not in this PR
- The actual full Phase B run (~10,700 calls for UCB × all CCs; ~58K for top-5 UCs). Resume by:
  \`\`\`
  ASSIST_FIXTURES_DIR=$(pwd)/data/ca/assist-fixtures-phaseb \
    npx tsx scripts/ca/scrape-assist-receivers.ts --phase=b --receiver=UCB --concurrency=2 --delay=300
  \`\`\`
  Detached. Resumable — re-runs skip fixtures already on disk.
- The Supabase import of the data (run \`scripts/import-assist-articulation.ts\` with the same env var afterward).
- The UI that surfaces per-major detail on \`/ca/transfer/to/<receiver>\` — separate PR once the data lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)