### PR TITLE
fix(hi): enable transfers — surface 15,649 hidden UH equivalencies

### DIFF
--- a/lib/states/hi/config.ts
+++ b/lib/states/hi/config.ts
@@ -23,7 +23,9 @@ const hiConfig: StateConfig = {
       "University of Hawaiʻi Board of Regents Policy 6.205 lets Hawaiʻi residents aged 60+ enroll in regular UH credit courses without paying tuition, on a space-available basis. Some fees still apply, and seats are allocated after regular registration — contact your campus registrar for the timing.",
   },
 
-  transferSupported: false,
+  // Transfer data: 15,649 in-state equivalencies across the 3 UH-system
+  // 4-years (Hilo, Mānoa, West Oʻahu), scraped via scrape-transfer-uhdad.ts.
+  transferSupported: true,
   popularCourses: ["ENG 1007", "ENG 1005", "ENG 1006", "PHYL 141L5", "PHYL 1415", "SP 1515"],
   defaultZip: "96813",
   defaultZipCity: "Honolulu",


### PR DESCRIPTION
## What changes for someone using the site

**Hawaii now has a working transfer page.** `/hi/transfer` was hidden entirely, even though we'd already scraped 15,649 course-to-course equivalencies into the three University of Hawaiʻi four-years (Mānoa, Hilo, West Oʻahu). A student at a Hawaiʻi community college can now look up whether a class transfers to UH and what it counts as.

Part of audit issue #933.

## What changed technically

One line: `transferSupported: false → true` in `lib/states/hi/config.ts`. The `/[state]/transfer` route is gated on that flag, so the existing `data/hi/transfer-equiv.json` was sitting unused.

`git blame` shows the `false` came directly from HI's auto-add-state bootstrap (#459, 2026-05-16) and was never updated after the transfer scraper landed — no comment marks it intentional. This is the documented "auto-add-state leaves placeholder defaults" pattern (see the audit), not a deliberate suppression for a data-quality reason.

## Verification

- Data loads cleanly through the page's path: **15,649 records** across 3 receivers — West Oʻahu 5,967 / Hilo 4,641 / Mānoa 5,041
- **9,077** have a mapped target course; the remainder are flagged `is_elective` (elective/no-credit credit), which the transfer UI already handles
- All 3 receivers are **in-state** (UH system) — satisfies the in-state-only rule
- `tsc --noEmit` clean

## Note

HI's *scheduled* transfer scrape failed on 2026-05-30 (a separate transient/WAF issue); this PR surfaces the committed good data from the prior successful run and is independent of that. Re-running the scraper is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)