### PR TITLE
Block git push to MERGED/CLOSED PR branches (prevents lost commits)

### DIFF
--- a/.claude/hooks/pre-push-merged-pr-guard.sh
+++ b/.claude/hooks/pre-push-merged-pr-guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# PreToolUse hook: blocks `git push` when the current branch's PR is already
+# MERGED or CLOSED on GitHub. Commits pushed after squash-merge become
+# orphaned dead commits on the remote branch — they never reach main and
+# are silently lost.
+#
+# Why: this has happened three times now — PRs #37 and #41 (lost edits the
+# user only noticed in prod), and PR #947 (Nebraska auto-add-state) where
+# a follow-up LPTC scraper commit was pushed seconds after the PR squash-
+# merged. CLAUDE.md has the rule ("Don't push to a PR branch after you've
+# told the user to merge") but guidance has now failed three times. This
+# hook makes it mechanically enforced.
+#
+# Heuristic:
+#   1. Only fires on `git push` (any form: bare, --set-upstream, with refs).
+#   2. Resolves the current branch via `git symbolic-ref`.
+#   3. Asks `gh pr list --head <branch> --state all` for the PR's state.
+#   4. If state is MERGED or CLOSED, BLOCK with a recovery hint.
+#
+# Pass-through cases (exit 0):
+#   - No `gh` CLI available (offline / unauthenticated)
+#   - Not in a git repo
+#   - Detached HEAD (no branch to look up)
+#   - No PR found for the branch (first push of a new branch)
+#   - PR state is OPEN or DRAFT (normal flow)
+#   - Push targets a different remote/ref than the branch's PR (e.g.
+#     pushing a local-only ref); err on the side of allowing.
+#
+# Exit codes:
+#   0 → allow
+#   2 → block (stderr shown to the model)
+
+set -euo pipefail
+
+PAYLOAD=$(cat)
+
+CMD=$(echo "$PAYLOAD" | /usr/bin/python3 -c '
+import sys, json
+p = json.load(sys.stdin).get("tool_input", {})
+print((p.get("command", "") or "").replace("\n", " "))
+' 2>/dev/null || echo "")
+
+# Only care about `git push`. Strip any leading `cd X && ` so we see the
+# real first command word. Avoids false-positives from commit-message
+# heredocs that mention "git push" in the body.
+FIRST_CMD=$(echo "$CMD" | /usr/bin/python3 -c '
+import sys, re
+cmd = sys.stdin.read().strip()
+cmd = re.sub(r"^cd\s+\S+\s*(&&|;)\s*", "", cmd)
+m = re.match(r"\s*(\S+)", cmd)
+print(m.group(1) if m else "")
+' 2>/dev/null || echo "")
+
+[ "$FIRST_CMD" = "git" ] || exit 0
+echo "$CMD" | grep -qE '^\s*(cd\s+\S+\s*(&&|;)\s*)?git\s+push\b' || exit 0
+
+# Need gh CLI.
+command -v gh >/dev/null 2>&1 || exit 0
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+[ -n "$BRANCH" ] || exit 0  # detached HEAD or not in a repo
+
+# Skip protected branch names — never block pushes to main/master/develop;
+# those are unusual and the user knows what they're doing.
+case "$BRANCH" in
+  main|master|develop) exit 0 ;;
+esac
+
+# Query GitHub. --state all so we see MERGED/CLOSED PRs, not just OPEN.
+# `-q '.[0].state'` returns empty when no PR exists.
+STATE=$(gh pr list --head "$BRANCH" --state all --json state -q '.[0].state' 2>/dev/null || echo "")
+
+case "$STATE" in
+  MERGED|CLOSED)
+    PR_NUM=$(gh pr list --head "$BRANCH" --state all --json number -q '.[0].number' 2>/dev/null || echo "?")
+    cat >&2 <<EOF
+❌ pre-push-merged-pr-guard: PR #${PR_NUM} for branch '${BRANCH}' is ${STATE}.
+
+Pushing more commits to a merged/closed PR branch creates orphaned dead
+commits — they live on the remote branch but never reach main, and are
+silently lost. This has happened on PRs #37, #41, and #947.
+
+To ship this work as a follow-up:
+  cd \$(git rev-parse --show-toplevel)/../..   # back to main checkout
+  WT=\$(scripts/new-pr-worktree.sh <slug>-followup)
+  cd "\$WT"
+  git cherry-pick <commit-sha>
+  git push -u origin claude/<slug>-followup
+  gh pr create ...
+
+If you genuinely need to push to this branch (rare — e.g. fixing a tag),
+bypass with: \`git -c core.hooksPath=/dev/null push\`
+EOF
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/test-pre-push-merged-pr-guard.sh
+++ b/.claude/hooks/test-pre-push-merged-pr-guard.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Test cases for pre-push-merged-pr-guard.sh.
+#
+# We mock `gh` and `git` by prepending a temp dir to PATH that contains
+# shims returning canned output. Each test feeds JSON on stdin (matching
+# the Bash PreToolUse hook payload) and asserts on exit code + stderr.
+
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pre-push-merged-pr-guard.sh"
+[ -x "$HOOK" ] || { echo "Hook not executable: $HOOK"; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0
+FAIL=0
+
+# ---- mocks ---------------------------------------------------------------
+make_gh_mock() {
+  # $1 = state to return for `gh pr list --json state`
+  # $2 = PR number to return for `--json number`
+  # Empty $1 means no PR found.
+  cat > "$TMP/gh" <<EOF
+#!/usr/bin/env bash
+# Mock gh — returns canned values.
+args="\$*"
+case "\$args" in
+  *--json\ state*) echo "${1:-}" ;;
+  *--json\ number*) echo "${2:-}" ;;
+  *) echo "" ;;
+esac
+EOF
+  chmod +x "$TMP/gh"
+}
+
+make_git_mock() {
+  # $1 = branch name to return for `git symbolic-ref --short HEAD`
+  cat > "$TMP/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "symbolic-ref --short HEAD") echo "${1:-}" ;;
+  *) /usr/bin/git "\$@" ;;
+esac
+EOF
+  chmod +x "$TMP/git"
+}
+
+# ---- assertion helper ----------------------------------------------------
+assert() {
+  local name="$1" expected_exit="$2" payload="$3" expected_stderr="${4:-}"
+  local stderr_file="$TMP/stderr"
+  local actual_exit=0
+  echo "$payload" | PATH="$TMP:$PATH" "$HOOK" 2>"$stderr_file" >/dev/null || actual_exit=$?
+  local actual_stderr=$(cat "$stderr_file")
+
+  if [ "$actual_exit" -ne "$expected_exit" ]; then
+    echo "✗ $name: exit $actual_exit (expected $expected_exit)"
+    [ -n "$actual_stderr" ] && echo "  stderr: $actual_stderr"
+    FAIL=$((FAIL+1)); return
+  fi
+  if [ -n "$expected_stderr" ] && ! echo "$actual_stderr" | grep -q "$expected_stderr"; then
+    echo "✗ $name: stderr missing '$expected_stderr'"
+    echo "  got: $actual_stderr"
+    FAIL=$((FAIL+1)); return
+  fi
+  echo "✓ $name"
+  PASS=$((PASS+1))
+}
+
+# ---- test cases ----------------------------------------------------------
+
+# 1. Non-git command passes through.
+make_gh_mock "MERGED" "947"
+make_git_mock "claude/foo"
+assert "non-git command (ls) passes" 0 \
+  '{"tool_input":{"command":"ls -la"}}'
+
+# 2. git command other than push passes through.
+assert "git status passes" 0 \
+  '{"tool_input":{"command":"git status"}}'
+
+assert "git commit passes" 0 \
+  '{"tool_input":{"command":"git commit -m foo"}}'
+
+# 3. git push on a branch with MERGED PR is BLOCKED.
+assert "git push on MERGED PR is blocked" 2 \
+  '{"tool_input":{"command":"git push"}}' \
+  "is MERGED"
+
+# 4. git push with -u flag on MERGED PR is blocked.
+assert "git push -u on MERGED PR is blocked" 2 \
+  '{"tool_input":{"command":"git push -u origin claude/foo"}}' \
+  "is MERGED"
+
+# 5. git push on CLOSED PR is BLOCKED.
+make_gh_mock "CLOSED" "947"
+assert "git push on CLOSED PR is blocked" 2 \
+  '{"tool_input":{"command":"git push"}}' \
+  "is CLOSED"
+
+# 6. git push on OPEN PR passes (normal case).
+make_gh_mock "OPEN" "947"
+assert "git push on OPEN PR passes" 0 \
+  '{"tool_input":{"command":"git push"}}'
+
+# 7. git push on DRAFT PR passes.
+make_gh_mock "DRAFT" "947"
+assert "git push on DRAFT PR passes" 0 \
+  '{"tool_input":{"command":"git push"}}'
+
+# 8. git push with no PR (first push) passes.
+make_gh_mock "" ""
+assert "git push with no PR (first push) passes" 0 \
+  '{"tool_input":{"command":"git push -u origin claude/new-branch"}}'
+
+# 9. git push on main passes (we explicitly allow protected branches).
+make_gh_mock "MERGED" "947"
+make_git_mock "main"
+assert "git push on main passes (protected branch)" 0 \
+  '{"tool_input":{"command":"git push"}}'
+
+make_git_mock "master"
+assert "git push on master passes (protected branch)" 0 \
+  '{"tool_input":{"command":"git push"}}'
+
+# 10. Detached HEAD passes (no branch to check).
+make_git_mock ""
+assert "detached HEAD passes" 0 \
+  '{"tool_input":{"command":"git push"}}'
+
+# 11. Leading "cd X && git push" is detected.
+make_git_mock "claude/foo"
+make_gh_mock "MERGED" "947"
+assert "cd X && git push on MERGED is blocked" 2 \
+  '{"tool_input":{"command":"cd /tmp/foo && git push"}}' \
+  "is MERGED"
+
+# 12. Heredoc mentioning "git push" in commit body is NOT misdetected as push.
+assert "git commit with 'git push' in body is allowed" 0 \
+  '{"tool_input":{"command":"git commit -m \"Reminder: dont git push without verifying\""}}'
+
+# 13. Malformed JSON payload passes (don't crash).
+assert "malformed JSON payload passes" 0 \
+  'not-json-at-all'
+
+# 14. Empty command passes.
+assert "empty command passes" 0 \
+  '{"tool_input":{"command":""}}'
+
+# 15. `git push --force` on MERGED is blocked (same rule).
+make_gh_mock "MERGED" "947"
+assert "git push --force on MERGED is blocked" 2 \
+  '{"tool_input":{"command":"git push --force"}}' \
+  "is MERGED"
+
+# ---- summary -------------------------------------------------------------
+echo
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[ $FAIL -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/pre-pr-build-check.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-push-merged-pr-guard.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,11 @@ Branch naming convention used so far: `claude/<state>-phase<N><letter>-<topic>` 
 
 Merging is the user's job — they click "Squash and merge" on GitHub. Don't run `gh pr merge` on their behalf unless they explicitly ask.
 
-**Don't push to a PR branch after you've told the user to merge.** GitHub squashes whatever is on the branch at merge-time; a commit pushed seconds after they click Merge becomes an orphaned dead commit on the remote branch and never reaches `main`. This has happened twice (PR #37 and PR #41). If you realize you need one more small edit after saying "go merge", either:
-1. Wait for the merge to land, then open a tiny follow-up PR, or
+**Don't push to a PR branch after you've told the user to merge.** GitHub squashes whatever is on the branch at merge-time; a commit pushed seconds after they click Merge becomes an orphaned dead commit on the remote branch and never reaches `main`. This has happened three times (PRs #37, #41, and #947). If you realize you need one more small edit after saying "go merge", either:
+1. Wait for the merge to land, then open a tiny follow-up PR (cherry-pick onto a fresh branch off `main`), or
 2. Grab the user's attention before they click Merge ("one more commit coming, hold on").
+
+The `pre-push-merged-pr-guard.sh` hook blocks `git push` when the current branch's PR is already MERGED or CLOSED. If you hit the block, don't bypass — cherry-pick onto a fresh worktree off `main` and open a follow-up PR. Run the test suite with `bash .claude/hooks/test-pre-push-merged-pr-guard.sh` (17 cases).
 
 Never push a commit and _hope_ the user hasn't merged yet. That's what caused the lost commits.
 


### PR DESCRIPTION
## What changes for someone using the site

Users see nothing new. This is a developer-facing safety hook — it prevents a class of bug where post-merge commits silently disappear.

## What changes on the technical front

Adds `.claude/hooks/pre-push-merged-pr-guard.sh`, a PreToolUse Bash hook that aborts `git push` when the current branch's PR is already MERGED or CLOSED on GitHub.

**Why this hook exists:** GitHub's squash-merge takes whatever is on the branch *at the moment the user clicks Merge*. A commit pushed seconds later lands on the remote branch but never reaches `main` — it becomes an orphaned dead commit. CLAUDE.md has had the rule for months (`"Don't push to a PR branch after you've told the user to merge"`) but guidance has now failed three times:

| PR | What was lost |
|---|---|
| #37 | small edit pushed after squash-merge |
| #41 | small edit pushed after squash-merge |
| #947 | Little Priest Tribal scraper (234 sections) — pushed ~2 min after #947 squash-merged |

The Nebraska LPTC case is what triggered this PR. Recovery for #947 is [#948](https://github.com/rohan-c0de/cc-coursemap/pull/948) (cherry-pick onto fresh branch).

## Hook behavior

- **Triggers only on** `git push` (bare, `-u`, `--force`, with refspecs — all handled). Strips leading `cd X && ` so the real first command word is what matters.
- **Resolves the current branch** via `git symbolic-ref --short HEAD`.
- **Asks GitHub** for the PR state via `gh pr list --head <branch> --state all`.
- **If state is `MERGED` or `CLOSED`**: exit 2 (block), print a recovery hint pointing the model at `scripts/new-pr-worktree.sh <slug>-followup`.
- **Pass-through cases** (exit 0): no PR found (first push of a new branch), state is OPEN/DRAFT, branch is `main`/`master`/`develop`, detached HEAD, `gh` CLI missing, malformed payload.
- **Bypass** (rare, last-resort only): `git -c core.hooksPath=/dev/null push`.

## Test suite

17 cases in `.claude/hooks/test-pre-push-merged-pr-guard.sh`, mocking `gh` and `git symbolic-ref` so the suite runs offline:

- ✅ non-git commands pass
- ✅ git status / git commit pass
- ✅ git push on MERGED PR blocked (also tested with `-u origin <branch>`)
- ✅ git push on CLOSED PR blocked
- ✅ git push on OPEN / DRAFT PRs passes
- ✅ git push with no PR (first push of new branch) passes
- ✅ git push on main / master passes (protected branches)
- ✅ detached HEAD passes
- ✅ `cd X && git push` detected (cwd-prefix shouldn't fool the matcher)
- ✅ git commit with `git push` mentioned in commit body NOT misdetected
- ✅ malformed JSON / empty command pass
- ✅ `git push --force` on MERGED blocked

Run: `bash .claude/hooks/test-pre-push-merged-pr-guard.sh`

## Composition with existing hooks

Slots in next to `pre-pr-build-check.sh` in the PreToolUse Bash matcher chain. Independent: this hook only inspects branch + PR state; the build-check hook only inspects auto-add-state result JSON. No overlap.

## Test plan

- [ ] Hook test suite passes locally (17/17)
- [ ] After merge, deliberately try `git push` on a merged branch and confirm the block fires
- [ ] Confirm normal pushes on OPEN PRs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)