### PR TITLE
chore(ne): curate Nebraska state metadata + fix runner type errors

### DIFF
--- a/data/state-metadata.json
+++ b/data/state-metadata.json
@@ -237,6 +237,16 @@
       "defaultZipCity": "Raleigh",
       "seniorWaiver": null
     },
+    "ne": {
+      "fullName": "Nebraska",
+      "fipsCode": "31",
+      "systemName": "NCCA",
+      "systemFullName": "Nebraska Community College Association",
+      "systemUrl": "https://nebraskacommunitycolleges.org/",
+      "defaultZip": "68508",
+      "defaultZipCity": "Lincoln",
+      "seniorWaiver": null
+    },
     "nh": {
       "fullName": "New Hampshire",
       "fipsCode": "33",

--- a/lib/states/ne/config.ts
+++ b/lib/states/ne/config.ts
@@ -5,21 +5,37 @@ const neConfig: StateConfig = {
   name: "Nebraska",
   systemName: "NCCA",
   systemFullName: "Nebraska Community College Association",
-  systemUrl: "https://ncca.ne.gov/",
+  systemUrl: "https://nebraskacommunitycolleges.org/",
   collegeCount: 9,
 
+  // Nebraska has no statewide senior tuition-waiver statute. Individual
+  // colleges set their own policy — e.g. Mid-Plains CC offers a 62+ rate
+  // (institutional, not state-mandated). Leave null at the state level.
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  // Top 8 by section count across all 7 scraped NE colleges (9,636 sections).
+  // Computed once from data/ne/courses; refresh periodically as new colleges
+  // come online. ACFS 1015 = Adult Coping & Family Skills (workforce);
+  // ENGL 1010 dominates with 310 sections statewide.
+  popularCourses: [
+    "ENGL 1010",
+    "MATH 1150",
+    "PSYC 1810",
+    "ENGL 1020",
+    "SPCH 1110",
+    "BIOS 1010",
+    "SOCI 1010",
+    "ACCT 1200",
+  ],
   defaultZip: "68508",
   defaultZipCity: "Lincoln",
 
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    "https://ncca.ne.gov/",
+    "https://nebraskacommunitycolleges.org/",
 
   collegeCoursesUrl: (_collegeSlug: string) =>
-    "https://ncca.ne.gov/",
+    "https://nebraskacommunitycolleges.org/",
 
   branding: {
     siteName: "Community College Path Nebraska",
@@ -36,30 +52,12 @@ const neConfig: StateConfig = {
   },
   scrapers: {
     courses: [
-      {
-        scripts: ["scripts/ne/scrape-colleague.ts"],
-        runner: "node" as const,
-      },
-      {
-        scripts: ["scripts/ne/scrape-banner-ssb.ts"],
-        runner: "node" as const,
-      },
-      {
-        scripts: ["scripts/ne/scrape-nicc.ts"],
-        runner: "node" as const,
-      },
-      {
-        scripts: ["scripts/ne/scrape-mpcc.ts"],
-        runner: "node" as const,
-      },
-      {
-        scripts: ["scripts/ne/scrape-wncc.ts"],
-        runner: "node" as const,
-      },
-      {
-        scripts: ["scripts/ne/scrape-lptc.ts"],
-        runner: "node" as const,
-      },
+      { scripts: ["scripts/ne/scrape-colleague.ts"], runner: "playwright" },
+      { scripts: ["scripts/ne/scrape-banner-ssb.ts"], runner: "http" },
+      { scripts: ["scripts/ne/scrape-nicc.ts"], runner: "http" },
+      { scripts: ["scripts/ne/scrape-mpcc.ts"], runner: "http" },
+      { scripts: ["scripts/ne/scrape-wncc.ts"], runner: "http" },
+      { scripts: ["scripts/ne/scrape-lptc.ts"], runner: "http" },
     ],
     prereqs: { source: "aggregate-from-courses" as const },
     // manual-only: transfers — no articulation portal registered for NE.


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible. This is a config-hygiene PR that fills in the placeholder values left behind by the original Nebraska bootstrap (#947) and corrects a type error that snuck through.

## What changes on the technical front

Three small improvements to `lib/states/ne/config.ts` and `data/state-metadata.json`:

| Field | Was | Now | Why |
|---|---|---|---|
| `systemUrl` (state-metadata.json + config) | `https://ncca.ne.gov/` (placeholder, doesn't exist) | `https://nebraskacommunitycolleges.org/` | Real NCCA homepage, verified via web search |
| `popularCourses` (config) | `[]` | `["ENGL 1010", "MATH 1150", "PSYC 1810", "ENGL 1020", "SPCH 1110", "BIOS 1010", "SOCI 1010", "ACCT 1200"]` | Top 8 by section count across 9,636 scraped sections — data-driven, not guessed |
| `data/state-metadata.json` | no `ne` entry | full entry with NCCA name + fipsCode 31 + defaults | Re-bootstrapping NE later would otherwise regenerate placeholders again |
| `runner: "node"` (6 places in config.ts) | typecheck error (`"node"` not in `"http" \| "playwright"`) | `"playwright"` for Colleague, `"http"` for the others | Slipped past #947 because that PR didn't run typecheck; cron scheduler would have skipped these jobs |
| `seniorWaiver` (state-metadata + config) | `null` (unverified) | `null` (verified — see below) | confirmed no statewide statute exists |

**Senior-waiver verification:** searched the Nebraska Revised Statutes; the relevant chapters (80-411, 85-2616 series) cover veterans' and first-responders' dependents only. Some individual colleges (e.g. [Mid-Plains CC](https://www.mpcc.edu/cost-and-aid/)) offer a 62+ rate as institutional policy, but it's not state-mandated. `seniorWaiver: null` stays; added an inline comment explaining the institutional-vs-statutory distinction so the next person doesn't redo the research.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run check:scrapers` passes (49 states × 4 datatypes accounted for)
- [ ] After merge, Vercel rebuild — confirm `/ne` still renders and shows updated NCCA URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)