### PR TITLE
infra: auto-reclaim merged worktrees on session start (disk hygiene)

### DIFF
--- a/.claude/hooks/session-reclaim-worktrees.sh
+++ b/.claude/hooks/session-reclaim-worktrees.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# session-reclaim-worktrees.sh — SessionStart hook.
+#
+# Kicks off scripts/reclaim-merged-worktrees.sh in the BACKGROUND so that every
+# new session triggers a sweep of .claude/worktrees/, removing any whose PR has
+# already merged/closed (and whose tree is clean + pushed). Backgrounded so it
+# never adds latency to session startup; the reclaim script is lock-guarded so
+# 17 concurrent sessions starting at once don't collide.
+#
+# Always exits 0 — worktree cleanup must never block a session from starting.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECLAIM="$SCRIPT_DIR/../../scripts/reclaim-merged-worktrees.sh"
+
+if [ -x "$RECLAIM" ]; then
+  ( nohup bash "$RECLAIM" > "${TMPDIR:-/tmp}/cc-reclaim.log" 2>&1 < /dev/null & )
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-reclaim-worktrees.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/reclaim-merged-worktrees.sh
+++ b/scripts/reclaim-merged-worktrees.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# reclaim-merged-worktrees.sh — remove worktrees whose PR has already landed.
+#
+# WHY: each of ~17 concurrent Claude sessions creates a worktree under
+# .claude/worktrees/<slug> (≈3 GB each: full checkout + node_modules). They are
+# NOT auto-removed when the PR merges, so they pile up and fill the disk. This
+# sweep reclaims any worktree whose work is fully landed and pushed.
+#
+# SAFETY GATES (all must hold, or the worktree is kept):
+#   1. Its branch's PR state is MERGED or CLOSED (work is on main / abandoned).
+#   2. Working tree is clean — no uncommitted changes.
+#   3. No unpushed commits (branch is not ahead of its upstream).
+# A worktree failing any gate is left untouched — we never remove in-flight work.
+#
+# Concurrency-safe (lock), defensive (no gh / not authed -> no-op), idempotent.
+#
+# Usage:
+#   scripts/reclaim-merged-worktrees.sh [--dry-run]
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the MAIN checkout root, not the current worktree: this script is
+# committed into every worktree, but .claude/worktrees/ lives only under the
+# main checkout. `--git-common-dir` points at the shared .git regardless of
+# which worktree we're invoked from; its parent is the main root.
+COMMON_GIT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+if [ -n "$COMMON_GIT_DIR" ]; then
+  REPO_ROOT="$(dirname "$COMMON_GIT_DIR")"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd)"
+fi
+WT_DIR="$REPO_ROOT/.claude/worktrees"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+log() { echo "[reclaim] $*"; }
+
+# Preconditions — fail soft (this runs unattended from a hook).
+command -v gh  >/dev/null 2>&1 || { log "gh not installed — skip";  exit 0; }
+command -v git >/dev/null 2>&1 || { log "git not installed — skip"; exit 0; }
+gh auth status >/dev/null 2>&1 || { log "gh not authenticated — skip"; exit 0; }
+[ -d "$WT_DIR" ] || { log "no worktrees dir — nothing to do"; exit 0; }
+
+# Single-flight lock so 17 sessions firing at once don't collide.
+LOCK="${TMPDIR:-/tmp}/cc-reclaim-worktrees.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+  log "another sweep is running — skip"; exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+cd "$REPO_ROOT" || exit 0
+
+removed=0; kept=0
+for dir in "$WT_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  dir="${dir%/}"
+  slug="$(basename "$dir")"
+
+  branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)" || { log "keep $slug (not a git worktree)"; kept=$((kept+1)); continue; }
+  if [ "$branch" = "HEAD" ] || [ -z "$branch" ]; then
+    log "keep $slug (detached HEAD — can't resolve PR)"; kept=$((kept+1)); continue
+  fi
+
+  state="$(gh pr view "$branch" --json state --jq .state 2>/dev/null)"
+  if [ -z "$state" ]; then
+    log "keep $slug [$branch] (no PR found)"; kept=$((kept+1)); continue
+  fi
+  if [ "$state" != "MERGED" ] && [ "$state" != "CLOSED" ]; then
+    log "keep $slug [$branch] (PR $state)"; kept=$((kept+1)); continue
+  fi
+
+  # Gate 2: clean working tree.
+  if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]; then
+    log "keep $slug [$branch] (PR $state but UNCOMMITTED changes — not safe)"; kept=$((kept+1)); continue
+  fi
+  # Gate 3: no unpushed commits (must have an upstream and be not-ahead).
+  upstream="$(git -C "$dir" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null)"
+  if [ -z "$upstream" ]; then
+    log "keep $slug [$branch] (PR $state but no upstream — not safe)"; kept=$((kept+1)); continue
+  fi
+  ahead="$(git -C "$dir" rev-list --count '@{upstream}..HEAD' 2>/dev/null || echo 1)"
+  if [ "$ahead" != "0" ]; then
+    log "keep $slug [$branch] (PR $state but $ahead unpushed commit(s) — not safe)"; kept=$((kept+1)); continue
+  fi
+
+  # All gates pass — safe to reclaim.
+  if [ "$DRY_RUN" = "1" ]; then
+    log "WOULD REMOVE $slug [$branch] (PR $state, clean, pushed)"
+    removed=$((removed+1)); continue
+  fi
+  if git worktree remove --force "$dir" 2>/dev/null; then
+    git branch -D "$branch" >/dev/null 2>&1 || true
+    log "removed $slug [$branch] (PR $state)"
+    removed=$((removed+1))
+  else
+    log "FAILED to remove $slug [$branch] — left in place"; kept=$((kept+1))
+  fi
+done
+
+git worktree prune 2>/dev/null || true
+if [ "$DRY_RUN" = "1" ]; then
+  log "dry-run: would reclaim $removed, keep $kept"
+else
+  log "reclaimed $removed, kept $kept"
+fi


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-facing. This is internal disk hygiene: it stops the build/dev environment from filling up and breaking, which had started blocking new work for *every* session.

