### PR TITLE
fix(prereqs): aggregator refuses to clobber prereqs.json on >50% drop

### DIFF
--- a/scripts/lib/aggregate-prereqs.ts
+++ b/scripts/lib/aggregate-prereqs.ts
@@ -159,24 +159,33 @@ function aggregateState(state: string): number {
     sorted[key] = prereqs[key];
   }
 
-  // Safety net: refuse to overwrite a non-empty prereqs.json with zero
-  // entries. This catches the ME-style mistake where someone runs the
-  // aggregator against a state whose prereqs come from a catalog scraper
-  // (not from section inline text) — sections have no prereq_text, so
-  // aggregation yields 0 entries and would clobber 948 catalog-sourced
-  // entries. Pass --force to override (e.g. for genuine resets).
+  // Safety net: refuse to overwrite a healthy prereqs.json with a rebuild
+  // that drops below 50% of the existing entry count. Aggregation re-derives
+  // prereqs from course-section `prerequisite_text` + coursedog-catalog files.
+  // That source can be far thinner than the committed file when:
+  //   - a dedicated catalog/Coursedog scraper wrote a richer prereqs.json this
+  //     same run but emits per-college catalog files for only some colleges
+  //     (NV: 1322 entries from 4 colleges, but only 1 catalog file on disk →
+  //     re-aggregation yields 339 and would clobber it), or
+  //   - an upstream AWS-WAF challenge gutted the catalog input this tick
+  //     (TX/NY May-2026 regressions), or
+  //   - sections simply carry no prereq_text (the original ME 0-entry case).
+  // 50% mirrors scrape-diff.ts's ABORT_RATIO so the aggregator and the diff
+  // agree on what "looks broken" means. Pass --force for genuine resets.
   const newCount = Object.keys(sorted).length;
-  if (newCount === 0 && fs.existsSync(outPath)) {
+  if (fs.existsSync(outPath) && !process.argv.includes("--force")) {
     let existingCount = 0;
     try {
       const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
       existingCount = existing && typeof existing === "object" ? Object.keys(existing).length : 0;
     } catch { /* unreadable — treat as empty */ }
-    if (existingCount > 0 && !process.argv.includes("--force")) {
+    if (existingCount > 0 && newCount < existingCount * 0.5) {
       console.error(
-        `  REFUSED to overwrite ${outPath}: aggregation produced 0 entries ` +
-          `but the existing file has ${existingCount}. This state likely uses ` +
-          `a catalog-based prereq scraper — check StateConfig.scrapers.prereqs. ` +
+        `  REFUSED to overwrite ${outPath}: aggregation produced ${newCount} ` +
+          `entries but the existing file has ${existingCount} (< 50%). The ` +
+          `dedicated catalog scraper's output or a WAF-degraded catalog likely ` +
+          `differs from section-derived aggregation — check ` +
+          `StateConfig.scrapers.prereqs and scraper health. ` +
           `Re-run with --force to overwrite anyway.`,
       );
       return existingCount;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visibly new — this is a data-integrity fix. It stops a pipeline step from silently **deleting good prerequisite data**. On 2026-05-31, Nevada's prereqs were rebuilt down from 1,322 to 339 entries by a re-aggregation step, which tripped the safety guard and filed a false "scraper broken" alert (#901). The same bug degraded New York's prereqs and would have shipped Texas's WAF-degraded data. With this fix, a healthy file is never overwritten by a much thinner rebuild, so the planner/prereq UI keeps the richer data.

## Root cause

The scheduled-scrape `aggregate` job runs `aggregate-prereqs.ts <state>` for **every** prereqs state (`scheduled-scrape-v2.yml:267-268`), including states whose dedicated catalog/Coursedog scraper already wrote a richer `prereqs.json` in the same run. `aggregate-prereqs.ts` re-derives prereqs from course-section `prerequisite_text` + `coursedog-catalog/*.json` and **overwrites** the file. Its only guard was *"refuse if the rebuild is exactly 0 entries"* — a degraded-but-nonzero rebuild walked right past it.

Concretely for **NV** (issue #901): the dedicated scraper produced 1,322 prereqs across 4 colleges, but only 1 college emits a catalog file and 0/10,903 sections carry `prerequisite_text`, so re-aggregation produced **339** and clobbered the 1,322. `scrape-diff` then correctly flagged the 1398→339 drop and filed a regression issue. Same overwrite mechanism degraded **NY** (838) and would ship WAF-degraded **TX** data.

(The MN/TX regressions on the same day are primarily upstream AWS-WAF challenges defeating the Acalog cookie bypass — tracked under #912 — but this fix prevents the aggregator from *compounding* them.)

## The fix

Generalize the safety net in `aggregate-prereqs.ts` from "refuse if 0" to **"refuse if the rebuild drops below 50% of the existing file"** — the same `ABORT_RATIO` (0.5) that `scrape-diff.ts` already uses, so the aggregator and the diff agree on what "looks broken" means. `--force` still overrides for genuine resets.

## Verification (local)

- `aggregate-prereqs.ts nv` → rebuild 373 < 50% of 1398 → **REFUSED**, `data/nv/prereqs.json` untouched (no git diff)
- `aggregate-prereqs.ts nc` (healthy aggregate-from-courses) → writes 2367, **no false refusal**
- `aggregate-prereqs.ts nv --force` → overrides as designed
- `tsc --noEmit` clean

## Effect on the open regression issues

Once merged, the NV regression (#901) resolves outright — the dedicated scraper's output is preserved and a normal PR opens with fresh data. The WAF-driven shortfalls in MN (#908) / TX (#897) / NY (#892) still need the Acalog bypass hardening in #912, but this stops the aggregator from clobbering their good prior data in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)