### PR TITLE
perf(build): precompute landing-page summary manifests (#946 slice 1)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -11,6 +11,7 @@ import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getArticlesByState, getStateTopicLinks, categoryLabel } from "@/lib/blog";
 import { getQualifyingProgramSlugs, getProgramBySlug } from "@/lib/programs";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
+import { loadStateSummary } from "@/lib/state-summary";
 
 type Props = {
   params: Promise<{ state: string }>;
@@ -54,13 +55,30 @@ export default async function HomePage({ params }: Props) {
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
   // Phase 4 hub links — only surfaced when underlying pages would render.
-  // Loading both in parallel; failures are non-fatal (page still renders
-  // without the section).
-  const [programSlugs, onlineData] = await Promise.all([
-    getQualifyingProgramSlugs(state).catch(() => [] as string[]),
-    loadOnlineData(state).catch(() => null),
-  ]);
-  const showOnline = onlineQualifies(onlineData);
+  // #946: prefer the precomputed summary manifest so the build does no heavy
+  // data loading. Fall back to the live loaders when the manifest is absent
+  // (e.g. a brand-new state before the precompute step has run) so behavior is
+  // never worse than before. Both loaders are non-fatal (section just hides).
+  const summary = loadStateSummary(state);
+  let programSlugs: string[];
+  let showOnline: boolean;
+  let onlineSections: number;
+  let onlineColleges: number;
+  if (summary) {
+    programSlugs = summary.programSlugs;
+    showOnline = summary.showOnline;
+    onlineSections = summary.onlineSections;
+    onlineColleges = summary.onlineColleges;
+  } else {
+    const [slugs, onlineData] = await Promise.all([
+      getQualifyingProgramSlugs(state).catch(() => [] as string[]),
+      loadOnlineData(state).catch(() => null),
+    ]);
+    programSlugs = slugs;
+    showOnline = onlineQualifies(onlineData);
+    onlineSections = onlineData?.totalSections ?? 0;
+    onlineColleges = onlineData?.totalColleges ?? 0;
+  }
 
   const breadcrumbLd = {
     "@context": "https://schema.org",
@@ -290,7 +308,7 @@ export default async function HomePage({ params }: Props) {
                   Online Courses
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-slate-400">
-                  {onlineData!.totalSections} online sections across {onlineData!.totalColleges} {config.systemName} colleges this term.
+                  {onlineSections} online sections across {onlineColleges} {config.systemName} colleges this term.
                 </p>
               </Link>
             )}

--- a/data/ak/summary.json
+++ b/data/ak/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 44,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:39.733Z"
+}

--- a/data/al/summary.json
+++ b/data/al/summary.json
@@ -1,0 +1,21 @@
+{
+  "showOnline": true,
+  "onlineSections": 3869,
+  "onlineColleges": 20,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:23:28.053Z"
+}

--- a/data/ar/summary.json
+++ b/data/ar/summary.json
@@ -1,0 +1,13 @@
+{
+  "showOnline": false,
+  "onlineSections": 438,
+  "onlineColleges": 2,
+  "programSlugs": [
+    "liberal-arts",
+    "biology",
+    "history",
+    "mathematics",
+    "english"
+  ],
+  "generatedAt": "2026-06-01T00:25:11.979Z"
+}

--- a/data/az/summary.json
+++ b/data/az/summary.json
@@ -1,0 +1,20 @@
+{
+  "showOnline": true,
+  "onlineSections": 3044,
+  "onlineColleges": 16,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:09.009Z"
+}

--- a/data/ca/summary.json
+++ b/data/ca/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 22802,
+  "onlineColleges": 47,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:02.159Z"
+}

--- a/data/co/summary.json
+++ b/data/co/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 4327,
+  "onlineColleges": 14,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:51.355Z"
+}

--- a/data/ct/summary.json
+++ b/data/ct/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 2072,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:34.322Z"
+}

--- a/data/dc/summary.json
+++ b/data/dc/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 140,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:07.285Z"
+}

--- a/data/de/summary.json
+++ b/data/de/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 389,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:17.261Z"
+}

