### PR TITLE
fix(ks): unbreak prod build — type error in scrape-colby

### DIFF
--- a/scripts/ks/scrape-colby.ts
+++ b/scripts/ks/scrape-colby.ts
@@ -139,7 +139,9 @@ function parseRow(line: string): Omit<CourseSection, "college_code" | "term"> | 
   // or dates + FEES. Pull the first MM/DD/YYYY date we find from the right
   // side of the row.
   const dateMatches = after.match(/\d{1,2}\/\d{1,2}\/\d{4}/g) ?? [];
-  const start_date = dateMatches.length > 0 ? parseDate(dateMatches[0]) : "";
+  // Index the array directly so noUncheckedIndexedAccess narrows the element
+  // from `string | undefined` to `string` before passing it to parseDate.
+  const start_date = dateMatches[0] ? parseDate(dateMatches[0]) : "";
 
   // Time is typically the field with "-" between two times
   const timeIdx = parts.findIndex((p) => /\d{1,2}:\d{2}\s?[AP]M?-\d{1,2}:\d{2}\s?[AP]M?/.test(p) || p === "-");


### PR DESCRIPTION
## What this changes

**For someone using the site:** nothing visible changes. This is a build hotfix — production deploys have been failing, so the live site is frozen on the last good build. Merging this unblocks Vercel so future PRs can ship again.

**Technical:** PR #961 (Kansas follow-up scrapers) added [`scripts/ks/scrape-colby.ts`](scripts/ks/scrape-colby.ts) with a TypeScript error on line 142 that fails `npm run build` at the "Running TypeScript" step:

```
Type error: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

It went undetected because PR checks don't run the full `next build` typecheck — it only surfaced on the next Vercel prod deploy of `main` (the #963 deploy), which is where the failure showed up, but #963 itself is an unrelated VT config change.

The scraper pulls a start date out of a regex-matched array:

```ts
const dateMatches = after.match(/\d{1,2}\/\d{1,2}\/\d{4}/g) ?? [];
const start_date = dateMatches.length > 0 ? parseDate(dateMatches[0]) : "";  // ❌
```

Under `noUncheckedIndexedAccess`, checking `.length > 0` does **not** narrow `dateMatches[0]` — it stays `string | undefined`, and `parseDate` takes `string`. Indexing and testing the element directly narrows it correctly:

```ts
const start_date = dateMatches[0] ? parseDate(dateMatches[0]) : "";  // ✅
```

Behaviorally identical (empty array → `""` either way), so the scraper output is unchanged.

## Test plan

- `npx tsc --noEmit` → exit 0 (this was the only error; full project typechecks clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)