### PR TITLE
fix(ms): align program filenames to institution slugs → Mississippi planner goes from 0 to 252 plannable programs

### DIFF
--- a/data/ms/programs/hinds-community-college.json
+++ b/data/ms/programs/hinds-community-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "hinds",
+  "college_slug": "hinds-community-college",
   "catalog_year": "2026-2027",
   "catalog_url": "https://catalog.hindscc.edu",
   "scraped_at": "2026-05-13T17:35:56.749Z",

--- a/data/ms/programs/jones-county-junior-college.json
+++ b/data/ms/programs/jones-county-junior-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "jcjc",
+  "college_slug": "jones-county-junior-college",
   "catalog_year": "2025-2026",
   "catalog_url": "https://catalog.jcjc.edu",
   "scraped_at": "2026-05-13T17:36:11.028Z",

--- a/data/ms/programs/meridian-community-college.json
+++ b/data/ms/programs/meridian-community-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "meridian",
+  "college_slug": "meridian-community-college",
   "catalog_year": "",
   "catalog_url": "https://catalog.meridiancc.edu",
   "scraped_at": "2026-05-13T17:36:15.075Z",

--- a/data/ms/programs/mississippi-gulf-coast-community-college.json
+++ b/data/ms/programs/mississippi-gulf-coast-community-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "mgccc",
+  "college_slug": "mississippi-gulf-coast-community-college",
   "catalog_year": "2025-2026",
   "catalog_url": "https://catalog.mgccc.edu",
   "scraped_at": "2026-05-13T17:35:50.647Z",

--- a/data/ms/programs/northwest-mississippi-community-college.json
+++ b/data/ms/programs/northwest-mississippi-community-college.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "northwest",
+  "college_slug": "northwest-mississippi-community-college",
   "catalog_year": "",
   "catalog_url": "https://catalog.northwestms.edu",
   "scraped_at": "2026-05-13T17:36:17.215Z",

--- a/scripts/ms/scrape-programs.ts
+++ b/scripts/ms/scrape-programs.ts
@@ -16,42 +16,42 @@ import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
 
 const COLLEGES: AcalogProgramConfig[] = [
   {
-    collegeSlug: "mgccc",
+    collegeSlug: "mississippi-gulf-coast-community-college",
     baseUrl: "https://catalog.mgccc.edu",
     catoidFallback: 32,
     programNavoids: [3113],
     autoDiscoverCatoid: false,
   },
   {
-    collegeSlug: "hinds",
+    collegeSlug: "hinds-community-college",
     baseUrl: "https://catalog.hindscc.edu",
     catoidFallback: 22,
     programNavoids: [1040, 1041],
     autoDiscoverCatoid: false,
   },
   {
-    collegeSlug: "eastms",
+    collegeSlug: "east-mississippi-community-college",
     baseUrl: "https://catalog.eastms.edu",
     catoidFallback: 6,
     programNavoids: [601],
     autoDiscoverCatoid: false,
   },
   {
-    collegeSlug: "jcjc",
+    collegeSlug: "jones-county-junior-college",
     baseUrl: "https://catalog.jcjc.edu",
     catoidFallback: 9,
     programNavoids: [638],
     autoDiscoverCatoid: false,
   },
   {
-    collegeSlug: "meridian",
+    collegeSlug: "meridian-community-college",
     baseUrl: "https://catalog.meridiancc.edu",
     catoidFallback: 6,
     programNavoids: [141],
     autoDiscoverCatoid: false,
   },
   {
-    collegeSlug: "northwest",
+    collegeSlug: "northwest-mississippi-community-college",
     baseUrl: "https://catalog.northwestms.edu",
     catoidFallback: 8,
     programNavoids: [375],


### PR DESCRIPTION
## What changes for someone using the site

The **Degree-Path Planner now works in Mississippi**. Before this, a student picking any Mississippi community college and looking for a program plan got *nothing* — the planner reported zero plannable programs statewide. After this change, four colleges light up with real, transfer-validated program checklists:

- Hinds CC — **51** programs
- Jones County Junior College — **108** programs
- Meridian CC — **37** programs (also shows live section counts — it's the one MS college whose course sections are scraped)
- Mississippi Gulf Coast CC — **56** programs

That's **252 plannable programs** that were already scraped and sitting on disk, but invisible to the planner.

## What changed on the technical front

The planner loads a college's programs by `institution.college_slug`, reading `data/ms/programs/{college_slug}.json`. The MS program files were named with **short slugs** (`hinds`, `jcjc`, `meridian`, `mgccc`, `northwest`) that matched *no* institution slug, so `loadCollegeProgramsFromFile` always missed and `listPlannableProgramsForCollege` returned empty.

Fix is pure identifier alignment — no scraping, no app-code change:
1. Renamed the 5 program files **and** their internal `college_slug` field to the canonical institution slugs (e.g. `jcjc` → `jones-county-junior-college`).
2. Updated the 6 college configs in `scripts/ms/scrape-programs.ts` so a future re-scrape writes the correct filenames (a rename alone would be undone on the next scheduled run — this is the durability half of the fix).

### Known gap (named honestly)
- `northwest-mississippi-community-college` has only 1 scraped program, below the 5-course plannable threshold, so it stays at 0 — expected.
- `east-mississippi-community-college`'s scraper config is fixed too, but it has no data file yet (the catalog is behind an Imperva WAF that blocks the scraper) — no plan there until that's resolved.
- Section counts show only for Meridian; the other three colleges' course sections aren't scraped yet, so their plans render the transfer-validated checklist without live section availability. That's a separate course-scraping gap, not part of this fix.

## Test plan
- `npx tsc --noEmit` — clean for all touched files (one pre-existing error in `scripts/ks/scrape-colby.ts` is unrelated to this change).
- `tsx scripts/check-scraper-coverage.ts` — passes (51 states × 4 datatypes accounted for; MS programs scraper still declared in `StateConfig.scrapers`).
- Ran the planner's own `listPlannableProgramsForCollege` + `buildMajorPlan` against MS (0 → 4 colleges, 252 programs) and KY (16 colleges, unchanged — regression sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)