## What changed on the technical front

Each of the ~17 concurrent Claude sessions creates a worktree under `.claude/worktrees/<slug>` — about **3 GB each** (a full checkout plus its own `node_modules`). Nothing removed them when their PR merged, so they accumulated: today's tree had **16 worktrees ≈ 51 GB**, 7 of them already-merged dead weight. Once the disk hit 100%, `git worktree add` failed for everyone — the concrete failure that motivated this.

**`scripts/reclaim-merged-worktrees.sh`** sweeps `.claude/worktrees/` and removes a worktree **only if all three gates hold**:
1. its branch's PR is `MERGED` or `CLOSED`,
2. the working tree is clean (no uncommitted changes),
3. it has no unpushed commits (not ahead of upstream).

Anything failing a gate is kept — so **in-flight work is never destroyed, even when its PR has already merged**. The script is lock-guarded (17 sessions can fire at once without colliding), defensive (no `gh` / not authenticated → silent no-op), idempotent, and has a `--dry-run` mode. It resolves the main checkout via `git rev-parse --git-common-dir`, so it works correctly even when invoked from inside a worktree.

It's wired to a **`SessionStart` hook** (`.claude/hooks/session-reclaim-worktrees.sh`) that launches the sweep in the **background** — measured 4 ms to return, so it adds no startup latency — giving ongoing cleanup across every session. (A remote scheduled routine can't do this: the worktrees are local files, so cleanup must run locally.)

## Test plan
- **Dry-run** correctly flagged 7 merged+clean+pushed worktrees and kept 10 — 5 with uncommitted changes, 1 with an unpushed commit, 4 with no PR.
- **Real sweep** reclaimed those 7 and freed **~20 GB** (disk 100% → 89%).
- Hook returns in 4 ms and backgrounds the sweep; `settings.json` validates; root resolution verified from inside a worktree.

### Note
A worktree with uncommitted or unpushed work whose PR is merged is deliberately **kept** (gates 2–3) — so finish/commit/push your work and it'll be reclaimed on a later session start. Nothing is ever removed that isn't fully landed on the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)