### PR TITLE
ci(check): guard transferSupported flag against transfer-equiv data drift

### DIFF
--- a/.github/workflows/scraper-coverage.yml
+++ b/.github/workflows/scraper-coverage.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "lib/states/**"
       - "scripts/**"
-      - "scripts/check-scraper-coverage.ts"
+      - "data/**/transfer-equiv.json"
       - ".github/workflows/scraper-coverage.yml"
   push:
     branches: [main]
@@ -21,4 +21,5 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run check:scrapers
+      - run: npm run check:config-data
       - run: npm run check:scraper-terms

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:run": "vitest run",
     "check:registry": "tsx scripts/check-registry-integrity.ts",
     "check:scrapers": "tsx scripts/check-scraper-coverage.ts",
+    "check:config-data": "tsx scripts/check-config-data-consistency.ts",
     "check:scraper-terms": "tsx scripts/check-scraper-term-hardcoding.ts",
     "check:data": "tsx scripts/check-data-integrity.ts",
     "check:blog-mdx": "tsx scripts/check-blog-mdx.ts",

--- a/scripts/check-config-data-consistency.ts
+++ b/scripts/check-config-data-consistency.ts
@@ -1,0 +1,97 @@
+/**
+ * check-config-data-consistency.ts — CI guard for StateConfig flags that
+ * disagree with the data actually on disk.
+ *
+ * Motivated by the 2026-05-31 data-foundation audit (issue #937), which found
+ * Hawaii shipping `transferSupported: false` while 15,649 in-state transfer
+ * equivalencies sat unused on disk (the route was hidden for no reason). This
+ * check fails CI on that class of drift so a flag and its backing data can
+ * never silently diverge again.
+ *
+ * Checks (CLAUDE.md invariant #1 — no hardcoded state lists; derive from the
+ * registry):
+ *
+ *   FAIL  transferSupported ⇎ transfer-equiv.json
+ *         - flag is false but data/{state}/transfer-equiv.json has > 0 rows
+ *           → the transfer route is hidden despite having data (the HI bug).
+ *         - flag is true but the file is missing / has 0 rows
+ *           → the UI promises a transfer page with nothing behind it.
+ *
+ *   WARN  prereqs coverage declared but no backing file
+ *         - hasPrereqsCoverage(state) is true but data/{state}/prereqs.json is
+ *           missing or empty. Non-fatal: some states (e.g. WA) intentionally
+ *           declare `aggregate-from-courses` against a source that currently
+ *           yields nothing, and the planner degrades gracefully. Surfaced so
+ *           the list stays visible, not so it blocks a PR.
+ *
+ * Usage: npx tsx scripts/check-config-data-consistency.ts
+ * Exits 1 if any FAIL; 0 otherwise (warnings never fail the run).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { getAllStates, hasPrereqsCoverage } from "../lib/states/registry";
+
+function jsonRowCount(file: string): number {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    if (Array.isArray(parsed)) return parsed.length;
+    if (parsed && typeof parsed === "object") return Object.keys(parsed).length;
+    return 0;
+  } catch {
+    return 0; // missing or unparseable → treat as no data
+  }
+}
+
+const root = process.cwd();
+const failures: string[] = [];
+const warnings: string[] = [];
+
+for (const cfg of getAllStates()) {
+  const slug = cfg.slug;
+
+  // --- transferSupported ⇎ transfer-equiv.json (FAIL) ---
+  const transferRows = jsonRowCount(
+    path.join(root, "data", slug, "transfer-equiv.json"),
+  );
+  if (transferRows > 0 && !cfg.transferSupported) {
+    failures.push(
+      `${slug}: transferSupported=false but data/${slug}/transfer-equiv.json has ${transferRows} rows — ` +
+        `the transfer route is hidden despite having data. Set transferSupported: true.`,
+    );
+  }
+  if (transferRows === 0 && cfg.transferSupported) {
+    failures.push(
+      `${slug}: transferSupported=true but data/${slug}/transfer-equiv.json is missing/empty — ` +
+        `the UI promises a transfer page with no data. Set transferSupported: false (and document the ceiling).`,
+    );
+  }
+
+  // --- prereqs coverage declared but no backing file (WARN) ---
+  if (hasPrereqsCoverage(slug)) {
+    const prereqRows = jsonRowCount(
+      path.join(root, "data", slug, "prereqs.json"),
+    );
+    if (prereqRows === 0) {
+      warnings.push(
+        `${slug}: hasPrereqsCoverage=true but data/${slug}/prereqs.json is missing/empty ` +
+          `(declared coverage with nothing behind it — verify the prereq UI degrades gracefully).`,
+      );
+    }
+  }
+}
+
+if (warnings.length > 0) {
+  console.warn(`\n⚠  ${warnings.length} prereq-coverage warning(s):`);
+  for (const w of warnings) console.warn(`   - ${w}`);
+}
+
+if (failures.length > 0) {
+  console.error(`\n✖ config/data consistency: ${failures.length} failure(s):`);
+  for (const f of failures) console.error(`   - ${f}`);
+  process.exit(1);
+}
+
+console.log(
+  `\n✔ config/data consistency OK — ${getAllStates().length} states; transferSupported matches transfer-equiv.json data for all.`,
+);


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is a CI safety net. It makes the **HI bug we just fixed impossible to reintroduce**: a state can no longer ship `transferSupported: false` while transfer data sits unused on disk (or vice-versa, promising a transfer page with no data). The check runs on every PR that touches state configs, scripts, or transfer data.

First of the #937 anti-whack-a-mole guardrails.

## What changed technically

New `scripts/check-config-data-consistency.ts` (derives the state list from the registry per invariant #1 — no hardcoded lists):

- **FAIL** — `transferSupported` disagrees with `data/{state}/transfer-equiv.json`: flag `false` with >0 rows (the HI bug, #941), or flag `true` with 0 rows (a transfer page promised with nothing behind it).
- **WARN** (non-fatal) — `hasPrereqsCoverage(state)` is true but `prereqs.json` is missing/empty. This is the WA-style "declares `aggregate-from-courses`, source yields nothing, planner degrades gracefully" case — surfaced for visibility, deliberately *not* a hard failure so it doesn't override that documented decision.

Wired into the existing `scraper-coverage.yml` workflow (now also triggered by `transfer-equiv.json` changes) and exposed as `npm run check:config-data`.

## Verification

- `npm run check:config-data` → **0 failures**, exit 0
- One expected warning: `wa` (intentional empty-aggregate)
- `tsc --noEmit` clean
- Confirmed the audit's whole-fleet scan: every state's `transferSupported` now matches its transfer-equiv row count (HI was the only violation; fixed in #941)

## Scope

This is the first and cleanest of the #937 guardrails (the one with zero current violations and no judgment calls). The remaining #937 items — a parsed-ratio floor for prereqs, content-correctness monitoring, and a per-college coverage ledger — stay tracked on that issue as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)