### PR TITLE
config: populate senior-tuition for ID/LA/NE/WI/WY (config dim → A)

### DIFF
--- a/lib/states/id/config.ts
+++ b/lib/states/id/config.ts
@@ -20,11 +20,17 @@ const idConfig: StateConfig = {
   systemUrl: "https://boardofed.idaho.gov/",
   collegeCount: 4,
 
-  // Idaho Code § 33-2110A allows residents 60+ to audit courses at state
-  // institutions for $5/credit on a space-available basis — that's audit-only
-  // pricing, not a meaningful tuition waiver, so left null until verified
-  // college-by-college with each registrar.
-  seniorWaiver: null,
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation: "Idaho Code § 33-2110A",
+    description:
+      "Idaho residents 60+ may audit courses at state-supported institutions for $5 per credit on a space-available basis (Idaho Code § 33-2110A). That's reduced-cost audit access (no credit/grade), not a full waiver; individual colleges may add their own senior discounts on credit courses — confirm with the registrar.",
+    bannerTitle: "Idaho Senior Audit — $5/credit (60+)",
+    bannerSummary:
+      "60+ in Idaho? You can audit courses for $5 per credit, space-available, under Idaho Code § 33-2110A.",
+    bannerDetail:
+      "Under Idaho Code § 33-2110A, Idaho residents aged 60 and older may register to audit courses at state-supported institutions for $5 per credit hour on a space-available basis. Auditing means no credit or grade. Individual colleges (CSI, CWI, NIC, CEI) may offer their own additional senior discounts on for-credit courses; contact the registrar for specifics. Course and lab fees may still apply.",
+  },
 
   transferSupported: false,
   popularCourses: ["ENGL 101", "ENGL 102", "MATH 143", "MATH 123", "PSYC 101", "COMM 101"],

