### PR TITLE
fix(programs): stop 504 timeout on program landing pages

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -19,9 +19,9 @@ import {
   loadProgramData,
   qualifies,
   getProgramBySlug,
-  getQualifyingProgramSlugs,
   PROGRAMS,
 } from "@/lib/programs";
+import { loadStateSummary } from "@/lib/state-summary";
 import { loadProgramAcrossColleges, checkCourseAvailability } from "@/lib/programs/requirements";
 import { countRealCourses, programSlug, PLAN_MIN_COURSES } from "@/lib/programs/plan-shared";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
@@ -245,19 +245,17 @@ export default async function ProgramPage(props: PageProps) {
   // qualifies. Builds a topic cluster — both for student comparison
   // (\"how does nursing in NC stack up vs VA, SC, GA?\") and for SEO
   // link equity flowing through topically-related pages.
-  const otherStatesWithThisProgram = (
-    await Promise.all(
-      getAllStates()
-        .filter((s) => s.slug !== state)
-        .map(async (s) => {
-          const slugs = await getQualifyingProgramSlugs(s.slug).catch(
-            () => [] as string[],
-          );
-          return slugs.includes(slug) ? s : null;
-        }),
-    )
-  )
-    .filter((s): s is NonNullable<typeof s> => s !== null)
+  //
+  // Read each state's qualifying-program list from its precomputed summary
+  // manifest (#946) — a synchronous file read — rather than calling
+  // getQualifyingProgramSlugs() live for all ~48 other states. The live path
+  // ran paginated `courses` subject queries for every program in every state
+  // on each render; on a cold serverless instance (empty in-memory cache)
+  // that fan-out blew past the function timeout and 504'd the whole page.
+  // States without a manifest yet are simply omitted from this footer.
+  const otherStatesWithThisProgram = getAllStates()
+    .filter((s) => s.slug !== state)
+    .filter((s) => loadStateSummary(s.slug)?.programSlugs.includes(slug))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (


### PR DESCRIPTION
## What changes for someone using the site

Program pages like **communitycollegepath.com/ca/program/welding** were returning a **504 timeout error** — a blank Vercel error page instead of the program. After this change they load normally (the welding page renders in ~0.5s warm), showing the colleges, sections, earnings, and the "Compare … in other states" footer as intended. This affected any program page on a cold serverless instance, not just CA welding — that's just the one that surfaced it.

## What was actually wrong

The page has a footer — *"Compare Welding Technology programs in other states"* — that links to the same program in every other state where it qualifies. To build that list it was calling `getQualifyingProgramSlugs()` **live for all ~48 other states on every render**. Each of those calls runs paginated `courses` subject queries for all 18 programs. On a cold Lambda (empty in-memory cache) that's thousands of Supabase round-trips in one request — well past Vercel's function timeout, so the whole page 504'd. ISR couldn't save it because the cold render never completed to be cached.

## The fix

Those exact per-state program lists are **already precomputed** in `data/{state}/summary.json` (the `programSlugs` field, shipped in #946/#951 — 48 states covered). The footer now reads them with a synchronous `loadStateSummary()` file read instead of querying Supabase 48× at request time. Same data, zero request-time fan-out. States that don't have a manifest yet are simply omitted from the footer (graceful — the homepage uses the same fallback pattern).

Net diff: one file, −14/+12 lines. Removes the now-unused `getQualifyingProgramSlugs` import from this page; the function itself stays (still used by the sitemap and single-state callers, which only scan one state and are fine).

## Test plan

- `npx tsc --noEmit` — clean.
- Local dev: `/ca/program/welding` → **200** (was 504), 3.97s cold / 0.5s warm.
- Confirmed the cross-state footer still populates — 12 states (az, co, ia, il, ky, mn, mo, nc, or, sc, tx, va) — pulled from the manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)