### PR TITLE
fix(tn): Pellissippi State planner — 122 programs become plannable (filename↔slug fix)

### DIFF
--- a/data/tn/programs/pellissippi-state.json
+++ b/data/tn/programs/pellissippi-state.json
@@ -1,5 +1,5 @@
 {
-  "college_slug": "pstcc",
+  "college_slug": "pellissippi-state",
   "catalog_year": "2026-2027",
   "catalog_url": "https://catalog.pstcc.edu",
   "scraped_at": "2026-05-07T01:07:15.284Z",

--- a/scripts/tn/scrape-programs.ts
+++ b/scripts/tn/scrape-programs.ts
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   npx tsx scripts/tn/scrape-programs.ts
- *   npx tsx scripts/tn/scrape-programs.ts --college pstcc
+ *   npx tsx scripts/tn/scrape-programs.ts --college pellissippi-state
  *   npx tsx scripts/tn/scrape-programs.ts --limit 5     # smoke test
  */
 
@@ -31,7 +31,7 @@ import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
 
 const COLLEGES: AcalogProgramConfig[] = [
   {
-    collegeSlug: "pstcc",
+    collegeSlug: "pellissippi-state",
     baseUrl: "https://catalog.pstcc.edu",
     catoidFallback: 20,
     programNavoids: [1127, 1140, 1132],


### PR DESCRIPTION
## What changes for someone using the site

A student at **Pellissippi State Community College** (Tennessee) can now use the **Degree-Path Planner** — pick a program and see its transfer-validated course checklist with live section counts. Before this, every one of Pellissippi State's **122 plannable programs** returned nothing, even though TN's other 11 colleges worked fine. (Example that now renders: "A+/Network+ Certification Preparation Certificate" — 5 courses, 2 offered this term, accepted by 5 transfer universities.)

## What changed on the technical front

This is the same bug as [PR #964](https://github.com/rohan-c0de/cc-coursemap/pull/964) (Mississippi), found by a cross-state scan. The planner loads programs by `institution.college_slug`, reading `data/tn/programs/{college_slug}.json`. Pellissippi State's file was named `pstcc.json`, but its institution slug — and its course directory — are both `pellissippi-state`, so `loadCollegeProgramsFromFile` always missed.

Fix is pure identifier alignment — no scraping, no app-code change:
1. Renamed `pstcc.json` → `pellissippi-state.json` (and its internal `college_slug` field).
2. Updated the `collegeSlug` config in `scripts/tn/scrape-programs.ts` so a future re-scrape writes the correct filename (durability — a rename alone would be undone next run).

Because the course directory was *already* `pellissippi-state`, this also lights up live section counts on the plan, not just the checklist.

A cross-state scan of all program states found only MS and TN had this filename↔slug mismatch — with this PR, both are fixed.

## Test plan
- Ran the planner's own `listPlannableProgramsForCollege` + `buildMajorPlan`: `pellissippi-state` now resolves **122 plannable programs** and a sample plan renders with courses, sections, and transfer universities. Other TN colleges unchanged.
- `tsx scripts/check-scraper-coverage.ts` — passes (51 states × 4 datatypes; TN programs scraper still declared in `StateConfig.scrapers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)