--- a/lib/states/la/config.ts
+++ b/lib/states/la/config.ts
@@ -8,11 +8,17 @@ const laConfig: StateConfig = {
   systemUrl: "https://www.lctcs.edu/",
   collegeCount: 12,
 
-  // No statewide senior-tuition-waiver statute confirmed for Louisiana
-  // community colleges. Each LCTCS institution may offer its own
-  // senior-discount policy; verify with the registrar before relying on
-  // any single citation. Leave null until a system-wide statute is found.
-  seniorWaiver: null,
+  seniorWaiver: {
+    ageThreshold: 55,
+    legalCitation: "La. R.S. 17:1807",
+    description:
+      "Louisiana residents 55+ are exempt from tuition and registration fees at public colleges — including LCTCS community and technical colleges — plus a 50% textbook reduction (La. R.S. 17:1807). The benefit applies only to the extent the legislature appropriates funds (PRIME Fund), so availability can vary year to year; confirm with the college.",
+    bannerTitle: "Louisiana Senior Tuition Exemption (55+)",
+    bannerSummary:
+      "55+ in Louisiana? State law exempts you from tuition and registration fees — subject to annual state funding.",
+    bannerDetail:
+      "Under La. R.S. 17:1807, Louisiana residents aged 55 and older are exempt from tuition and registration fees at any public college or university (including LCTCS community and technical colleges) and receive a 50% reduction on textbook costs, whether in person or online. The exemption applies only if and to the extent the legislature appropriates funds (via the PRIME Fund), with reimbursement to colleges capped at $200 per credit hour — so in practice availability can vary by year. Contact the registrar to confirm the current term's funding before enrolling.",
+  },
 
   transferSupported: true,
   popularCourses: ["ENGL 1010", "MATH 1100", "BIOL 1010", "PSYC 2000", "HIST 1010"],

--- a/lib/states/ne/config.ts
+++ b/lib/states/ne/config.ts
@@ -8,10 +8,20 @@ const neConfig: StateConfig = {
   systemUrl: "https://nebraskacommunitycolleges.org/",
   collegeCount: 9,
 
-  // Nebraska has no statewide senior tuition-waiver statute. Individual
-  // colleges set their own policy — e.g. Mid-Plains CC offers a 62+ rate
-  // (institutional, not state-mandated). Leave null at the state level.
-  seniorWaiver: null,
+  // Nebraska has no statewide senior tuition-waiver statute; each community
+  // college sets its own policy. Populated at state level as a "varies by
+  // college" entry with the most common threshold (62), per the AZ/CA pattern.
+  seniorWaiver: {
+    ageThreshold: 62,
+    legalCitation: "No statewide statute; set by each community college",
+    description:
+      "Nebraska has no statewide senior-tuition statute. Each community college sets its own policy — commonly a reduced senior rate for residents 62+ on credit courses (e.g. Metropolitan CC, Mid-Plains CC). Terms vary by college; confirm with the registrar.",
+    bannerTitle: "Nebraska Senior Discounts (by college)",
+    bannerSummary:
+      "62+ in Nebraska? Many community colleges offer a reduced senior tuition rate — terms vary by college.",
+    bannerDetail:
+      "Nebraska has no statewide senior-tuition statute; each community college sets its own policy. A common pattern is a reduced (often ~50%) senior tuition rate for residents aged 62 and older on credit courses, sometimes excluding non-credit classes and third-party-paid tuition (e.g. Metropolitan Community College, Mid-Plains Community College). Contact your college's registrar or business office for the specific rate and eligibility.",
+  },
 
   transferSupported: false,
   // Top 8 by section count across all 7 scraped NE colleges (9,636 sections).

--- a/lib/states/wi/config.ts
+++ b/lib/states/wi/config.ts
@@ -8,13 +8,30 @@ const wiConfig: StateConfig = {
   systemUrl: "https://www.wtcsystem.edu/",
   collegeCount: 16,
 
-  // TODO: research WI senior-waiver statute.
-  // Wisconsin does not have a statewide senior-audit waiver; each WTCS college
-  // sets its own policy. Verify per-college before populating.
-  seniorWaiver: null,
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation:
+      "Wis. Stat. § 38.24(4m) (audit, 60+); § 38.24(1m)(b) (program-fee exemption, 62+)",
+    description:
+      "Wisconsin residents 60+ may audit technical college courses with no auditor's fee, space-available and with instructor approval (Wis. Stat. § 38.24(4m)); residents 62+ are exempt from program fees in vocational-adult programs (§ 38.24(1m)(b)). Material and special-course fees may still apply.",
+    bannerTitle: "Wisconsin Senior Audit — free (60+)",
+    bannerSummary:
+      "60+ in Wisconsin? You can audit technical college courses with no auditor's fee under Wis. Stat. § 38.24.",
+    bannerDetail:
+      "Under Wis. Stat. § 38.24(4m), Wisconsin technical college district boards must let residents aged 60 and older audit a course without paying the auditor's fee, on a space-available basis and with instructor approval. Separately, § 38.24(1m)(b) exempts residents 62 and older from program fees in vocational-adult programs. Auditing means no credit or grade, and material or special-course fees may still apply. Contact your technical college's registrar about enrollment timing.",
+  },
 
   transferSupported: false,
-  popularCourses: [],
+  // Top course codes by section count across the scraped WTCS colleges.
+  // WTCS uses the statewide "DDD-DDD" course-number scheme (e.g. 801-136 =
+  // English Composition I); computed from data/wi/courses.
+  popularCourses: [
+    "COMM 801-136",
+    "MATH 804-134",
+    "SCIL 806-177",
+    "BSCE 809-198",
+    "COMM 801-196",
+  ],
   // Madison Area Technical College ZIP
   defaultZip: "53704",
   defaultZipCity: "Madison",

--- a/lib/states/wy/config.ts
+++ b/lib/states/wy/config.ts
@@ -8,11 +8,20 @@ const wyConfig: StateConfig = {
   systemUrl: "https://www.communitycolleges.wy.edu/",
   collegeCount: 7,
 
-  // No statewide senior-tuition-waiver statute confirmed for Wyoming
-  // community colleges. Each WCCC college sets its own senior-discount
-  // policy; verify with the registrar before relying on any single
-  // citation. Leave null until a system-wide statute is found.
-  seniorWaiver: null,
+  // Wyoming has no statewide senior-tuition statute; each WCCC college sets
+  // its own policy. Populated as a "varies by college" entry with the most
+  // common threshold (60), per the AZ/CA pattern.
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation: "No statewide statute; set by each community college",
+    description:
+      "Wyoming has no statewide senior-tuition statute. Each community college sets its own policy, typically for residents 60+ — from a full waiver on a few credits (e.g. Northwest College's Golden Age program) to a per-credit or percentage discount (e.g. Laramie County CC, Western Wyoming CC). Course/mandatory fees often still apply; confirm with the registrar.",
+    bannerTitle: "Wyoming Senior Discounts (by college)",
+    bannerSummary:
+      "60+ in Wyoming? Most community colleges offer a senior tuition waiver or discount — terms vary by college.",
+    bannerDetail:
+      "Wyoming has no statewide senior-tuition statute; each community college sets its own policy, usually for residents aged 60 and older. Examples range from a full tuition waiver on a limited number of credits (Northwest College's Golden Age program) to a reduced per-credit rate or percentage discount (Laramie County Community College, Western Wyoming Community College). Course and mandatory fees often still apply, and seats are typically space-available. Contact your college's registrar for the specific terms.",
+  },
 
   transferSupported: false,
   popularCourses: ["ENGL 1010", "MATH 1000", "BIOL 1010", "PSYC 1000", "HIST 1110"],


### PR DESCRIPTION
## What changes for someone using the site

Five states now show an accurate **senior-tuition banner** on their pages, where before there was nothing. A 60-year-old in Idaho now learns they can audit courses for $5/credit; a 55-year-old in Louisiana sees the state tuition-fee exemption (with the honest "subject to state funding" caveat); Wisconsin's 60+ free-audit law is surfaced; Nebraska and Wyoming get accurate "varies by college" guidance. All five states' **config** audit dimension goes from B/C → **A**.

This is the config half of the "Wave 0" mechanical sweep. It does **not** change any state's composite grade — these states are still limited by transfers/courses/prereqs/scorecard — but it removes the config gap so a later fix to the limiting dimension isn't held back, and it gives older students real information today.

## What's accurate vs. left blank (the important part)

Populated only where a citation genuinely applies to **our** colleges:

| State | Basis | Age | Notes |
|---|---|---|---|
| ID | Idaho Code § 33-2110A | 60 | $5/credit audit, space-available |
| LA | La. R.S. 17:1807 | 55 | full tuition+fee exemption (LCTCS included); **appropriation-dependent** — caveat stated in the copy |
| WI | Wis. Stat. § 38.24(4m)/(1m)(b) | 60 / 62 | free audit (60+); program-fee exemption (62+); applies to WTCS |
| NE | no statute → varies by college | 62 | grounded examples (Metropolitan CC, Mid-Plains CC) |
| WY | no statute → varies by college | 60 | grounded examples (Northwest College, Laramie County CC) |

**Deliberately left null** (the cited statewide policy does NOT bind the colleges in our dataset — populating it would be misleading):
- **AK** — the University of Alaska 65+ waiver doesn't reach Ilisagvik (a tribal college, AK's only IPEDS-listed CC).
- **SD** — the SD Board of Regents 65+ reduction covers the six public *universities*, not the four technical + two tribal colleges we list (verified 2026-05-29: their cost pages publish no senior discount).

Also filled **WI popularCourses** (was empty) with the top course codes by section count from real `data/wi/courses` (WTCS uses the `801-136`-style numbering).

## Sources
Idaho Code § 33-2110A; La. R.S. 17:1807 (verified scope/age/appropriation via legis.la.gov); Wis. Stat. § 38.24 (docs.legis.wisconsin.gov); college registrar pages for NE/WY examples.

## Test plan
- `tsc --noEmit` → no errors in the five edited configs
- State-data audit → config dimension = A for id, la, ne, wi, wy

🤖 Generated with [Claude Code](https://claude.com/claude-code)