### PR TITLE
fix(config): populate empty popularCourses for NM, ID, OK

### DIFF
--- a/lib/states/id/config.ts
+++ b/lib/states/id/config.ts
@@ -27,7 +27,7 @@ const idConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGL 101", "ENGL 102", "MATH 143", "MATH 123", "PSYC 101", "COMM 101"],
   defaultZip: "83702",
   defaultZipCity: "Boise",
 

--- a/lib/states/nm/config.ts
+++ b/lib/states/nm/config.ts
@@ -20,7 +20,7 @@ const nmConfig: StateConfig = {
   },
 
   transferSupported: true,
-  popularCourses: [],
+  popularCourses: ["ENGL 1110", "ENGL 1120", "MATH 1130", "MATH 1350", "PSYC 1110", "COMM 1130"],
   defaultZip: "87501",
   defaultZipCity: "Santa Fe",
 

--- a/lib/states/ok/config.ts
+++ b/lib/states/ok/config.ts
@@ -45,7 +45,7 @@ const okConfig: StateConfig = {
   },
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGL 1113", "ENGL 1213", "MATH 1513", "HIST 1493", "PSYC 1113", "COMM 1113"],
   defaultZip: "73102",
   defaultZipCity: "Oklahoma City",
 


### PR DESCRIPTION
## What changes for someone using the site

On the **New Mexico, Idaho, and Oklahoma** course pages, the "popular courses" quick-link row was empty, and their schedule-planner subject filter had nothing pre-populated. This adds 6 real, common gen-ed courses per state (English Comp, College Algebra, Intro Psych, etc.), so students landing on `/{state}/courses` get one-tap links into the most-taken classes instead of a blank section.

Part of audit issue #933.

## What changed technically

`popularCourses` in each `StateConfig` feeds three surfaces — `app/[state]/courses` (quick-links), `app/[state]/schedule` (subject prefixes), and the transfer-compare presets — not just transfers. These three states shipped with `popularCourses: []`. Filled each with high-frequency codes **verified to exist in the state's scraped catalog**:

| State | Courses (section counts in catalog) |
|---|---|
| NM | ENGL 1110 (200), ENGL 1120 (84), MATH 1130 (79), MATH 1350 (55), PSYC 1110 (121), COMM 1130 (53) |
| ID | ENGL 101 (144), ENGL 102 (91), MATH 143, MATH 123, PSYC 101 (43), COMM 101 (133) |
| OK | ENGL 1113 (366), ENGL 1213 (160), MATH 1513 (161), HIST 1493 (132), PSYC 1113 (92), COMM 1113 (79) |

**WI deferred** (the 4th empty state from #933): its scraped course codes are inconsistently parsed across the 4 scraped colleges (`COMM 801-136` vs bare `801 136` vs `809 198` for the same course families), so any preset would be unreliable. WI needs the scraper-normalization / college backfill work first (#456) — called out in #933.

## Verification

- All 18 codes confirmed present in each state's `data/{state}/courses/**` (counts above)
- `tsc --noEmit` clean
- Verified at the data layer: `CompareEmptyState` already filters presets to available courses, and the courses-page links resolve to non-empty searches since every code exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)