### PR TITLE
fix(build): floor build-time page generation to stop the OOM cliff

### DIFF
--- a/app/[state]/about/page.tsx
+++ b/app/[state]/about/page.tsx
@@ -1,13 +1,17 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 type Props = {
   params: Promise<{ state: string }>;
 };
 
+// On-demand ISR: generate no pages at build (keeps build memory low — see the
+// staticGenerationMaxConcurrency note in next.config). Pages render on first
+// request and cache; requireStateConfig() 404s invalid states.
+export const dynamicParams = true;
+export const revalidate = 1209600; // 14 days
 export function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
+  return [];
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/app/[state]/plan/page.tsx
+++ b/app/[state]/plan/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import PlannerClient from "./PlannerClient";
 
@@ -7,8 +6,13 @@ type Props = {
   params: Promise<{ state: string }>;
 };
 
+// On-demand ISR: generate no pages at build (keeps build memory low — see the
+// staticGenerationMaxConcurrency note in next.config). requireStateConfig()
+// 404s invalid states.
+export const dynamicParams = true;
+export const revalidate = 1209600; // 14 days
 export function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
+  return [];
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/app/[state]/programs/page.tsx
+++ b/app/[state]/programs/page.tsx
@@ -16,7 +16,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getAllStates, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { PROGRAMS } from "@/lib/programs/registry";
 import {
@@ -26,16 +26,20 @@ import {
 } from "@/lib/programs";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
-export const revalidate = 604800; // 7 days
+export const revalidate = 1209600; // 14 days
 
 type PageProps = {
   params: Promise<{ state: string }>;
 };
 
-export const dynamicParams = false;
+// On-demand ISR: generate no pages at build (keeps build memory low — see the
+// staticGenerationMaxConcurrency note in next.config). Programs index loads a
+// state's full program data, so building all 48 at once was a memory hog.
+// requireStateConfig()/isValidState 404 invalid states.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
+  return [];
 }
 
 function siteUrl(): string {

--- a/app/[state]/results/page.tsx
+++ b/app/[state]/results/page.tsx
@@ -1,14 +1,18 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import ResultsContent from "./ResultsContent";
-import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 type Props = {
   params: Promise<{ state: string }>;
 };
 
+// On-demand ISR: generate no pages at build (keeps build memory low — see the
+// staticGenerationMaxConcurrency note in next.config). This is a search-results
+// page (robots: noindex); requireStateConfig() 404s invalid states.
+export const dynamicParams = true;
+export const revalidate = 1209600; // 14 days
 export function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
+  return [];
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/app/[state]/starting-soon/page.tsx
+++ b/app/[state]/starting-soon/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import StartingSoonClient from "./StartingSoonClient";
-import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
@@ -8,8 +7,17 @@ type Props = {
   params: Promise<{ state: string }>;
 };
 
+// On-demand ISR: generate no pages at build (keeps build memory low — see the
+// staticGenerationMaxConcurrency note in next.config). requireStateConfig()
+// 404s invalid states.
+export const dynamicParams = true;
+export const revalidate = 1209600; // 14 days
+// NOTE: this page is time-sensitive ("starting soon" / late-start classes), so
+// a 14-day TTL can show stale sections. The right freshness fix is on-demand
+// revalidation triggered by the scrape pipeline (revalidatePath) rather than a
+// timer — tracked with the build-decoupling follow-up.
 export function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
+  return [];
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,13 +4,23 @@ import createMDX from "@next/mdx";
 const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   experimental: {
-    // Default is 8 concurrent pages per worker × 3 workers = 24 pages
-    // rendering at once, each making multiple Supabase queries. That
-    // saturates the free-tier connection pool (~15 connections) and
-    // causes "Timed out acquiring connection" / statement_timeout errors
-    // that kill the build. Cap to 2 so total concurrency stays under the
-    // pool limit even with 3 workers (3 × 2 = 6 pages at once).
-    staticGenerationMaxConcurrency: 4,
+    // Two reasons to keep this low:
+    //  1. Supabase pool — default 8 pages/worker × 3 workers = 24 pages at
+    //     once, each running multiple queries, saturates the free-tier pool
+    //     (~15 conns) → "Timed out acquiring connection" build failures.
+    //  2. Memory — each in-flight page loads a state's course/program data;
+    //     several large states (CA 189k sections, TX) rendering at once
+    //     spiked peak RAM past Vercel's 8 GB build machine → OOM (exit 137).
+    //     A prior bump to 4 reintroduced the OOM. At 2, the build still hit
+    //     Supabase pool saturation locally (7 workers × 2 = 14 concurrent
+    //     pages > ~15-conn free-tier pool → "statement timeout" / connection
+    //     resets during static generation). Set to 1 so concurrent in-flight
+    //     pages = worker count, staying under the pool and minimizing RAM.
+    // The high-cardinality + data-heavy per-state pages now generate
+    // on-demand (empty generateStaticParams across course/subject/program/
+    // about/plan/results/starting-soon/programs), so build-time generation
+    // is minimal regardless — this cap is the belt to that suspenders.
+    staticGenerationMaxConcurrency: 1,
   },
   // Explicitly bundle every state's prereqs.json into the serverless
   // functions that PARSE it — only the API routes need the file content.


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is a deploy-reliability fix. Production has been **intermittently failing to deploy** with out-of-memory errors during the build, which is why today's merged work (Colorado, HI transfers, prereqs) only reached users once a build happened to squeak through. This makes the build pass **reliably with margin** instead of by luck, so the next state/data merge doesn't knock prod over again.

## The problem

Vercel builds sit right on the memory cliff. The deployment history tells the story: `17bba74` passed (17m53s), the next three commits **errored (OOM, exit 137)**, then `#944` passed again — same code, different outcome. Each new state/data merge (CO's +25,864 sections was the latest) tips it back over.

Root cause: per-state pages are statically generated at build time, and each loads that state's **full dataset** (CA = 189k sections); several large states render at once → memory spike (Vercel OOM) or Supabase free-tier pool saturation (local "statement timeout").

## The fix (two levers)

1. **Floor build-time generation.** Convert the 5 remaining data-heavy per-state page types to on-demand ISR (`generateStaticParams` → `[]`, `dynamicParams=true`, `revalidate=14d`): `about`, `plan`, `results`, `starting-soon`, `programs`. Combined with the already-deferred high-cardinality routes, the **only** thing generated at build is the 48 state-landing pages (kept static — they have a documented `dynamicParams=false` to avoid Search Console soft-404s) + homepage + blog. Pages render on first request and cache for 14 days.
2. **`staticGenerationMaxConcurrency` 4 → 1.** At 2, the build still saturated the ~15-conn free-tier Supabase pool (7 workers × 2 = 14 concurrent). At 1, concurrent pages = worker count — under the pool, and minimal peak RAM.

## Verification

- **Clean local build: 204 static pages in 27.5s, no OOM, no Supabase timeout.** (At concurrency 2 it hung at 153/204 with cascading connection timeouts.)
- `tsc --noEmit` clean.
- Build *time* is not worse despite concurrency 1 — flooring the pages means far fewer to generate, offsetting the lower parallelism.

## Durable follow-up (separate issue)

This stops the bleeding, but the permanent fix is to **decouple the build from data volume**: precompute small per-page manifests in the scrape pipeline (so pages read a tiny artifact, not the full dataset) + on-demand revalidation triggered by scrapes (so pages are static-fast *and* fresh-on-change, not on a 14-day timer). That makes the build cheap and OOM-immune regardless of how many states we add — retiring the recurring `fix(build): defer X to ISR` whack-a-mole. Filing as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)