### PR TITLE
feat(co): wire Colorado into the registry — 14 colleges, 25,864 sections

### DIFF
--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -196,6 +196,7 @@ import akConfig from "./ak/config";
 import idConfig from "./id/config";
 import wiConfig from "./wi/config";
 import okConfig from "./ok/config";
+import coConfig from "./co/config";
 
 const ALL_CONFIGS: StateConfig[] = [
   vaConfig,
@@ -245,6 +246,7 @@ const ALL_CONFIGS: StateConfig[] = [
   idConfig,
   wiConfig,
   okConfig,
+  coConfig,
 ];
 
 const configs: Record<string, StateConfig> = Object.fromEntries(


### PR DESCRIPTION
## What changes for someone using the site

**Colorado becomes a live state.** CCCS course data — 14 of 15 Colorado community colleges, 25,864 sections — has been scraped and sitting on disk since bootstrap, but Colorado never appeared on the site (no map pin, no `/co` pages) because its config was never registered. This turns it on, so CO students can search courses across the system.

Resolves the "wire or remove" decision in #934 — **wire**, since the data is substantial and the config is fully curated.

## What changed technically

Two lines in `lib/states/registry.ts`: `import coConfig` + add it to `ALL_CONFIGS`. Everything else was already in place — CO's config is fully curated (CCCS branding, collegeCount, popularCourses, declared scrapers for the Banner-8 cluster + Colorado Mountain College's Colleague), and the static-import maps (`lib/institutions.ts`, `lib/geo.ts`) already included CO.

CO ships **courses-only**, by design and with documented reasons:
- **Transfers** — documented hard ceiling (#804): CU/CSU equivalency tools are login-gated; CDHE's GT Pathways maps gen-ed *categories*, not course-to-course. `transferSupported: false`.
- **Prereqs** — `aggregate-from-courses` yields 0 (CCCS Banner-8 sections carry no prereq text; author-documented). Same benign-empty pattern as WA. Catalog-based prereq sources tracked as follow-up.
- **Programs** — deferred (no catalog matched a template yet).
- **Aims Community College** — documented per-college ceiling (Acalog-only, no live section search).

## Verification

- `getAllStates()` → **48** states, CO present
- `getStateConfig('co')` resolves (Colorado / CCCS); `loadInstitutions('co')` → 15
- `npm run check:scrapers` passes (48 × 4 datatypes)
- `next build` **compiles successfully + passes TypeScript**. The full static-export phase hung locally at "Collecting page data" with all 7 workers at 0% CPU — the known large-codebase stall (CLAUDE.md / upstream next#78407), app-wide and **not** CO-specific. Recommend watching the Vercel deploy on merge (CLAUDE.md post-merge prod check) and confirming `/co` renders.

## Note

This is easily reversible (revert the 2-line registry change) if anything looks off post-deploy. CO's thin field completeness (low seats/instructor coverage) matches other already-live courses-only states (e.g. VA ships 0% seats_total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)