--- a/data/fl/summary.json
+++ b/data/fl/summary.json
@@ -1,0 +1,17 @@
+{
+  "showOnline": true,
+  "onlineSections": 13102,
+  "onlineColleges": 21,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "psychology",
+    "mathematics",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:58.797Z"
+}

--- a/data/ga/summary.json
+++ b/data/ga/summary.json
@@ -1,0 +1,18 @@
+{
+  "showOnline": true,
+  "onlineSections": 3481,
+  "onlineColleges": 19,
+  "programSlugs": [
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:14.222Z"
+}

--- a/data/hi/summary.json
+++ b/data/hi/summary.json
@@ -1,0 +1,19 @@
+{
+  "showOnline": true,
+  "onlineSections": 10627,
+  "onlineColleges": 6,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:39.935Z"
+}

--- a/data/ia/summary.json
+++ b/data/ia/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 1321,
+  "onlineColleges": 3,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:09.729Z"
+}

--- a/data/id/summary.json
+++ b/data/id/summary.json
@@ -1,0 +1,15 @@
+{
+  "showOnline": true,
+  "onlineSections": 917,
+  "onlineColleges": 3,
+  "programSlugs": [
+    "business-administration",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english"
+  ],
+  "generatedAt": "2026-06-01T00:25:43.052Z"
+}

--- a/data/il/summary.json
+++ b/data/il/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 3168,
+  "onlineColleges": 10,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:32.385Z"
+}

--- a/data/ky/summary.json
+++ b/data/ky/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 5638,
+  "onlineColleges": 16,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:23:23.922Z"
+}

--- a/data/la/summary.json
+++ b/data/la/summary.json
@@ -1,0 +1,18 @@
+{
+  "showOnline": true,
+  "onlineSections": 1831,
+  "onlineColleges": 11,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:18.312Z"
+}

--- a/data/ma/summary.json
+++ b/data/ma/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 2659,
+  "onlineColleges": 8,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:52.012Z"
+}

--- a/data/md/summary.json
+++ b/data/md/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 3499,
+  "onlineColleges": 11,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:11.103Z"
+}

--- a/data/me/summary.json
+++ b/data/me/summary.json
@@ -1,0 +1,19 @@
+{
+  "showOnline": true,
+  "onlineSections": 1265,
+  "onlineColleges": 7,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:37.823Z"
+}

--- a/data/mi/summary.json
+++ b/data/mi/summary.json
@@ -1,0 +1,21 @@
+{
+  "showOnline": true,
+  "onlineSections": 2140,
+  "onlineColleges": 8,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:23:58.717Z"
+}

--- a/data/mn/summary.json
+++ b/data/mn/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 5734,
+  "onlineColleges": 26,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:15.259Z"
+}

--- a/data/mo/summary.json
+++ b/data/mo/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 1607,
+  "onlineColleges": 5,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:12.931Z"
+}

--- a/data/ms/summary.json
+++ b/data/ms/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 1,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:23:43.405Z"
+}

--- a/data/mt/summary.json
+++ b/data/mt/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 44,
+  "onlineColleges": 3,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:24:46.539Z"
+}

--- a/data/nc/summary.json
+++ b/data/nc/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 6277,
+  "onlineColleges": 33,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:00.774Z"
+}

--- a/data/nd/summary.json
+++ b/data/nd/summary.json
@@ -1,0 +1,20 @@
+{
+  "showOnline": true,
+  "onlineSections": 814,
+  "onlineColleges": 5,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:34.181Z"
+}

--- a/data/nh/summary.json
+++ b/data/nh/summary.json
@@ -1,0 +1,14 @@
+{
+  "showOnline": true,
+  "onlineSections": 336,
+  "onlineColleges": 7,
+  "programSlugs": [
+    "business-administration",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "mathematics",
+    "english"
+  ],
+  "generatedAt": "2026-06-01T00:22:48.527Z"
+}

--- a/data/nj/summary.json
+++ b/data/nj/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 2126,
+  "onlineColleges": 5,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:44.984Z"
+}

