### PR TITLE
docs: refresh stale Scope section in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ A national community college course navigator. Helps students find classes, plan
 
 ## Scope
 
-The project is **national, expanding state-by-state**. East Coast is nearly complete. Never treat this as a Virginia-only tool — VA was the original scope but the architecture is multi-state.
+The project is **national, expanding state-by-state**. All 50 states + DC are now registered in the registry. Never treat this as a Virginia-only tool — VA was the original scope but the architecture is multi-state.
 
-Currently covered states (as of this writing): ct, dc, de, ga, ma, md, me, nc, nh, nj, ny, pa, ri, sc, tn, va, vt. Run `getAllStates()` for the authoritative list.
+Run `getAllStates()` for the authoritative list — never restate it here (it goes stale, and this file is always in context). **Registration ≠ data completeness:** a state can be registered with a config + `data/{slug}/` directory and still have empty or stub data. The remaining work is raising each registered state's data quality (courses, transfers, prereqs, programs, planner) — use `/state-audit` to grade where each one actually stands.
 
 ## Stack
 


### PR DESCRIPTION
## What changes for someone using the site

Nothing — this is a docs-only fix to the agent instructions file (`CLAUDE.md`). No user-facing or runtime change.

## What changes on the technical front

The **Scope** section of `CLAUDE.md` was stuck in the VA-era: it listed only 17 "currently covered states" (`ct, dc, de, ga, ma, md, me, nc, nh, nj, ny, pa, ri, sc, tn, va, vt`) and claimed "East Coast is nearly complete." In reality the registry (`getAllStates()` in `lib/states/registry.ts`) now holds **all 50 states + DC** — each with a `lib/states/{slug}/config.ts` and a `data/{slug}/` directory.

The fix removes the hardcoded list entirely (it just goes stale, and this file is always in context) and replaces it with:
- a pointer to `getAllStates()` as the single source of truth, and
- an explicit note that **registration ≠ data completeness** — a state can be registered and still have empty/stub data — so the real remaining work is raising each state's data quality, gradeable via `/state-audit`.

This also keeps the Scope section consistent with architectural invariant #1 ("never hardcode state lists").

## Test plan
- [x] Docs-only; no code paths touched.
- [x] Reworded line still renders as valid Markdown.