### PR TITLE
fix(va): surface 302 hidden prereq chains

### DIFF
--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -63,7 +63,11 @@ const vaConfig: StateConfig = {
   scrapers: {
     // manual-only: courses — VA PeopleSoft scraper consistently exceeds the 6h GitHub Actions timeout; run manually when needed.
     // manual-only: transfers — disabled alongside courses to avoid partial-refresh drift.
-    // manual-only: prereqs — disabled alongside courses.
+    // Prereqs aggregate from committed course-section prerequisite_text
+    // (data/va/prereqs.json, 302 parsed chains; 4,227 sections carry prereq
+    // text). This reads already-committed data — it does NOT run the heavy
+    // PeopleSoft scraper — so it's safe on cron despite courses being manual-only.
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — disabled alongside courses.
   },
 };


### PR DESCRIPTION
## What changes for someone using the site

**Virginia courses now show prerequisites, and the VA semester planner can sequence them.** We already had 302 parsed prerequisite chains for VA sitting in `data/va/prereqs.json`, but they were switched off — so a VA student looking at a course saw no prereq info and the planner couldn't order classes. This turns that existing data on.

Part of audit issue #932.

## What changed technically

VA's config had all four scrapers as `// manual-only`. The user-visible gate `hasPrereqsCoverage()` keys off `scrapers.prereqs` being declared, so the parsed file was unused. Added `prereqs: { source: "aggregate-from-courses" }`.

The reason the markers existed is that VA's PeopleSoft **course** scraper blows past the 6-hour Actions timeout, so it's run manually. But the `aggregate-from-courses` prereqs step reads **already-committed** section `prerequisite_text` (4,227 VA sections carry it) — it never invokes PeopleSoft — so it's safe on the weekly cron and consistent with how VA's courses and transfers are already served from on-disk data.

## Verification

- `hasPrereqsCoverage('va')` → `true` (was `false`)
- `loadPrereqs('va')` → 374 records (302 parsed chains) surface immediately
- `npm run check:scrapers` passes; `tsc --noEmit` clean
- Next cron re-aggregates from the 4,227 prereq-text sections (likely *increasing* coverage); the #939 50%-drop guard protects against any erosion

## Scope note (rest of #932)

This PR does the one clear win (VA). The other two items in #932 are intentionally **not changed**, with reasoning recorded on the issue:
- **WA** declares `aggregate-from-courses` but yields 0 (ctcLink exposes no prereq text; acalog catalogs are AWS-WAF-blocked). The config author explicitly judged the empty result "not harmful," and the planner's coverage gate already degrades gracefully. Left as-is pending a real WA catalog source.
- **MT**'s 119 records are honest `"Prerequisites required (see catalog)"` placeholders — low-value but not misleading. Left as-is pending a real MT catalog scraper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)