--- a/data/nm/summary.json
+++ b/data/nm/summary.json
@@ -1,0 +1,15 @@
+{
+  "showOnline": true,
+  "onlineSections": 1415,
+  "onlineColleges": 6,
+  "programSlugs": [
+    "business-administration",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:21.529Z"
+}

--- a/data/nv/summary.json
+++ b/data/nv/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 1861,
+  "onlineColleges": 4,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:05.672Z"
+}

--- a/data/ny/summary.json
+++ b/data/ny/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 5382,
+  "onlineColleges": 20,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:24.123Z"
+}

--- a/data/oh/summary.json
+++ b/data/oh/summary.json
@@ -1,0 +1,19 @@
+{
+  "showOnline": true,
+  "onlineSections": 3378,
+  "onlineColleges": 5,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english"
+  ],
+  "generatedAt": "2026-06-01T00:23:47.062Z"
+}

--- a/data/ok/summary.json
+++ b/data/ok/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 0,
+  "onlineColleges": 0,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:47.783Z"
+}

--- a/data/or/summary.json
+++ b/data/or/summary.json
@@ -1,0 +1,16 @@
+{
+  "showOnline": true,
+  "onlineSections": 1611,
+  "onlineColleges": 9,
+  "programSlugs": [
+    "nursing",
+    "computer-science",
+    "early-childhood-education",
+    "criminal-justice",
+    "psychology",
+    "welding",
+    "mathematics",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:54.127Z"
+}

--- a/data/pa/summary.json
+++ b/data/pa/summary.json
@@ -1,0 +1,23 @@
+{
+  "showOnline": true,
+  "onlineSections": 2894,
+  "onlineColleges": 7,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:41.075Z"
+}

--- a/data/ri/summary.json
+++ b/data/ri/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 607,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:26.890Z"
+}

--- a/data/sc/summary.json
+++ b/data/sc/summary.json
@@ -1,0 +1,22 @@
+{
+  "showOnline": true,
+  "onlineSections": 2001,
+  "onlineColleges": 10,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "accounting",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:04.407Z"
+}

--- a/data/sd/summary.json
+++ b/data/sd/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 23,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:25.026Z"
+}

--- a/data/tn/summary.json
+++ b/data/tn/summary.json
@@ -1,0 +1,17 @@
+{
+  "showOnline": true,
+  "onlineSections": 2756,
+  "onlineColleges": 12,
+  "programSlugs": [
+    "business-administration",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:22:20.670Z"
+}

--- a/data/tx/summary.json
+++ b/data/tx/summary.json
@@ -1,0 +1,20 @@
+{
+  "showOnline": true,
+  "onlineSections": 7273,
+  "onlineColleges": 20,
+  "programSlugs": [
+    "business-administration",
+    "accounting",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:24:20.094Z"
+}

--- a/data/ut/summary.json
+++ b/data/ut/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 1246,
+  "onlineColleges": 2,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:28.423Z"
+}

--- a/data/va/summary.json
+++ b/data/va/summary.json
@@ -1,0 +1,24 @@
+{
+  "showOnline": true,
+  "onlineSections": 8481,
+  "onlineColleges": 23,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "computer-science",
+    "accounting",
+    "early-childhood-education",
+    "criminal-justice",
+    "liberal-arts",
+    "engineering",
+    "biology",
+    "psychology",
+    "welding",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:21:56.916Z"
+}

--- a/data/vt/summary.json
+++ b/data/vt/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 559,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:30.184Z"
+}

--- a/data/wa/summary.json
+++ b/data/wa/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 0,
+  "onlineColleges": 0,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:30.476Z"
+}

--- a/data/wi/summary.json
+++ b/data/wi/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": true,
+  "onlineSections": 1755,
+  "onlineColleges": 4,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:25:45.613Z"
+}

--- a/data/wv/summary.json
+++ b/data/wv/summary.json
@@ -1,0 +1,7 @@
+{
+  "showOnline": false,
+  "onlineSections": 195,
+  "onlineColleges": 1,
+  "programSlugs": [],
+  "generatedAt": "2026-06-01T00:22:54.842Z"
+}

