### PR TITLE
config(vt): document transfer ceiling → composite C→B

### DIFF
--- a/lib/states/vt/config.ts
+++ b/lib/states/vt/config.ts
@@ -60,6 +60,20 @@ const vtConfig: StateConfig = {
     prereqs: [{ scripts: ["scripts/vt/scrape-catalog-prereqs.ts"], runner: "http" }],
     programs: [{ scripts: ["scripts/vt/scrape-programs.ts"], runner: "http" }],
   },
+  documentedCeilings: {
+    // Transfers cap at B: the University of Vermont is the only Vermont
+    // receiver exposing a public, scrapeable course-to-course articulation
+    // table (UVM Banner transfer guide, ~346 CCV→UVM pairs — shipped/wired).
+    // Re-verified 2026-05-31: Vermont State University (the largest in-state
+    // receiver) renders its CCV pathways only via a JS-only Acalog page with
+    // no public lookup; Champlain, Norwich, Saint Michael's and Bennington
+    // publish prose "transfer guarantee" / credit-block agreements with no
+    // course-to-course tables; there is no statewide Vermont articulation
+    // portal. CCV's own transfer-pathways API is program-level, not
+    // course-to-course. So one public receiver is the structural ceiling.
+    transfers:
+      "University of Vermont is the only Vermont receiver with a public course-to-course articulation table (UVM Banner transfer guide, wired). Vermont State University is JS-only Acalog with no public lookup; Champlain/Norwich/St. Michael's/Bennington publish only prose credit-block agreements; no statewide articulation portal exists. Verified 2026-05-31.",
+  },
 };
 
 export default vtConfig;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible changes for users — Vermont's transfer page already shows the real University of Vermont equivalencies (~346 CCV→UVM course-to-course mappings). This PR is an **accurate grade correction**: it records *why* UVM is the only receiver we can offer, so the state-data audit stops treating Vermont as "unfinished work" and recognizes it as at its real structural ceiling.

## What changes technically

Adds `documentedCeilings.transfers` to `lib/states/vt/config.ts`. This caps the transfers dimension at B (same mechanism already used for CO, NH, DC). Result: VT transfers C→B, **composite C→B**.

The ceiling is honest, not a shortcut — re-verified every in-state Vermont receiver on 2026-05-31:
- **UVM** — public Banner transfer guide, ~346 course-to-course pairs (shipped + wired). The only one.
- **Vermont State University** (the biggest CCV receiver) — its "CCV → VTSU Pathways" render only via a JavaScript-only Acalog page; no public course-to-course lookup.
- **Champlain / Norwich / Saint Michael's / Bennington** — publish prose "Vermont Transfer Guarantee" / credit-block agreements with no course-to-course tables.
- **CCV's own transfer-pathways API** is program-level (degree→degree), not course-to-course.
- No statewide Vermont articulation portal exists.

Reaching A (≥3 receivers, ≥1000 mappings) is genuinely not possible from public Vermont data — so B is the ceiling.

## Test plan
- State-data audit → vt transfers B (ceiling), composite **B** (was C)
- `tsc --noEmit` → vt config type-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)