--- a/data/wy/summary.json
+++ b/data/wy/summary.json
@@ -1,0 +1,19 @@
+{
+  "showOnline": true,
+  "onlineSections": 273,
+  "onlineColleges": 3,
+  "programSlugs": [
+    "nursing",
+    "business-administration",
+    "accounting",
+    "liberal-arts",
+    "biology",
+    "psychology",
+    "automotive-technology",
+    "history",
+    "mathematics",
+    "english",
+    "art"
+  ],
+  "generatedAt": "2026-06-01T00:25:36.951Z"
+}

--- a/lib/state-summary.ts
+++ b/lib/state-summary.ts
@@ -1,0 +1,59 @@
+/**
+ * state-summary.ts — per-state precomputed page-summary manifests (#946).
+ *
+ * The state-landing page (`app/[state]/page.tsx`) renders a few *derived*
+ * values that each require loading a state's full dataset (online-course
+ * counts, qualifying program slugs, statewide insights). Computing those at
+ * build time, for every state, is what pushed the Vercel build into OOM /
+ * Supabase-pool-saturation (see next.config + #946).
+ *
+ * Instead, a precompute step (`scripts/build-state-summaries.ts`, run in the
+ * scrape pipeline — NOT the deploy build) writes a tiny committed manifest per
+ * state to `data/{state}/summary.json`. Pages read the manifest, so the build
+ * does no heavy data loading and stays cheap regardless of state count.
+ *
+ * This first slice (#946 step 1) covers `showOnline` + `programSlugs`. The
+ * heavier statewide-insights prose is migrated in a follow-up. Callers should
+ * treat a missing manifest as "not precomputed yet" and fall back to the live
+ * loaders, so behavior is never worse than before and brand-new states work
+ * before the precompute has run.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+export interface StateSummary {
+  /** Whether the state has enough online-course data to surface the online hub link. */
+  showOnline: boolean;
+  /** Online section count rendered in the hub callout (0 when showOnline is false). */
+  onlineSections: number;
+  /** Online-offering college count rendered in the hub callout. */
+  onlineColleges: number;
+  /** Slugs of programs that qualify for the programs hub (have a renderable plan). */
+  programSlugs: string[];
+  /** ISO timestamp the manifest was generated (provenance/freshness). */
+  generatedAt: string;
+}
+
+/**
+ * Read a state's precomputed summary manifest. Returns null when the file is
+ * absent or unparseable — callers fall back to live loaders in that case.
+ * Synchronous fs read: only invoked from server components at build / ISR time.
+ */
+export function loadStateSummary(state: string): StateSummary | null {
+  try {
+    const file = path.join(process.cwd(), "data", state, "summary.json");
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.showOnline === "boolean" &&
+      Array.isArray(parsed.programSlugs)
+    ) {
+      return parsed as StateSummary;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm run build:css && npm run build:transfer-universities-cache && npm run build:transfer-coverage-rollup && next build",
     "build:transfer-universities-cache": "tsx scripts/build-transfer-universities-cache.ts",
     "build:transfer-coverage-rollup": "tsx scripts/build-transfer-coverage-rollup.ts",
+    "build:state-summaries": "tsx scripts/build-state-summaries.ts",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",

--- a/scripts/build-state-summaries.ts
+++ b/scripts/build-state-summaries.ts
@@ -1,0 +1,74 @@
+/**
+ * build-state-summaries.ts — precompute per-state landing-page summaries (#946).
+ *
+ * Runs the heavy per-state loaders ONCE, offline (in the scrape pipeline, not
+ * the deploy build), and writes a tiny `data/{state}/summary.json` manifest the
+ * state-landing page reads. This decouples the build from data volume: the
+ * build no longer loads full datasets for every state's landing page, so it
+ * stays cheap and OOM-immune as the state count grows.
+ *
+ * Sequential by design — running all states concurrently is exactly what
+ * saturated the free-tier Supabase pool during static generation. One state at
+ * a time keeps connections well under the limit.
+ *
+ * Usage:
+ *   npx tsx scripts/build-state-summaries.ts            # all registered states
+ *   npx tsx scripts/build-state-summaries.ts va nc      # specific states
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { getAllStates } from "../lib/states/registry";
+import { loadOnlineData, onlineQualifies } from "../lib/online";
+import { getQualifyingProgramSlugs } from "../lib/programs";
+import type { StateSummary } from "../lib/state-summary";
+
+async function buildOne(state: string): Promise<StateSummary> {
+  // Mirror the landing page's own failure handling: a loader error degrades to
+  // "section hidden" rather than aborting the whole manifest.
+  const [programSlugs, onlineData] = await Promise.all([
+    getQualifyingProgramSlugs(state).catch(() => [] as string[]),
+    loadOnlineData(state).catch(() => null),
+  ]);
+  return {
+    showOnline: onlineQualifies(onlineData),
+    onlineSections: onlineData?.totalSections ?? 0,
+    onlineColleges: onlineData?.totalColleges ?? 0,
+    programSlugs,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  const states =
+    args.length > 0 ? args : getAllStates().map((s) => s.slug);
+
+  console.log(`Building state summaries for ${states.length} state(s)...\n`);
+  let written = 0;
+  for (const state of states) {
+    try {
+      const summary = await buildOne(state);
+      const outDir = path.join(process.cwd(), "data", state);
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outDir, "summary.json"),
+        JSON.stringify(summary, null, 2) + "\n",
+      );
+      written++;
+      console.log(
+        `  ${state}: showOnline=${summary.showOnline} programs=${summary.programSlugs.length}`,
+      );
+    } catch (e) {
+      console.error(
+        `  ${state}: FAILED — ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
+  console.log(`\n✓ Wrote ${written}/${states.length} summary manifests.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is a build-performance / reliability change, the first concrete step on the durable fix behind the OOM crisis (#946). The state-landing pages now read a tiny precomputed file instead of loading each state's full course/program dataset at build time, so the build does less heavy work and is less likely to tip into OOM as we add states toward 50. The online-courses callout and program links render identically (verified values match).

## What changed technically

The state-landing page (`app/[state]/page.tsx`) renders derived values — online-section/college totals and qualifying program slugs — that each required loading a state's full dataset at build, for all 48 states. That's a chunk of the data loading that caused the Vercel OOM / Supabase pool saturation (#945 only mitigated it with concurrency 1).

This precomputes those values **once, offline** (in the scrape pipeline — not the deploy build) into a small committed manifest the page reads:

- **`lib/state-summary.ts`** — `StateSummary` type + `loadStateSummary()` (returns `null` → graceful fallback).
- **`scripts/build-state-summaries.ts`** — sequential precompute (sequential by design; concurrent is what saturated the pool). `npm run build:state-summaries`.
- **`app/[state]/page.tsx`** — reads the manifest for `showOnline` / online totals / `programSlugs`; **falls back to the live loaders when the manifest is absent**, so a brand-new state works before the precompute has run and behavior is never worse than today.
- **`data/{state}/summary.json`** — 48 manifests generated (e.g. `ga`: `showOnline:true, onlineSections:3481, onlineColleges:19, programSlugs:[10]`).

## Scope (this is slice 1 of #946)

Removes **2 of the 3** heavy landing-page loaders (`loadOnlineData`, `getQualifyingProgramSlugs`). The third — `StateContext` statewide insights (`loadAllCourses`) — plus **auto-refresh wiring** in the scrape pipeline and **on-demand revalidation** (so manifests stay fresh on data change, not on a timer) are the next slices, tracked in #946. Until auto-refresh lands, manifests are a committed snapshot (regenerate with `npm run build:state-summaries`); the derived values change rarely, and the live-loader fallback covers any gap.

## Verification

- `tsc --noEmit` clean.
- Full build completes: `✓ 204/204 static pages`, route table prints.
- Manifest values spot-checked against live loaders (match).
- (Local page-gen was slow this run only due to transient Supabase `fetch failed` errors in my environment — non-fatal/caught; #945 confirmed this builds fast on Vercel.)

Relates to #946 (durable build-decoupling) and #945 (interim hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)