### PR TITLE
docs: state-goals finish-line plan for all 51 states

### DIFF
--- a/docs/state-goals/README.md
+++ b/docs/state-goals/README.md
@@ -1,0 +1,151 @@
+# State goals — finish-line plan
+
+_Generated 2026-06-01 from the canonical `/state-audit` collector (`.claude/skills/state-audit/scripts/collect-audit-data.ts`) plus a 40-agent effort/lever diagnosis workflow. Grades respect `documentedCeilings`._
+
+**How to use:** open `{slug}.md` for any unfinished state and paste its **Goal checklist** into a fresh Claude session — each is written to be actionable cold. Tick states off the tracker below as they cross the line. Re-run the collector to regenerate `_audit-snapshot.json` and re-grade.
+
+> ⚠️ **Registration ≠ data completeness.** All 50 states + DC are in the registry; this plan is about raising the *data quality* of the 40 that aren't yet A-tier.
+
+## Tier distribution (51 states)
+
+| Tier | Count | States |
+|------|-------|--------|
+| A | 11 | al, ct, de, ga, hi, ky, me, nv, sc, tn, ut |
+| B | 7 | co, dc, fl, la, mn, nh, ri |
+| C | 17 | ar, az, ca, il, ma, md, mi, mo, mt, nc, nd, nj, nm, or, pa, tx, vt |
+| D | 6 | ia, ny, oh, sd, va, wv |
+| F | 10 | ak, id, in, ks, ms, ne, ok, wa, wi, wy |
+
+**Done (A-tier, 11):** al, ct, de, ga, hi, ky, me, nv, sc, tn, ut
+
+## 🎯 The single biggest lever
+
+**Run one batched 'documented-ceiling' audit pass that records each state's genuinely-unbuildable colleges (tribal/SSO/auth-gated) and complete-but-thin transfer sets as documentedCeilings, so the auditor stops penalizing fixed structural limits as open gaps. This is a config/audit-source edit plus an audit re-run per state — no scraping. It applies the already-accepted CO/DC/NH pattern uniformly to the ~12 states sitting below their true ceiling only because the ceiling was never recorded.**
+
+- **Category:** `documented-ceiling-accept`
+- **States affected:** mt, mn, la, pa, ak, ma, ar, id, wy, tx, or, wv
+- **Estimated states moved up a tier:** ~8
+- **Why:** Across the set, the single most common reason a state sits below its achievable tier is that its hard structural limits (independent tribal colleges with no public SIS, SSO/SAML/Workday-gated registration, thin-but-complete transfer coverage) are real ceilings that the audit's documentedCeilings list does not yet contain — so coverage % is computed against a denominator the state can never reach. mt, mn, la, ak each flip essentially straight to A/B+ from this alone (mt 60%->effective 100%, mn 93%->A, la 92%->A, ak F->B+). pa and ma stop being graded as fixable-C and read at their true B+ ceiling. ar/tx/or/wv get their unbuildable colleges excused so the remaining cheap course wins actually clear the bar. id/wy flip off F the moment transfers are accepted as a no-portal ceiling. It is the lowest cost-per-tier action because it is pure metadata, batchable in one PR, and the rationale already exists in each state's config comments and scraper headers — it just needs to be recorded where the auditor reads it.
+
+> ⚖️ **Honest caveat:** the biggest lever is a *re-grading* move — recording genuine structural ceilings (tribal colleges with no public SIS, SSO/Workday-gated registration, complete-but-thin transfers) so the audit stops penalizing unreachable denominators. It does **not** add student-facing data; it makes the grades reflect reality. The *data* wins live in the secondary levers below.
+
+## Secondary levers (batchable, real data gains)
+
+- **Re-run the already-wired-but-empty course scrapers across states where the scraper host map already contains the college but no data landed (transient 502 / wrong subdomain / term-resolution). Pure re-run + occasional host fix, zero new code. Cheapest course-coverage gains in the set.**
+  _states: md, az, nj, ny, oh, tx, ia, ks, fl_
+- **Wire/build a single statewide articulation scraper for the 'transfers-buildable' states whose composite is F only because transfer-equiv.json is empty but a public state portal exists (TransferIN/in.gov, Transfer Nebraska, OCEP VITA Oklahoma). One source per state, ~1-4hr each, flips F->A/B. Distinct from the no-portal states (ak/id/wy) which take the ceiling path instead.**
+  _states: in, ne, ok_
+- **Re-land the orphaned MS program-alignment commit e4134a06 (#964) — a squash-merge race left 252 MS programs on disk with short-slug filenames the planner can't resolve. Pure data rename + internal college_slug fix, no scrape, unlocks 4 plannable colleges. Audit other states for the same filename != institutions.college_slug pattern while touching it.**
+  _states: ms_
+- **Convert two prereq blockers that are pure cleanup/transport fixes: NC's 8 HTML-contaminated prereq entries (regex strip <br>, re-extract codes, C->A) and WA's prereq scraper switching from fetch() to Playwright real-Chrome to beat the AWS WAF challenge (F->pass). Both lift composite with no new data model work.**
+  _states: nc, wa_
+
+## Fastest realistic path
+
+The fastest realistic path is to front-load two near-zero-cost batches before any new scraping. First, a single 'documented-ceiling' audit pass that records each state's genuinely-unbuildable colleges (tribal/SSO/Workday/SAML) and complete-but-thin transfer sets as ceilings — this alone moves roughly 8 states (mt, mn, la, ak, plus pa/ma/ar/or reading at their true tier) without touching a scraper, because they are penalized only for a denominator they can never reach. Second, a re-run/host-fix sweep of the ~9 states whose course scrapers are already wired but produced no data (md, az, nj, ny, oh, tx, ia, ks, fl), plus VA's config-only transfer-cron wire (an outright D->A) and MS's orphaned-program-commit re-land. Of the 40, roughly 18-20 are cheap wins (ceiling-accepts, re-runs, regex/config edits, one-scraper portal builds for in/ne/ok), and about 8-10 are genuine medium builds (ca/mi/mo/nm/wa course or articulation scrapers). The hard slog tail is ~6 states — wi (12 bespoke WTCS scrapers), il/ma (mostly SSO-blocked), ia, ks transfers — where the 90% bar is structurally out of reach and the right move is to build the cheap wins and ceiling-document the rest so they ship at B/B+ rather than chase unwinnable coverage. Prioritize the big-reach cheap states (VA, NC, FL, AZ, NJ, NY-partial) in the 'now' tranche for maximum student impact per hour.
+
+## Impact ÷ effort ranking (all 40 unfinished)
+
+| # | State | Name | Tier | Impact | Effort | V/E | Tranche | Rationale |
+|---|-------|------|------|--------|--------|-----|---------|-----------|
+| 1 | [va](va.md) | Virginia | D | 5 | cheap | H | now | Big state, all 5 dims A-grade data already on disk; D only because robust 8-univ/15,483-row transfer scrapers aren't declared in config — a one-edit cron wire flips D->A. |
+| 2 | [md](md.md) | Maryland | C | 4 | cheap | H | now | All dims A except courses 81%; the 3 missing colleges (ccbc/cecil/garrett) already have wired scrapers that just need a re-run -> 16/16, no new code. |
+| 3 | [nc](nc.md) | North Carolina | C | 5 | cheap | H | now | Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A. |
+| 4 | [az](az.md) | Arizona | C | 5 | cheap | H | now | Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A. |
+| 5 | [ak](ak.md) | Alaska | F | 1 | cheap | H | now | Single tribal college; F only because no-portal transfers isn't recorded as a ceiling — a metadata edit flips F->B+/A with everything else already A/B. |
+| 6 | [la](la.md) | Louisiana | B | 3 | cheap | H | now | Everything built/wired incl 5 aligned programs; record northshore (LoLA SSO) as a courses ceiling and 92% becomes A -> composite A. |
+| 7 | [mn](mn.md) | Minnesota | B | 3 | cheap | H | now | 26/28 courses, all else A, planner-ready; document the 2 independent tribal colleges as ceilings -> courses A, composite A. No scraping. |
+| 8 | [mt](mt.md) | Montana | C | 2 | cheap | H | now | All dims A except courses 60%; the 4 missing are tribal/auth-gated ceilings — recording them lifts courses 60%->effective 100%, composite C->A. |
+| 9 | [ms](ms.md) | Mississippi | F | 3 | cheap | H | now | Re-land orphaned #964 (252 programs, pure rename) for an instant planner GOLD win; courses 7% is a separate medium slog, so do the cheap data fix now. |
+| 10 | [ri](ri.md) | Rhode Island | B | 1 | cheap | H | now | Single-college state, fully built; transfers B is a hard ceiling (both RI public unis mapped) — annotate ceiling + re-run, done. |
+| 11 | [dc](dc.md) | DC | B | 1 | cheap | H | now | Single college, all dims A except transfers which is an in-state-rule ceiling (no in-jurisdiction receiver) — already at finish line, just confirm ceiling. |
+| 12 | [co](co.md) | Colorado | B | 3 | medium | M | now | Shippable bar met (courses/prereqs/config/scorecard A, transfers documented ceiling); only GOLD programs remain (curate catalog configs) — accept as B or pursue planner. |
+| 13 | [fl](fl.md) | Florida | B | 5 | cheap | H | now | Huge state already at 93%; wire fscj's on-disk 2,963-course catalog + document pensacolastate Workday ceiling -> courses A, composite A. |
+| 14 | [nj](nj.md) | New Jersey | C | 5 | cheap | H | now | Big state; re-run wired colleague for camden+ocean (fix ocean's bare base URL) -> 89%, then document the 3 Jenzabar/custom colleges as ceiling. |
+| 15 | [nh](nh.md) | New Hampshire | B | 2 | cheap | M | now | Already shippable; transfers a hard ceiling (UNH/Plymouth no public DB, Keene wired). Accept; optional nashuacc programs for 7/7 planner. |
+| 16 | [pa](pa.md) | Pennsylvania | C | 5 | cheap | M | next | Large state; 5 missing colleges all Workday/SAML/custom-blocked per scraper headers — record as ceilings so composite reads at true B+ (no buildable course wins). |
+| 17 | [in](in.md) | Indiana | F | 3 | medium | H | next | Single-college (Ivy Tech), all dims A except empty transfers; build one TransferIN/Core Transfer Library scraper (portal exists) -> F->A. |
+| 18 | [ne](ne.md) | Nebraska | F | 2 | medium | H | next | Courses B, all else A; F is empty transfers only — one Transfer Nebraska scraper (portal exists) flips F->B/A. |
+| 19 | [ok](ok.md) | Oklahoma | F | 3 | medium | M | next | Implement the OCEP/VITA transfer scraper (currently a stub) to flip composite off F; courses 7/13 needs ~4 template scrapers as a follow-on. |
+| 20 | [ar](ar.md) | Arkansas | C | 2 | medium | M | next | All dims A except courses 12/14; build 2 bespoke scrapers (ANC, SouthArk) after a quick SIS probe, adapting existing AR colleague/Jenzabar templates -> A. |
+| 21 | [tx](tx.md) | Texas | C | 5 | medium | M | next | Largest state but courses 90% unreachable; re-run 3 wired colleges (galveston/southmost/north-central) then document the 19 SSO/custom as ceiling -> shippable B+. |
+| 22 | [wy](wy.md) | Wyoming | F | 1 | medium | M | next | F is empty transfers; investigate WCCC matrix or accept no-portal ceiling (cheap) + record central-wyoming SAML course ceiling -> composite B. |
+| 23 | [id](id.md) | Idaho | F | 2 | medium | M | next | Accept no-portal transfers ceiling (10-min, flips off F) then build/ceiling CSI's Campus-Management-Corp course gap to clear 90%. |
+| 24 | [vt](vt.md) | Vermont | C | 1 | medium | M | next | Single college, every dim A except transfers thin (UVM only); add VTSU as 2nd receiver or accept ceiling -> C->B, otherwise maxed. |
+| 25 | [wa](wa.md) | Washington | F | 5 | medium | M | next | Big state, F only from prereqs WAF-blocked; rework the committed scraper to Playwright real-Chrome to beat AWS WAF (or ceiling-accept) -> off F. |
+| 26 | [ny](ny.md) | New York | D | 5 | medium | M | next | Huge state; re-run 5 wired Banner hosts (49%->62%) + strip 250 HTML prereqs (C->A), then ceiling the 13 no-SIS colleges -> D->C/B. |
+| 27 | [ks](ks.md) | Kansas | F | 3 | hard | M | next | Cheap config + re-run 5 wired colleges lifts courses to ~75%, but F is binding transfers with no portal — hard investigation or ceiling needed to clear F. |
+| 28 | [oh](oh.md) | Ohio | D | 5 | medium | M | next | Large state; re-run 2 wired hosts + 1 Jenzabar -> ~55%, add 2nd transfer receiver (OTM/TAG); 8 custom colleges + 90% bar make full A a hard tail. |
+| 29 | [ca](ca.md) | California | C | 5 | medium | M | next | Highest student reach; ~9 detected colleges wire into existing templates (65%->85%) but the 90% bar needs ~27 custom re-fingerprints — biggest partial win, not a clean finish. |
+| 30 | [mi](mi.md) | Michigan | C | 5 | medium | M | next | Big state; build one Coursedog scraper (henry-ford+lake-michigan) + alpena re-run, then ceiling the 12 blocked — realistic cap ~61%, document the rest. |
+| 31 | [nm](nm.md) | New Mexico | C | 2 | medium | M | later | All else A; wire ruidoso coursedog (on-disk) then re-fingerprint clovis/luna/nmmi/mesalands — needs investigation + 1-2 scrapers to clear 90%. |
+| 32 | [nd](nd.md) | North Dakota | C | 1 | medium | M | later | Add CCCC+NHSC institution codes to the wired NDUS PS scraper (verified public) + ceiling Sitting Bull -> 7/7 courses, but PS endpoint is flaky. |
+| 33 | [sd](sd.md) | South Dakota | D | 1 | medium | M | later | seniorWaiver config fix + transform on-disk Mitchell coursedog dump + ceiling 3 PDF/no-catalog colleges; 2nd transfer receiver optional -> D->C/B. |
+| 34 | [mo](mo.md) | Missouri | C | 3 | medium | M | later | Fingerprint + build SLCC (largest, un-probed) + 2 others, ceiling 2 SSO colleges -> 11/11 buildable clears 90%; investigation-gated. |
+| 35 | [ma](ma.md) | Massachusetts | C | 5 | hard | M | later | Big state, programs 15/15 aligned; probe massbay PeopleSoft (1 win) then document 6 SAML/auth-gated colleges as ceilings -> courses no longer caps, composite B. |
+| 36 | [wv](wv.md) | West Virginia | D | 2 | medium | M | later | Document 5 SSO/SAML/WAF colleges as ceilings + build 1 Colleague guest scraper (southern) -> 4/4 reachable covered, composite D->B. |
+| 37 | [or](or.md) | Oregon | C | 4 | medium | L | later | Courses a hard ceiling (all 8 missing SSO/staff-portal); document them, then the real mover is adding a 2nd transfer receiver (PSU/UO) for C->B. |
+| 38 | [il](il.md) | Illinois | C | 5 | hard | L | later | Large state but most of 19 missing colleges are Jenzabar/SSO/custom-blocked; only elgin re-run is cheap — 90% unreachable, ceiling-document to ship at B. |
+| 39 | [ia](ia.md) | Iowa | D | 2 | medium | L | later | Courses 31%; 6 template-buildable (re-run colleague + wire Jenzabar/Banner) reaches ~69%, but 5 custom/unknown need fresh fingerprints to clear 90%. |
+| 40 | [wi](wi.md) | Wisconsin | F | 4 | hard | L | later | F from prereqs (cheap aggregate fix), but courses 25% with 12 WTCS singletons each on a distinct custom platform (0 clusters) = a ~12-scraper greenfield slog. |
+
+## Progress tracker
+
+### NOW — cheap, high-impact (do first)
+- [ ] **va** (D) — Virginia: Big state, all 5 dims A-grade data already on disk; D only because robust 8-univ/15,483-row transfer scrapers aren't declared in config — a one-edit cron wire flips D->A.
+- [ ] **md** (C) — Maryland: All dims A except courses 81%; the 3 missing colleges (ccbc/cecil/garrett) already have wired scrapers that just need a re-run -> 16/16, no new code.
+- [ ] **nc** (C) — North Carolina: Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A.
+- [ ] **az** (C) — Arizona: Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A.
+- [ ] **ak** (F) — Alaska: Single tribal college; F only because no-portal transfers isn't recorded as a ceiling — a metadata edit flips F->B+/A with everything else already A/B.
+- [ ] **la** (B) — Louisiana: Everything built/wired incl 5 aligned programs; record northshore (LoLA SSO) as a courses ceiling and 92% becomes A -> composite A.
+- [ ] **mn** (B) — Minnesota: 26/28 courses, all else A, planner-ready; document the 2 independent tribal colleges as ceilings -> courses A, composite A. No scraping.
+- [ ] **mt** (C) — Montana: All dims A except courses 60%; the 4 missing are tribal/auth-gated ceilings — recording them lifts courses 60%->effective 100%, composite C->A.
+- [ ] **ms** (F) — Mississippi: Re-land orphaned #964 (252 programs, pure rename) for an instant planner GOLD win; courses 7% is a separate medium slog, so do the cheap data fix now.
+- [ ] **ri** (B) — Rhode Island: Single-college state, fully built; transfers B is a hard ceiling (both RI public unis mapped) — annotate ceiling + re-run, done.
+- [ ] **dc** (B) — DC: Single college, all dims A except transfers which is an in-state-rule ceiling (no in-jurisdiction receiver) — already at finish line, just confirm ceiling.
+- [ ] **co** (B) — Colorado: Shippable bar met (courses/prereqs/config/scorecard A, transfers documented ceiling); only GOLD programs remain (curate catalog configs) — accept as B or pursue planner.
+- [ ] **fl** (B) — Florida: Huge state already at 93%; wire fscj's on-disk 2,963-course catalog + document pensacolastate Workday ceiling -> courses A, composite A.
+- [ ] **nj** (C) — New Jersey: Big state; re-run wired colleague for camden+ocean (fix ocean's bare base URL) -> 89%, then document the 3 Jenzabar/custom colleges as ceiling.
+- [ ] **nh** (B) — New Hampshire: Already shippable; transfers a hard ceiling (UNH/Plymouth no public DB, Keene wired). Accept; optional nashuacc programs for 7/7 planner.
+
+### NEXT — medium effort or lower reach
+- [ ] **pa** (C) — Pennsylvania: Large state; 5 missing colleges all Workday/SAML/custom-blocked per scraper headers — record as ceilings so composite reads at true B+ (no buildable course wins).
+- [ ] **in** (F) — Indiana: Single-college (Ivy Tech), all dims A except empty transfers; build one TransferIN/Core Transfer Library scraper (portal exists) -> F->A.
+- [ ] **ne** (F) — Nebraska: Courses B, all else A; F is empty transfers only — one Transfer Nebraska scraper (portal exists) flips F->B/A.
+- [ ] **ok** (F) — Oklahoma: Implement the OCEP/VITA transfer scraper (currently a stub) to flip composite off F; courses 7/13 needs ~4 template scrapers as a follow-on.
+- [ ] **ar** (C) — Arkansas: All dims A except courses 12/14; build 2 bespoke scrapers (ANC, SouthArk) after a quick SIS probe, adapting existing AR colleague/Jenzabar templates -> A.
+- [ ] **tx** (C) — Texas: Largest state but courses 90% unreachable; re-run 3 wired colleges (galveston/southmost/north-central) then document the 19 SSO/custom as ceiling -> shippable B+.
+- [ ] **wy** (F) — Wyoming: F is empty transfers; investigate WCCC matrix or accept no-portal ceiling (cheap) + record central-wyoming SAML course ceiling -> composite B.
+- [ ] **id** (F) — Idaho: Accept no-portal transfers ceiling (10-min, flips off F) then build/ceiling CSI's Campus-Management-Corp course gap to clear 90%.
+- [ ] **vt** (C) — Vermont: Single college, every dim A except transfers thin (UVM only); add VTSU as 2nd receiver or accept ceiling -> C->B, otherwise maxed.
+- [ ] **wa** (F) — Washington: Big state, F only from prereqs WAF-blocked; rework the committed scraper to Playwright real-Chrome to beat AWS WAF (or ceiling-accept) -> off F.
+- [ ] **ny** (D) — New York: Huge state; re-run 5 wired Banner hosts (49%->62%) + strip 250 HTML prereqs (C->A), then ceiling the 13 no-SIS colleges -> D->C/B.
+- [ ] **ks** (F) — Kansas: Cheap config + re-run 5 wired colleges lifts courses to ~75%, but F is binding transfers with no portal — hard investigation or ceiling needed to clear F.
+- [ ] **oh** (D) — Ohio: Large state; re-run 2 wired hosts + 1 Jenzabar -> ~55%, add 2nd transfer receiver (OTM/TAG); 8 custom colleges + 90% bar make full A a hard tail.
+- [ ] **ca** (C) — California: Highest student reach; ~9 detected colleges wire into existing templates (65%->85%) but the 90% bar needs ~27 custom re-fingerprints — biggest partial win, not a clean finish.
+- [ ] **mi** (C) — Michigan: Big state; build one Coursedog scraper (henry-ford+lake-michigan) + alpena re-run, then ceiling the 12 blocked — realistic cap ~61%, document the rest.
+
+### LATER — hard slog / structural ceilings
+- [ ] **nm** (C) — New Mexico: All else A; wire ruidoso coursedog (on-disk) then re-fingerprint clovis/luna/nmmi/mesalands — needs investigation + 1-2 scrapers to clear 90%.
+- [ ] **nd** (C) — North Dakota: Add CCCC+NHSC institution codes to the wired NDUS PS scraper (verified public) + ceiling Sitting Bull -> 7/7 courses, but PS endpoint is flaky.
+- [ ] **sd** (D) — South Dakota: seniorWaiver config fix + transform on-disk Mitchell coursedog dump + ceiling 3 PDF/no-catalog colleges; 2nd transfer receiver optional -> D->C/B.
+- [ ] **mo** (C) — Missouri: Fingerprint + build SLCC (largest, un-probed) + 2 others, ceiling 2 SSO colleges -> 11/11 buildable clears 90%; investigation-gated.
+- [ ] **ma** (C) — Massachusetts: Big state, programs 15/15 aligned; probe massbay PeopleSoft (1 win) then document 6 SAML/auth-gated colleges as ceilings -> courses no longer caps, composite B.
+- [ ] **wv** (D) — West Virginia: Document 5 SSO/SAML/WAF colleges as ceilings + build 1 Colleague guest scraper (southern) -> 4/4 reachable covered, composite D->B.
+- [ ] **or** (C) — Oregon: Courses a hard ceiling (all 8 missing SSO/staff-portal); document them, then the real mover is adding a 2nd transfer receiver (PSU/UO) for C->B.
+- [ ] **il** (C) — Illinois: Large state but most of 19 missing colleges are Jenzabar/SSO/custom-blocked; only elgin re-run is cheap — 90% unreachable, ceiling-document to ship at B.
+- [ ] **ia** (D) — Iowa: Courses 31%; 6 template-buildable (re-run colleague + wire Jenzabar/Banner) reaches ~69%, but 5 custom/unknown need fresh fingerprints to clear 90%.
+- [ ] **wi** (F) — Wisconsin: F from prereqs (cheap aggregate fix), but courses 25% with 12 WTCS singletons each on a distinct custom platform (0 clusters) = a ~12-scraper greenfield slog.
+
+### ✅ Done (A-tier)
+- [x] **al** — Alabama
+- [x] **ct** — Connecticut
+- [x] **de** — Delaware
+- [x] **ga** — Georgia
+- [x] **hi** — Hawaii
+- [x] **ky** — Kentucky
+- [x] **me** — Maine
+- [x] **nv** — Nevada
+- [x] **sc** — South Carolina
+- [x] **tn** — Tennessee
+- [x] **ut** — Utah

--- a/docs/state-goals/_audit-snapshot.json
+++ b/docs/state-goals/_audit-snapshot.json
@@ -1,0 +1,9620 @@
+[
+  {
+    "slug": "ak",
+    "name": "Alaska",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ilisagvik-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 467,
+      "zeroCreditSections": 0,
+      "sectionsByCollege": {
+        "ilisagvik-college": 467
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 71,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 17,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 Alaska has no registered articulation portal"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": false,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "B",
+        "reason": "71 entries"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "B",
+        "reason": "seniorWaiver missing"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "al",
+    "name": "Alabama",
+    "collegeCount": 23,
+    "courses": {
+      "coveredColleges": 22,
+      "collegeCount": 23,
+      "missingColleges": [
+        "marion-military-institute"
+      ],
+      "termsByCollege": {
+        "bevill-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "bishop-state-community-college": [
+          "2026FA"
+        ],
+        "central-alabama-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "chattahoochee-valley-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "coastal-alabama-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "enterprise-state-community-college": [
+          "2026FA"
+        ],
+        "gadsden-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "george-c-wallace-community-college-dothan": [
+          "2026FA",
+          "2026SU"
+        ],
+        "george-c-wallace-state-community-college-hanceville": [
+          "2026FA"
+        ],
+        "george-c-wallace-state-community-college-selma": [
+          "2026SU"
+        ],
+        "h-councill-trenholm-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "j-f-drake-state-community-and-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "jefferson-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "john-c-calhoun-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lawson-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lurleen-b-wallace-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northeast-alabama-community-college": [
+          "2026SU"
+        ],
+        "northwest-shoals-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "reid-state-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "shelton-state-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "snead-state-community-college": [
+          "2026FA"
+        ],
+        "southern-union-state-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 17010,
+      "zeroCreditSections": 20,
+      "sectionsByCollege": {
+        "bevill-state-community-college": 637,
+        "bishop-state-community-college": 433,
+        "central-alabama-community-college": 666,
+        "chattahoochee-valley-community-college": 350,
+        "coastal-alabama-community-college": 2484,
+        "enterprise-state-community-college": 303,
+        "gadsden-state-community-college": 1039,
+        "george-c-wallace-community-college-dothan": 1128,
+        "george-c-wallace-state-community-college-hanceville": 765,
+        "george-c-wallace-state-community-college-selma": 198,
+        "h-councill-trenholm-state-community-college": 503,
+        "j-f-drake-state-community-and-technical-college": 348,
+        "jefferson-state-community-college": 1202,
+        "john-c-calhoun-state-community-college": 1796,
+        "lawson-state-community-college": 634,
+        "lurleen-b-wallace-community-college": 615,
+        "northeast-alabama-community-college": 235,
+        "northwest-shoals-community-college": 607,
+        "reid-state-technical-college": 166,
+        "shelton-state-community-college": 1152,
+        "snead-state-community-college": 299,
+        "southern-union-state-community-college": 1450
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 530,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 86940,
+      "universities": [
+        "aamu",
+        "asu",
+        "athens",
+        "au",
+        "aum",
+        "jsu",
+        "troy",
+        "ua",
+        "uab",
+        "uah",
+        "um",
+        "una",
+        "usa",
+        "uwa"
+      ],
+      "universityCount": 14,
+      "directMatches": 18400,
+      "electiveOnly": 68540,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 23,
+      "collegeCount": 23
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": [
+        "marion-military-institute"
+      ]
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (21/22), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "530 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "14 universities, 86940 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "23/23 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": [
+        {
+          "dimension": "courses",
+          "reason": "1 college(s) exempted from coverage denominator"
+        }
+      ]
+    }
+  },
+  {
+    "slug": "ar",
+    "name": "Arkansas",
+    "collegeCount": 14,
+    "courses": {
+      "coveredColleges": 12,
+      "collegeCount": 14,
+      "missingColleges": [
+        "arkansas-northeastern-college",
+        "south-arkansas-college"
+      ],
+      "termsByCollege": {
+        "black-river-technical-college": [
+          "2026FA",
+          "2026SU1"
+        ],
+        "cossatot-community-college-of-the-university-of-arkansas": [
+          "2026FA",
+          "2026SU"
+        ],
+        "east-arkansas-community-college": [
+          "2026FA"
+        ],
+        "national-park-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "north-arkansas-college": [
+          "2026FA",
+          "2026SU1"
+        ],
+        "northwest-arkansas-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "ozarka-college": [
+          "2026FA",
+          "2026SU",
+          "2026SU2",
+          "2027SU2"
+        ],
+        "phillips-community-college-of-the-university-of-arkansas": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southeast-arkansas-college": [
+          "2026FA"
+        ],
+        "university-of-arkansas-community-college-batesville": [
+          "2026FA",
+          "2027SP"
+        ],
+        "university-of-arkansas-community-college-morrilton": [
+          "2026FA",
+          "2026SU"
+        ],
+        "university-of-arkansas-community-college-rich-mountain": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU",
+        "2026SU1",
+        "2026SU2",
+        "2027SP",
+        "2027SU2"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026SU1",
+        "2026SU2",
+        "2027SU2"
+      ],
+      "totalSections": 5189,
+      "zeroCreditSections": 1671,
+      "sectionsByCollege": {
+        "black-river-technical-college": 306,
+        "cossatot-community-college-of-the-university-of-arkansas": 304,
+        "east-arkansas-community-college": 20,
+        "national-park-college": 402,
+        "north-arkansas-college": 949,
+        "northwest-arkansas-community-college": 1655,
+        "ozarka-college": 306,
+        "phillips-community-college-of-the-university-of-arkansas": 461,
+        "southeast-arkansas-college": 201,
+        "university-of-arkansas-community-college-batesville": 235,
+        "university-of-arkansas-community-college-morrilton": 253,
+        "university-of-arkansas-community-college-rich-mountain": 97
+      },
+      "lowSectionColleges": [
+        "east-arkansas-community-college"
+      ]
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 466,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 53,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 13440,
+      "universities": [
+        "asuj",
+        "atu",
+        "sau",
+        "uaf",
+        "uafs",
+        "ualr",
+        "uca"
+      ],
+      "universityCount": 7,
+      "directMatches": 10363,
+      "electiveOnly": 23,
+      "noCredit": 3054,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 14,
+      "collegeCount": 14
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": true,
+      "transfersReason": "HSU (Henderson State, tcet.hsu.edu) sits behind Azure AD App Proxy \u2014 500 to anonymous; UAPB (Pine Bluff) has no public per-course ACTS table. Both require registrar contact to close. The other 7 AR public 4-years are covered via ATU/UAF/UCA master tables, the UALR/UAFS/SAU/UAM Acalog harvest, and the ASU-Jonesboro JSON API.",
+      "scorecard": false,
+      "courseColleges": [
+        "arkansas-northeastern-college",
+        "south-arkansas-college"
+      ]
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 83% (10/12)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "466 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "7 universities, 13440 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "14/14 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": [
+        {
+          "dimension": "courses",
+          "reason": "2 college(s) exempted from coverage denominator"
+        }
+      ]
+    }
+  },
+  {
+    "slug": "az",
+    "name": "Arizona",
+    "collegeCount": 21,
+    "courses": {
+      "coveredColleges": 18,
+      "collegeCount": 21,
+      "missingColleges": [
+        "arizona-western-college",
+        "central-arizona-college",
+        "tohono-oodham-community-college"
+      ],
+      "termsByCollege": {
+        "chandler-gilbert-community-college": [
+          "2026SU"
+        ],
+        "cochise-county-community-college-district": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "coconino-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "dine-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "eastern-arizona-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "estrella-mountain-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "gateway-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "glendale-community-college": [
+          "2026SU"
+        ],
+        "mesa-community-college": [
+          "2026SU"
+        ],
+        "mohave-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "northland-pioneer-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "paradise-valley-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "phoenix-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "pima-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "rio-salado-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "scottsdale-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "south-mountain-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "yavapai-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 20839,
+      "zeroCreditSections": 110,
+      "sectionsByCollege": {
+        "chandler-gilbert-community-college": 200,
+        "cochise-county-community-college-district": 1743,
+        "coconino-community-college": 484,
+        "dine-college": 439,
+        "eastern-arizona-college": 341,
+        "estrella-mountain-community-college": 896,
+        "gateway-community-college": 577,
+        "glendale-community-college": 236,
+        "mesa-community-college": 89,
+        "mohave-community-college": 1885,
+        "northland-pioneer-college": 771,
+        "paradise-valley-community-college": 1522,
+        "phoenix-college": 1609,
+        "pima-community-college": 4176,
+        "rio-salado-college": 2835,
+        "scottsdale-community-college": 1121,
+        "south-mountain-community-college": 591,
+        "yavapai-college": 1324
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2788,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 403,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 31464,
+      "universities": [
+        "asu",
+        "nau",
+        "ua"
+      ],
+      "universityCount": 3,
+      "directMatches": 12283,
+      "electiveOnly": 7347,
+      "noCredit": 11834,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 21,
+      "collegeCount": 21
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 scripts/az/scrape-programs.ts wrapper exists"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": [
+        "tohono-oodham-community-college",
+        "central-arizona-college"
+      ]
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 84% (16/19)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2788 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "3 universities, 31464 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "21/21 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": [
+        {
+          "dimension": "courses",
+          "reason": "2 college(s) exempted from coverage denominator"
+        }
+      ]
+    }
+  },
+  {
+    "slug": "ca",
+    "name": "California",
+    "collegeCount": 117,
+    "courses": {
+      "coveredColleges": 76,
+      "collegeCount": 117,
+      "missingColleges": [
+        "feather-river-community-college-district",
+        "miracosta-college",
+        "modesto-junior-college",
+        "santa-monica-college",
+        "skyline-college",
+        "canada-college",
+        "college-of-the-canyons",
+        "cerritos-college",
+        "cerro-coso-community-college",
+        "chabot-college",
+        "city-college-of-san-francisco",
+        "columbia-college",
+        "crafton-hills-college",
+        "el-camino-community-college-district",
+        "glendale-community-college",
+        "imperial-valley-college",
+        "irvine-valley-college",
+        "lake-tahoe-community-college",
+        "long-beach-city-college",
+        "los-angeles-county-college-of-nursing-and-allied-health",
+        "college-of-marin",
+        "mendocino-college",
+        "merced-college",
+        "mt-san-jacinto-community-college-district",
+        "ohlone-college",
+        "palomar-college",
+        "college-of-the-redwoods",
+        "riverside-city-college",
+        "saddleback-college",
+        "san-joaquin-delta-college",
+        "college-of-san-mateo",
+        "santa-barbara-city-college",
+        "college-of-the-sequoias",
+        "san-bernardino-valley-college",
+        "taft-college",
+        "las-positas-college",
+        "copper-mountain-community-college",
+        "santiago-canyon-college",
+        "moreno-valley-college",
+        "norco-college",
+        "california-indian-nations-college"
+      ],
+      "termsByCollege": {
+        "allan-hancock-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "american-river-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "antelope-valley-community-college-district": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bakersfield-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "barstow-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "berkeley-city-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "butte-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "cabrillo-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "chaffey-college": [
+          "2026-FA",
+          "2026-SU"
+        ],
+        "citrus-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "clovis-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "coalinga-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "coastline-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "college-of-alameda": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "college-of-the-desert": [
+          "2026FA",
+          "2026SU",
+          "26-FA",
+          "26-SU"
+        ],
+        "college-of-the-siskiyous": [
+          "2026FA",
+          "2026SU"
+        ],
+        "compton-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "contra-costa-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cosumnes-river-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cuesta-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cuyamaca-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cypress-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "de-anza-college": [
+          "2026SP",
+          "2026SU"
+        ],
+        "diablo-valley-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "east-los-angeles-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "evergreen-valley-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "folsom-lake-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "foothill-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "fresno-city-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "fullerton-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "gavilan-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "golden-west-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "grossmont-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hartnell-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "laney-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "lassen-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lemoore-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "los-angeles-city-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-harbor-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-mission-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-pierce-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-southwest-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-trade-technical-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-angeles-valley-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "los-medanos-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "madera-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "merritt-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mission-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "monterey-peninsula-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "moorpark-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "mt-san-antonio-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "napa-valley-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "orange-coast-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "oxnard-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "palo-verde-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "pasadena-city-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "porterville-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "reedley-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "rio-hondo-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "sacramento-city-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "san-diego-city-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "san-diego-mesa-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "san-diego-miramar-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "san-jose-city-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "santa-ana-college": [
+          "2026FA",
+          "2026SPN",
+          "2026SUN"
+        ],
+        "santa-rosa-junior-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "shasta-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "sierra-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "solano-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southwestern-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "ventura-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "victor-valley-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "west-los-angeles-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "west-valley-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "woodland-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "yuba-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-FA",
+        "2026-SU",
+        "2026FA",
+        "2026SP",
+        "2026SPN",
+        "2026SU",
+        "2026SUN",
+        "26-FA",
+        "26-SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-FA",
+        "2026-SU",
+        "2026SPN",
+        "2026SUN",
+        "26-FA",
+        "26-SU"
+      ],
+      "totalSections": 189185,
+      "zeroCreditSections": 15762,
+      "sectionsByCollege": {
+        "allan-hancock-college": 3049,
+        "american-river-college": 3612,
+        "antelope-valley-community-college-district": 3637,
+        "bakersfield-college": 9381,
+        "barstow-community-college": 969,
+        "berkeley-city-college": 1390,
+        "butte-college": 1693,
+        "cabrillo-college": 2991,
+        "chaffey-college": 2773,
+        "citrus-college": 2854,
+        "clovis-community-college": 1075,
+        "coalinga-college": 381,
+        "coastline-community-college": 977,
+        "college-of-alameda": 972,
+        "college-of-the-desert": 4026,
+        "college-of-the-siskiyous": 341,
+        "compton-college": 1326,
+        "contra-costa-college": 1562,
+        "cosumnes-river-college": 2559,
+        "cuesta-college": 2374,
+        "cuyamaca-college": 5359,
+        "cypress-college": 2829,
+        "de-anza-college": 3627,
+        "diablo-valley-college": 3914,
+        "east-los-angeles-college": 2680,
+        "evergreen-valley-college": 1957,
+        "folsom-lake-college": 1833,
+        "foothill-college": 6165,
+        "fresno-city-college": 3204,
+        "fullerton-college": 2873,
+        "gavilan-college": 1051,
+        "golden-west-college": 1379,
+        "grossmont-college": 5359,
+        "hartnell-college": 1317,
+        "laney-college": 2373,
+        "lassen-community-college": 298,
+        "lemoore-college": 605,
+        "los-angeles-city-college": 1480,
+        "los-angeles-harbor-college": 841,
+        "los-angeles-mission-college": 848,
+        "los-angeles-pierce-college": 1813,
+        "los-angeles-southwest-college": 741,
+        "los-angeles-trade-technical-college": 833,
+        "los-angeles-valley-college": 1825,
+        "los-medanos-college": 1730,
+        "madera-community-college": 657,
+        "merritt-college": 1267,
+        "mission-college": 1900,
+        "monterey-peninsula-college": 2310,
+        "moorpark-college": 1904,
+        "mt-san-antonio-college": 10152,
+        "napa-valley-college": 652,
+        "orange-coast-college": 2388,
+        "oxnard-college": 947,
+        "palo-verde-college": 531,
+        "pasadena-city-college": 7144,
+        "porterville-college": 5089,
+        "reedley-college": 1035,
+        "rio-hondo-college": 2725,
+        "sacramento-city-college": 2658,
+        "san-diego-city-college": 2410,
+        "san-diego-mesa-college": 4561,
+        "san-diego-miramar-college": 2611,
+        "san-jose-city-college": 1957,
+        "santa-ana-college": 5825,
+        "santa-rosa-junior-college": 3156,
+        "shasta-college": 1571,
+        "sierra-college": 5189,
+        "solano-community-college": 1255,
+        "southwestern-college": 3689,
+        "ventura-college": 1449,
+        "victor-valley-college": 3437,
+        "west-los-angeles-college": 775,
+        "west-valley-college": 2579,
+        "woodland-community-college": 1243,
+        "yuba-college": 1243
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 6013,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 1219,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 161680,
+      "universities": [
+        "csu-system",
+        "uc-system",
+        "university-of-california-berkeley",
+        "university-of-california-davis",
+        "university-of-california-irvine",
+        "university-of-california-los-angeles",
+        "university-of-california-san-diego"
+      ],
+      "universityCount": 7,
+      "directMatches": 5550,
+      "electiveOnly": 156130,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 115,
+      "collegeCount": 117
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "monthly cadence; ~5 min runtime; coverage is stable"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 65% (76/117)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "6013 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "7 universities, 161680 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "115/117 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "co",
+    "name": "Colorado",
+    "collegeCount": 15,
+    "courses": {
+      "coveredColleges": 15,
+      "collegeCount": 15,
+      "missingColleges": [],
+      "termsByCollege": {
+        "aims-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "arapahoe-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "colorado-mountain-college": [
+          "2026SU"
+        ],
+        "colorado-northwestern-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "community-college-of-aurora": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "community-college-of-denver": [
+          "2026FA",
+          "2026SU"
+        ],
+        "front-range-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lamar-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "morgan-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northeastern-junior-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "otero-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "pikes-peak-state-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "pueblo-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "red-rocks-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "trinidad-state-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 28079,
+      "zeroCreditSections": 109,
+      "sectionsByCollege": {
+        "aims-community-college": 2215,
+        "arapahoe-community-college": 2219,
+        "colorado-mountain-college": 314,
+        "colorado-northwestern-community-college": 1094,
+        "community-college-of-aurora": 2295,
+        "community-college-of-denver": 2012,
+        "front-range-community-college": 3910,
+        "lamar-community-college": 852,
+        "morgan-community-college": 1088,
+        "northeastern-junior-college": 2124,
+        "otero-college": 996,
+        "pikes-peak-state-college": 3736,
+        "pueblo-community-college": 1987,
+        "red-rocks-community-college": 2056,
+        "trinidad-state-college": 1181
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 868,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 319,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 336,
+      "universities": [
+        "du"
+      ],
+      "universityCount": 1,
+      "directMatches": 201,
+      "electiveOnly": 135,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 15,
+      "collegeCount": 15
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 6 (catalog discovery emitted a wrapper"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": true,
+      "transfersReason": "University of Denver is the only CO receiver exposing public course-to-course articulation (Banner bwcktart). All other in-state receivers (CU, CSU, UNC, MSU Denver, UCCS, Colorado Mesa, Western, Fort Lewis) are SSO/Transferology-gated or publish only degree-plan advising sheets with no receiving course codes. Verified 2026-05-31.",
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (15/15), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "868 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "B",
+        "reason": "ceiling: University of Denver is the only CO receiver exposing public course-to-course articulation (Banner bwcktart). All other in-state receivers (CU, CSU, UNC, MSU Denver, UCCS, Colorado Mesa, Western, Fort Lewis) are SSO/Transferology-gated or publish only degree-plan advising sheets with no receiving course codes. Verified 2026-05-31."
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "15/15 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "transfers",
+      "ceilingsApplied": [
+        {
+          "dimension": "transfers",
+          "reason": "University of Denver is the only CO receiver exposing public course-to-course articulation (Banner bwcktart). All other in-state receivers (CU, CSU, UNC, MSU Denver, UCCS, Colorado Mesa, Western, Fort Lewis) are SSO/Transferology-gated or publish only degree-plan advising sheets with no receiving course codes. Verified 2026-05-31."
+        }
+      ]
+    }
+  },
+  {
+    "slug": "ct",
+    "name": "Connecticut",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ct-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 12409,
+      "zeroCreditSections": 231,
+      "sectionsByCollege": {
+        "ct-state": 12409
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 674,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 80,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 11517,
+      "universities": [
+        "ccsu",
+        "scsu",
+        "uconn",
+        "wcsu"
+      ],
+      "universityCount": 4,
+      "directMatches": 4348,
+      "electiveOnly": 6795,
+      "noCredit": 374,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "674 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "4 universities, 11517 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "dc",
+    "name": "District of Columbia",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "udc-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 2464,
+      "zeroCreditSections": 144,
+      "sectionsByCollege": {
+        "udc-cc": 2464
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 510,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 DC has no in-state CC\u21924yr articulation pipeline; see `transferSupported` comment above.",
+        "programs \u2014 Acalog program scraper not yet wired up for this state."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": true,
+      "transfersReason": "UDC's 1,400+ CollegeTransfer.Net equivalencies target zero in-state institutions. The in-state-only rule strips every row to empty on each run.",
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "510 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "B",
+        "reason": "ceiling: UDC's 1,400+ CollegeTransfer.Net equivalencies target zero in-state institutions. The in-state-only rule strips every row to empty on each run."
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "transfers",
+      "ceilingsApplied": [
+        {
+          "dimension": "transfers",
+          "reason": "UDC's 1,400+ CollegeTransfer.Net equivalencies target zero in-state institutions. The in-state-only rule strips every row to empty on each run."
+        }
+      ]
+    }
+  },
+  {
+    "slug": "de",
+    "name": "Delaware",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "dtcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 4910,
+      "zeroCreditSections": 52,
+      "sectionsByCollege": {
+        "dtcc": 4910
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 611,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 11,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 1548,
+      "universities": [
+        "desu",
+        "udel",
+        "wilmington"
+      ],
+      "universityCount": 3,
+      "directMatches": 785,
+      "electiveOnly": 763,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "611 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "3 universities, 1548 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "fl",
+    "name": "Florida",
+    "collegeCount": 28,
+    "courses": {
+      "coveredColleges": 26,
+      "collegeCount": 28,
+      "missingColleges": [
+        "fscj",
+        "pensacolastate"
+      ],
+      "termsByCollege": {
+        "broward": [
+          "2026SU"
+        ],
+        "cf": [
+          "2026FA",
+          "2026SU"
+        ],
+        "cfk": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "chipola": [
+          "2026FA",
+          "2027SP",
+          "2027SU"
+        ],
+        "daytonastate": [
+          "2026FA",
+          "2026SU"
+        ],
+        "easternflorida": [
+          "2026FA",
+          "2026SU"
+        ],
+        "fgc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "fsw": [
+          "2026FA",
+          "2026SU"
+        ],
+        "gulfcoast": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hccfl": [
+          "2026FA",
+          "2026SU"
+        ],
+        "irsc": [
+          "2026FA"
+        ],
+        "lssc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "mdc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "nfc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "nwfsc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "palmbeachstate": [
+          "2026FA",
+          "2026SU"
+        ],
+        "phsc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "polk": [
+          "2026FA",
+          "2026SU"
+        ],
+        "scf": [
+          "2026FA",
+          "2026SU"
+        ],
+        "seminolestate": [
+          "2026FA",
+          "2026SU"
+        ],
+        "sfcollege": [
+          "2026FA",
+          "2026SU"
+        ],
+        "sjrstate": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southflorida": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "spcollege": [
+          "2026FA",
+          "2026SU"
+        ],
+        "tcc-fl": [
+          "2026FA",
+          "2026SU"
+        ],
+        "valencia": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 67857,
+      "zeroCreditSections": 5300,
+      "sectionsByCollege": {
+        "broward": 2072,
+        "cf": 1604,
+        "cfk": 666,
+        "chipola": 765,
+        "daytonastate": 2740,
+        "easternflorida": 2504,
+        "fgc": 1016,
+        "fsw": 2053,
+        "gulfcoast": 1134,
+        "hccfl": 5861,
+        "irsc": 1705,
+        "lssc": 1081,
+        "mdc": 12028,
+        "nfc": 677,
+        "nwfsc": 1025,
+        "palmbeachstate": 4765,
+        "phsc": 1657,
+        "polk": 2000,
+        "scf": 2192,
+        "seminolestate": 1865,
+        "sfcollege": 2393,
+        "sjrstate": 1438,
+        "southflorida": 2260,
+        "spcollege": 4707,
+        "tcc-fl": 1977,
+        "valencia": 5672
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2225,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 51,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 5240,
+      "universities": [
+        "famu",
+        "fau",
+        "fgcu",
+        "fiu",
+        "flpoly",
+        "fsu",
+        "ncf",
+        "ucf",
+        "uf",
+        "unf",
+        "usf",
+        "uwf"
+      ],
+      "universityCount": 12,
+      "directMatches": 5240,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 28,
+      "collegeCount": 28
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "coverage 93%"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2225 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "12 universities, 5240 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "28/28 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ga",
+    "name": "Georgia",
+    "collegeCount": 22,
+    "courses": {
+      "coveredColleges": 22,
+      "collegeCount": 22,
+      "missingColleges": [],
+      "termsByCollege": {
+        "albany-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "athens-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "atlanta-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "augusta-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "central-ga-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "chattahoochee-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "coastal-pines-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "columbus-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "ga-northwestern-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "ga-piedmont-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "gwinnett-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "lanier-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "north-ga-tech": [
+          "2026FA",
+          "2026SU"
+        ],
+        "oconee-fall-line-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "ogeechee-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "savannah-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "south-ga-tech": [
+          "2026SU"
+        ],
+        "southeastern-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southern-crescent-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southern-regional-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "west-ga-tech": [
+          "2026SP",
+          "2026SU"
+        ],
+        "wiregrass-tech": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 38383,
+      "zeroCreditSections": 19,
+      "sectionsByCollege": {
+        "albany-tech": 1634,
+        "athens-tech": 1066,
+        "atlanta-tech": 1386,
+        "augusta-tech": 2373,
+        "central-ga-tech": 5212,
+        "chattahoochee-tech": 2122,
+        "coastal-pines-tech": 1295,
+        "columbus-tech": 1429,
+        "ga-northwestern-tech": 1403,
+        "ga-piedmont-tech": 1533,
+        "gwinnett-tech": 3930,
+        "lanier-tech": 2370,
+        "north-ga-tech": 734,
+        "oconee-fall-line-tech": 1144,
+        "ogeechee-tech": 985,
+        "savannah-tech": 1042,
+        "south-ga-tech": 467,
+        "southeastern-tech": 597,
+        "southern-crescent-tech": 2312,
+        "southern-regional-tech": 1683,
+        "west-ga-tech": 1853,
+        "wiregrass-tech": 1813
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1664,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 9776,
+      "universities": [
+        "gatech",
+        "gsu",
+        "ksu",
+        "uga",
+        "uwg"
+      ],
+      "universityCount": 5,
+      "directMatches": 1198,
+      "electiveOnly": 2555,
+      "noCredit": 6023,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 22,
+      "collegeCount": 22
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (22/22), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1664 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "5 universities, 9776 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "22/22 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "hi",
+    "name": "Hawaii",
+    "collegeCount": 6,
+    "courses": {
+      "coveredColleges": 6,
+      "collegeCount": 6,
+      "missingColleges": [],
+      "termsByCollege": {
+        "hawaii-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "honolulu-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "kapiolani-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "kauai-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "leeward-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "windward-community-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 1821,
+      "zeroCreditSections": 13,
+      "sectionsByCollege": {
+        "hawaii-community-college": 241,
+        "honolulu-community-college": 232,
+        "kapiolani-community-college": 568,
+        "kauai-community-college": 152,
+        "leeward-community-college": 479,
+        "windward-community-college": 149
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 418,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 15649,
+      "universities": [
+        "uh-hilo",
+        "uh-manoa",
+        "uh-west-oahu"
+      ],
+      "universityCount": 3,
+      "directMatches": 9077,
+      "electiveOnly": 6565,
+      "noCredit": 7,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 6,
+      "collegeCount": 6
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (6/6), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "418 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "3 universities, 15649 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "6/6 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ia",
+    "name": "Iowa",
+    "collegeCount": 16,
+    "courses": {
+      "coveredColleges": 5,
+      "collegeCount": 16,
+      "missingColleges": [
+        "des-moines-area-community-college",
+        "ellsworth-community-college",
+        "hawkeye-community-college",
+        "indian-hills-community-college",
+        "iowa-central-community-college",
+        "iowa-lakes-community-college",
+        "marshalltown-community-college",
+        "north-iowa-area-community-college",
+        "northwest-iowa-community-college",
+        "southwestern-community-college",
+        "western-iowa-tech-community-college"
+      ],
+      "termsByCollege": {
+        "eastern-iowa-community-college-district": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "iowa-western-community-college": [
+          "2026FA",
+          "2026SU",
+          "26-FA",
+          "26-SP",
+          "26-SU"
+        ],
+        "kirkwood-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northeast-iowa-community-college": [
+          "2026-FA",
+          "2026-SU"
+        ],
+        "southeastern-community-college": [
+          "FL26",
+          "SU26"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-FA",
+        "2026-SU",
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "26-FA",
+        "26-SP",
+        "26-SU",
+        "FL26",
+        "SU26"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-FA",
+        "2026-SU",
+        "26-FA",
+        "26-SP",
+        "26-SU",
+        "FL26",
+        "SU26"
+      ],
+      "totalSections": 9871,
+      "zeroCreditSections": 2,
+      "sectionsByCollege": {
+        "eastern-iowa-community-college-district": 2624,
+        "iowa-western-community-college": 3451,
+        "kirkwood-community-college": 2040,
+        "northeast-iowa-community-college": 670,
+        "southeastern-community-college": 1086
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 907,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 3512,
+      "universities": [
+        "iowa-state"
+      ],
+      "universityCount": 1,
+      "directMatches": 3512,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 16,
+      "collegeCount": 16
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 31% (5/16)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "907 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 3512 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "16/16 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "D",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "id",
+    "name": "Idaho",
+    "collegeCount": 4,
+    "courses": {
+      "coveredColleges": 3,
+      "collegeCount": 4,
+      "missingColleges": [
+        "college-of-southern-idaho"
+      ],
+      "termsByCollege": {
+        "college-of-eastern-idaho": [
+          "2026FA",
+          "2026SU"
+        ],
+        "college-of-western-idaho": [
+          "2026FA",
+          "2026SU"
+        ],
+        "north-idaho-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 3236,
+      "zeroCreditSections": 124,
+      "sectionsByCollege": {
+        "college-of-eastern-idaho": 474,
+        "college-of-western-idaho": 1605,
+        "north-idaho-college": 1157
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 730,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 4,
+      "collegeCount": 4
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "college-of-southern-idaho \u2014 uses Campus Management Corp Portal",
+        "transfers \u2014 Idaho has no registered articulation portal. The",
+        "programs \u2014 no college's catalog matched a templated"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 75% (3/4)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "730 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "4/4 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "il",
+    "name": "Illinois",
+    "collegeCount": 48,
+    "courses": {
+      "coveredColleges": 29,
+      "collegeCount": 48,
+      "missingColleges": [
+        "southwestern-illinois-college",
+        "black-hawk-college",
+        "carl-sandburg-college",
+        "elgin-community-college",
+        "highland-community-college",
+        "illinois-central-college",
+        "illinois-valley-community-college",
+        "john-a-logan-college",
+        "john-wood-community-college",
+        "kaskaskia-college",
+        "college-of-lake-county",
+        "lake-land-college",
+        "rend-lake-college",
+        "richland-community-college",
+        "rock-valley-college",
+        "sauk-valley-community-college",
+        "southeastern-illinois-college",
+        "spoon-river-college",
+        "heartland-community-college"
+      ],
+      "termsByCollege": {
+        "city-colleges-of-chicago-harold-washington-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-harry-s-truman-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-kennedy-king-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-malcolm-x-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-olive-harvey-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-richard-j-daley-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "city-colleges-of-chicago-wilbur-wright-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "college-of-dupage": [
+          "2026FA",
+          "CE26SP"
+        ],
+        "danville-area-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "frontier-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "joliet-junior-college": [
+          "2026FL",
+          "2026SM"
+        ],
+        "kankakee-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "kishwaukee-college": [
+          "FA26",
+          "SU26"
+        ],
+        "lewis-and-clark-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lincoln-land-community-college": [
+          "2026-FL",
+          "2026-SM"
+        ],
+        "lincoln-trail-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "mchenry-county-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "moraine-valley-community-college": [
+          "2026SU"
+        ],
+        "morton-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "oakton-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "olney-central-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "parkland-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "prairie-state-college": [
+          "FA26",
+          "SU26"
+        ],
+        "shawnee-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "south-suburban-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "triton-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wabash-valley-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "waubonsee-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "william-rainey-harper-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-FL",
+        "2026-SM",
+        "2026FA",
+        "2026FL",
+        "2026SM",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "CE26SP",
+        "FA26",
+        "SU26"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-FL",
+        "2026-SM",
+        "2026FL",
+        "2026SM",
+        "CE26SP",
+        "FA26",
+        "SU26"
+      ],
+      "totalSections": 35214,
+      "zeroCreditSections": 746,
+      "sectionsByCollege": {
+        "city-colleges-of-chicago-harold-washington-college": 1435,
+        "city-colleges-of-chicago-harry-s-truman-college": 1737,
+        "city-colleges-of-chicago-kennedy-king-college": 1895,
+        "city-colleges-of-chicago-malcolm-x-college": 2253,
+        "city-colleges-of-chicago-olive-harvey-college": 1018,
+        "city-colleges-of-chicago-richard-j-daley-college": 1412,
+        "city-colleges-of-chicago-wilbur-wright-college": 1902,
+        "college-of-dupage": 3739,
+        "danville-area-community-college": 707,
+        "frontier-community-college": 171,
+        "joliet-junior-college": 2203,
+        "kankakee-community-college": 669,
+        "kishwaukee-college": 534,
+        "lewis-and-clark-community-college": 1250,
+        "lincoln-land-community-college": 937,
+        "lincoln-trail-college": 223,
+        "mchenry-county-college": 1314,
+        "moraine-valley-community-college": 638,
+        "morton-college": 1007,
+        "oakton-college": 2005,
+        "olney-central-college": 284,
+        "parkland-college": 1375,
+        "prairie-state-college": 789,
+        "shawnee-community-college": 486,
+        "south-suburban-college": 1255,
+        "triton-college": 2445,
+        "wabash-valley-college": 207,
+        "waubonsee-community-college": 1240,
+        "william-rainey-harper-college": 84
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2383,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 195,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 53969,
+      "universities": [
+        "niu",
+        "siu"
+      ],
+      "universityCount": 2,
+      "directMatches": 17795,
+      "electiveOnly": 36174,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 47,
+      "collegeCount": 48
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "~16 remaining custom-platform colleges. Notes:",
+        "programs \u2014 Phase 5+; no state has program scrapers yet."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 60% (29/48)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2383 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "B",
+        "reason": "2 universities, 53969 mappings"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "47/48 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "in",
+    "name": "Indiana",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ivy-tech-community-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 11904,
+      "zeroCreditSections": 0,
+      "sectionsByCollege": {
+        "ivy-tech-community-college": 11904
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 618,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 Indiana's Core Transfer Library / TransferIN",
+        "programs \u2014 no public catalog matched a templated platform"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "618 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ks",
+    "name": "Kansas",
+    "collegeCount": 24,
+    "courses": {
+      "coveredColleges": 13,
+      "collegeCount": 24,
+      "missingColleges": [
+        "barton-county-community-college",
+        "cloud-county-community-college",
+        "coffeyville-community-college",
+        "flint-hills-technical-college",
+        "fort-scott-community-college",
+        "garden-city-community-college",
+        "johnson-county-community-college",
+        "labette-community-college",
+        "north-central-kansas-technical-college",
+        "pratt-community-college",
+        "seward-county-community-college"
+      ],
+      "termsByCollege": {
+        "allen-county-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "butler-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "colby-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "cowley-county-community-college": [
+          "2026FA"
+        ],
+        "dodge-city-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "highland-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "hutchinson-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "independence-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "kansas-city-kansas-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "manhattan-area-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "neosho-county-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northwest-kansas-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "salina-area-technical-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 11431,
+      "zeroCreditSections": 140,
+      "sectionsByCollege": {
+        "allen-county-community-college": 393,
+        "butler-community-college": 1691,
+        "colby-community-college": 468,
+        "cowley-county-community-college": 732,
+        "dodge-city-community-college": 646,
+        "highland-community-college": 703,
+        "hutchinson-community-college": 3193,
+        "independence-community-college": 265,
+        "kansas-city-kansas-community-college": 1601,
+        "manhattan-area-technical-college": 48,
+        "neosho-county-community-college": 629,
+        "northwest-kansas-technical-college": 931,
+        "salina-area-technical-college": 131
+      },
+      "lowSectionColleges": [
+        "manhattan-area-technical-college"
+      ]
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 523,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 22,
+      "collegeCount": 24
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 no statewide articulation portal registered for KS yet.",
+        "programs \u2014 Phase 6 catalog discovery found no templated platforms; bespoke per-college needed."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": false,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 0,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 54% (13/24)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "523 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "22/24 scorecards"
+      },
+      "config": {
+        "grade": "C",
+        "reason": "seniorWaiver missing; popularCourses empty"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ky",
+    "name": "Kentucky",
+    "collegeCount": 16,
+    "courses": {
+      "coveredColleges": 16,
+      "collegeCount": 16,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ashland-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "big-sandy-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bluegrass-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "elizabethtown-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "gateway-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hazard-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "henderson-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hopkinsville-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "jefferson-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "madisonville-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "maysville-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "owensboro-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "somerset-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southcentral-kentucky-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southeast-kentucky-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "west-kentucky-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 29560,
+      "zeroCreditSections": 0,
+      "sectionsByCollege": {
+        "ashland-community-and-technical-college": 1718,
+        "big-sandy-community-and-technical-college": 970,
+        "bluegrass-community-and-technical-college": 4385,
+        "elizabethtown-community-and-technical-college": 2249,
+        "gateway-community-and-technical-college": 1908,
+        "hazard-community-and-technical-college": 1016,
+        "henderson-community-college": 612,
+        "hopkinsville-community-college": 1096,
+        "jefferson-community-and-technical-college": 3449,
+        "madisonville-community-college": 1259,
+        "maysville-community-and-technical-college": 1645,
+        "owensboro-community-and-technical-college": 1789,
+        "somerset-community-college": 2593,
+        "southcentral-kentucky-community-and-technical-college": 1908,
+        "southeast-kentucky-community-and-technical-college": 1384,
+        "west-kentucky-community-and-technical-college": 1579
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1612,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 348,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 10641,
+      "universities": [
+        "eku",
+        "morehead",
+        "nku",
+        "uky",
+        "uofl",
+        "wku"
+      ],
+      "universityCount": 6,
+      "directMatches": 6733,
+      "electiveOnly": 3743,
+      "noCredit": 165,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 16,
+      "collegeCount": 16
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (16/16), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1612 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 10641 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "16/16 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "la",
+    "name": "Louisiana",
+    "collegeCount": 12,
+    "courses": {
+      "coveredColleges": 11,
+      "collegeCount": 12,
+      "missingColleges": [
+        "northshore-technical-community-college"
+      ],
+      "termsByCollege": {
+        "baton-rouge-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bossier-parish-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "central-louisiana-technical-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "delgado-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "fletcher-technical-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "louisiana-delta-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northwest-louisiana-technical-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "nunez-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "river-parishes-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "south-louisiana-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "sowela-technical-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 18703,
+      "zeroCreditSections": 110,
+      "sectionsByCollege": {
+        "baton-rouge-community-college": 2540,
+        "bossier-parish-community-college": 2764,
+        "central-louisiana-technical-community-college": 532,
+        "delgado-community-college": 4769,
+        "fletcher-technical-community-college": 787,
+        "louisiana-delta-community-college": 1351,
+        "northwest-louisiana-technical-community-college": 367,
+        "nunez-community-college": 468,
+        "river-parishes-community-college": 972,
+        "south-louisiana-community-college": 2498,
+        "sowela-technical-community-college": 1655
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2048,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 10,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 14903,
+      "universities": [
+        "grambling-state",
+        "louisiana-tech",
+        "lsu-alexandria",
+        "lsu-baton-rouge",
+        "lsu-eunice",
+        "lsu-shreveport",
+        "mcneese-state",
+        "new-orleans",
+        "nicholls-state",
+        "northwestern-state",
+        "southeastern-louisiana",
+        "southern-baton-rouge",
+        "southern-new-orleans",
+        "southern-shreveport",
+        "ul-lafayette",
+        "ul-monroe"
+      ],
+      "universityCount": 16,
+      "directMatches": 14903,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 12,
+      "collegeCount": 12
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "coverage 92%"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2048 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "16 universities, 14903 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "12/12 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ma",
+    "name": "Massachusetts",
+    "collegeCount": 15,
+    "courses": {
+      "coveredColleges": 8,
+      "collegeCount": 15,
+      "missingColleges": [
+        "massbay",
+        "massasoit",
+        "mwcc",
+        "northshore",
+        "necc",
+        "qcc",
+        "rcc"
+      ],
+      "termsByCollege": {
+        "berkshire": [
+          "2026FA"
+        ],
+        "bhcc": [
+          "2026FA"
+        ],
+        "bristol": [
+          "2026FA",
+          "2026SU"
+        ],
+        "capecod": [
+          "2026FA"
+        ],
+        "gcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hcc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "middlesex": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "stcc": [
+          "2026FA"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 9691,
+      "zeroCreditSections": 319,
+      "sectionsByCollege": {
+        "berkshire": 353,
+        "bhcc": 1515,
+        "bristol": 1692,
+        "capecod": 679,
+        "gcc": 727,
+        "hcc": 844,
+        "middlesex": 2790,
+        "stcc": 1091
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1946,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 54,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 45723,
+      "universities": [
+        "bridgewater-state-university",
+        "fitchburg-state-university",
+        "framingham-state-university",
+        "massachusetts-college-of-art-and-design",
+        "massachusetts-college-of-liberal-arts",
+        "massachusetts-maritime-academy",
+        "salem-state-university",
+        "university-of-massachusetts-at-amherst",
+        "university-of-massachusetts-at-boston",
+        "university-of-massachusetts-at-dartmouth",
+        "university-of-massachusetts-at-lowell",
+        "westfield-state-university",
+        "worcester-state-university"
+      ],
+      "universityCount": 13,
+      "directMatches": 21657,
+      "electiveOnly": 21789,
+      "noCredit": 2277,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 15,
+      "collegeCount": 15
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 53% (8/15)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1946 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "13 universities, 45723 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "15/15 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "md",
+    "name": "Maryland",
+    "collegeCount": 16,
+    "courses": {
+      "coveredColleges": 13,
+      "collegeCount": 16,
+      "missingColleges": [
+        "cecil",
+        "ccbc",
+        "garrett"
+      ],
+      "termsByCollege": {
+        "aacc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "allegany": [
+          "2026FA",
+          "2026SU"
+        ],
+        "bccc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "carroll": [
+          "2026FA",
+          "2026SU"
+        ],
+        "chesapeake": [
+          "2026SP",
+          "2026SU"
+        ],
+        "csm": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "frederick": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "hagerstown": [
+          "2026FA",
+          "2026SU"
+        ],
+        "harford": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "howardcc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "montgomery": [
+          "2025FA",
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "pgcc": [
+          "2026CSU",
+          "2026FA"
+        ],
+        "wor-wic": [
+          "2026FA",
+          "2026S1"
+        ]
+      },
+      "uniqueTerms": [
+        "2025FA",
+        "2026CSU",
+        "2026FA",
+        "2026S1",
+        "2026SP",
+        "2026SU",
+        "2027SP"
+      ],
+      "staleTerms": [
+        "2025FA"
+      ],
+      "suspiciousTerms": [
+        "2026CSU",
+        "2026S1"
+      ],
+      "totalSections": 25538,
+      "zeroCreditSections": 2876,
+      "sectionsByCollege": {
+        "aacc": 3182,
+        "allegany": 682,
+        "bccc": 1220,
+        "carroll": 560,
+        "chesapeake": 325,
+        "csm": 2266,
+        "frederick": 3588,
+        "hagerstown": 1139,
+        "harford": 2124,
+        "howardcc": 1911,
+        "montgomery": 5252,
+        "pgcc": 2737,
+        "wor-wic": 552
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2797,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 5,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 123481,
+      "universities": [
+        "bowie-state",
+        "frostburg",
+        "morgan-state",
+        "salisbury",
+        "towson",
+        "umbc",
+        "umcp",
+        "umgc"
+      ],
+      "universityCount": 8,
+      "directMatches": 59746,
+      "electiveOnly": 63735,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 16,
+      "collegeCount": 16
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 81% (13/16)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2797 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "8 universities, 123481 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "16/16 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "me",
+    "name": "Maine",
+    "collegeCount": 7,
+    "courses": {
+      "coveredColleges": 7,
+      "collegeCount": 7,
+      "missingColleges": [],
+      "termsByCollege": {
+        "cmcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "emcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "kvcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "nmcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "smcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wccc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "yccc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 6988,
+      "zeroCreditSections": 5624,
+      "sectionsByCollege": {
+        "cmcc": 1872,
+        "emcc": 927,
+        "kvcc": 631,
+        "nmcc": 423,
+        "smcc": 2669,
+        "wccc": 313,
+        "yccc": 153
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 948,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 134,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 41492,
+      "universities": [
+        "uma",
+        "umaine",
+        "umf",
+        "umfk",
+        "umpi",
+        "usm"
+      ],
+      "universityCount": 6,
+      "directMatches": 17304,
+      "electiveOnly": 24188,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 7,
+      "collegeCount": 7
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Acalog program scraper not yet wired up for this state."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (7/7), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "948 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 41492 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "7/7 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "mi",
+    "name": "Michigan",
+    "collegeCount": 31,
+    "courses": {
+      "coveredColleges": 16,
+      "collegeCount": 31,
+      "missingColleges": [
+        "alpena-community-college",
+        "henry-ford-college",
+        "northwestern-michigan-college",
+        "bay-mills-community-college",
+        "bay-de-noc-community-college",
+        "gogebic-community-college",
+        "grand-rapids-community-college",
+        "kalamazoo-valley-community-college",
+        "kirtland-community-college",
+        "lake-michigan-college",
+        "monroe-county-community-college",
+        "wayne-county-community-college-district",
+        "west-shore-community-college",
+        "saginaw-chippewa-tribal-college",
+        "keweenaw-bay-ojibwa-community-college"
+      ],
+      "termsByCollege": {
+        "delta-college": [
+          "26-FA",
+          "26-SP"
+        ],
+        "glen-oaks-community-college": [
+          "26-FL",
+          "26-SM"
+        ],
+        "jackson-college": [
+          "26-FAL",
+          "26-SUM"
+        ],
+        "kellogg-community-college": [
+          "26-FA",
+          "26-SU"
+        ],
+        "lansing-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "macomb-community-college": [
+          "2026FA",
+          "2026SS"
+        ],
+        "mid-michigan-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "montcalm-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mott-community-college": [
+          "F26-27",
+          "S25-26"
+        ],
+        "muskegon-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "north-central-michigan-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "oakland-community-college": [
+          "2026-FA",
+          "2026-SU"
+        ],
+        "schoolcraft-community-college-district": [
+          "2026-02",
+          "2026-03",
+          "2026-04"
+        ],
+        "southwestern-michigan-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "st-clair-county-community-college": [
+          "26-FA",
+          "26-SU"
+        ],
+        "washtenaw-community-college": [
+          "2026FA",
+          "2026SP"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-02",
+        "2026-03",
+        "2026-04",
+        "2026-FA",
+        "2026-SU",
+        "2026FA",
+        "2026SP",
+        "2026SS",
+        "2026SU",
+        "26-FA",
+        "26-FAL",
+        "26-FL",
+        "26-SM",
+        "26-SP",
+        "26-SU",
+        "26-SUM",
+        "F26-27",
+        "S25-26"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-02",
+        "2026-03",
+        "2026-04",
+        "2026-FA",
+        "2026-SU",
+        "2026SS",
+        "26-FA",
+        "26-FAL",
+        "26-FL",
+        "26-SM",
+        "26-SP",
+        "26-SU",
+        "26-SUM",
+        "F26-27",
+        "S25-26"
+      ],
+      "totalSections": 22936,
+      "zeroCreditSections": 525,
+      "sectionsByCollege": {
+        "delta-college": 2078,
+        "glen-oaks-community-college": 345,
+        "jackson-college": 1141,
+        "kellogg-community-college": 1020,
+        "lansing-community-college": 2742,
+        "macomb-community-college": 2829,
+        "mid-michigan-college": 797,
+        "montcalm-community-college": 804,
+        "mott-community-college": 1685,
+        "muskegon-community-college": 762,
+        "north-central-michigan-college": 357,
+        "oakland-community-college": 3073,
+        "schoolcraft-community-college-district": 1829,
+        "southwestern-michigan-college": 587,
+        "st-clair-county-community-college": 817,
+        "washtenaw-community-college": 2070
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2317,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 55,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 152825,
+      "universities": [
+        "emich",
+        "msu",
+        "umich",
+        "wayne-state",
+        "wmich"
+      ],
+      "universityCount": 5,
+      "directMatches": 135093,
+      "electiveOnly": 4104,
+      "noCredit": 13628,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 31,
+      "collegeCount": 31
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 52% (16/31)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2317 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "5 universities, 152825 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "31/31 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "mn",
+    "name": "Minnesota",
+    "collegeCount": 28,
+    "courses": {
+      "coveredColleges": 26,
+      "collegeCount": 28,
+      "missingColleges": [
+        "leech-lake-tribal-college",
+        "red-lake-nation-college"
+      ],
+      "termsByCollege": {
+        "alexandria-technical-and-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "anoka-ramsey-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "anoka-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "central-lakes-college-brainerd": [
+          "2026FA",
+          "2026SU"
+        ],
+        "century-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "dakota-county-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "fond-du-lac-tribal-and-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "hennepin-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "inver-hills-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "lake-superior-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "minneapolis-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "minnesota-north-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "minnesota-state-college-southeast": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "minnesota-state-community-and-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "minnesota-west-community-and-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "normandale-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "north-hennepin-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "northland-community-and-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northwest-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "pine-technical-and-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "ridgewater-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "riverland-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "rochester-community-and-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "saint-paul-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "south-central-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "st-cloud-technical-and-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 33017,
+      "zeroCreditSections": 545,
+      "sectionsByCollege": {
+        "alexandria-technical-and-community-college": 502,
+        "anoka-ramsey-community-college": 2703,
+        "anoka-technical-college": 771,
+        "central-lakes-college-brainerd": 595,
+        "century-college": 2260,
+        "dakota-county-technical-college": 1678,
+        "fond-du-lac-tribal-and-community-college": 455,
+        "hennepin-technical-college": 566,
+        "inver-hills-community-college": 1394,
+        "lake-superior-college": 703,
+        "minneapolis-community-and-technical-college": 3168,
+        "minnesota-north-college": 390,
+        "minnesota-state-college-southeast": 378,
+        "minnesota-state-community-and-technical-college": 998,
+        "minnesota-west-community-and-technical-college": 477,
+        "normandale-community-college": 2693,
+        "north-hennepin-community-college": 1355,
+        "northland-community-and-technical-college": 289,
+        "northwest-technical-college": 300,
+        "pine-technical-and-community-college": 233,
+        "ridgewater-college": 2276,
+        "riverland-community-college": 1589,
+        "rochester-community-and-technical-college": 2030,
+        "saint-paul-college": 2856,
+        "south-central-college": 888,
+        "st-cloud-technical-and-community-college": 1470
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 3313,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 555,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 6172,
+      "universities": [
+        "bemidji-state-university",
+        "metro-state-university",
+        "minnesota-state-university-mankato",
+        "minnesota-state-university-moorhead",
+        "southwest-minnesota-state-university",
+        "st-cloud-state-university",
+        "winona-state-university"
+      ],
+      "universityCount": 7,
+      "directMatches": 6172,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 28,
+      "collegeCount": 28
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "coverage 93%"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "3313 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "7 universities, 6172 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "28/28 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "mo",
+    "name": "Missouri",
+    "collegeCount": 13,
+    "courses": {
+      "coveredColleges": 8,
+      "collegeCount": 13,
+      "missingColleges": [
+        "saint-louis-community-college",
+        "state-technical-college-of-missouri",
+        "moberly-area-community-college",
+        "three-rivers-college",
+        "north-central-missouri-college"
+      ],
+      "termsByCollege": {
+        "crowder-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "east-central-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "jefferson-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "metropolitan-community-college-kansas-city": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mineral-area-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "ozarks-technical-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "st-charles-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "state-fair-community-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 19014,
+      "zeroCreditSections": 707,
+      "sectionsByCollege": {
+        "crowder-college": 1468,
+        "east-central-college": 786,
+        "jefferson-college": 1854,
+        "metropolitan-community-college-kansas-city": 4229,
+        "mineral-area-college": 1063,
+        "ozarks-technical-community-college": 4997,
+        "st-charles-community-college": 3190,
+        "state-fair-community-college": 1427
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 645,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 8874,
+      "universities": [
+        "harris-stowe",
+        "lincoln",
+        "missouri-southern",
+        "missouri-st",
+        "missouri-state",
+        "missouri-western",
+        "mizzou",
+        "northwest-missouri",
+        "semo",
+        "truman",
+        "ucm",
+        "umkc",
+        "umsl"
+      ],
+      "universityCount": 13,
+      "directMatches": 8874,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 13,
+      "collegeCount": 13
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 62% (8/13)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "645 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "13 universities, 8874 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "13/13 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ms",
+    "name": "Mississippi",
+    "collegeCount": 15,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 15,
+      "missingColleges": [
+        "coahoma-community-college",
+        "copiah-lincoln-community-college",
+        "east-central-community-college",
+        "east-mississippi-community-college",
+        "hinds-community-college",
+        "holmes-community-college",
+        "itawamba-community-college",
+        "jones-county-junior-college",
+        "mississippi-delta-community-college",
+        "mississippi-gulf-coast-community-college",
+        "northeast-mississippi-community-college",
+        "northwest-mississippi-community-college",
+        "pearl-river-community-college",
+        "southwest-mississippi-community-college"
+      ],
+      "termsByCollege": {
+        "meridian-community-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 1011,
+      "zeroCreditSections": 11,
+      "sectionsByCollege": {
+        "meridian-community-college": 1011
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1848,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 846,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 2109,
+      "universities": [
+        "ole-miss"
+      ],
+      "universityCount": 1,
+      "directMatches": 833,
+      "electiveOnly": 1276,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 15,
+      "collegeCount": 15
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "F",
+        "reason": "coverage 7% (1/15)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1848 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 2109 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "15/15 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "mt",
+    "name": "Montana",
+    "collegeCount": 10,
+    "courses": {
+      "coveredColleges": 6,
+      "collegeCount": 10,
+      "missingColleges": [
+        "aaniiih-nakoda-college",
+        "stone-child-college",
+        "highlands-college-of-montana-tech",
+        "fort-peck-community-college"
+      ],
+      "termsByCollege": {
+        "chief-dull-knife-college": [
+          "2026SU"
+        ],
+        "dawson-community-college": [
+          "2026SU"
+        ],
+        "flathead-valley-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "little-big-horn-college": [
+          "2025FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "miles-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "salish-kootenai-college": [
+          "2026FA",
+          "2026SP"
+        ]
+      },
+      "uniqueTerms": [
+        "2025FA",
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP"
+      ],
+      "staleTerms": [
+        "2025FA"
+      ],
+      "suspiciousTerms": [],
+      "totalSections": 2912,
+      "zeroCreditSections": 272,
+      "sectionsByCollege": {
+        "chief-dull-knife-college": 35,
+        "dawson-community-college": 15,
+        "flathead-valley-community-college": 1619,
+        "little-big-horn-college": 238,
+        "miles-community-college": 243,
+        "salish-kootenai-college": 762
+      },
+      "lowSectionColleges": [
+        "chief-dull-knife-college",
+        "dawson-community-college"
+      ]
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 119,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 119,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 1309,
+      "universities": [
+        "montana-tech",
+        "msu-billings",
+        "msu-bozeman",
+        "msu-northern",
+        "um-missoula",
+        "um-western"
+      ],
+      "universityCount": 6,
+      "directMatches": 1309,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 10,
+      "collegeCount": 10
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 60% (6/10)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "119 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 1309 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "10/10 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "nc",
+    "name": "North Carolina",
+    "collegeCount": 58,
+    "courses": {
+      "coveredColleges": 58,
+      "collegeCount": 58,
+      "missingColleges": [],
+      "termsByCollege": {
+        "alamance": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "asheville-buncombe-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "beaufort-county": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bladen": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "blue-ridge": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "brunswick": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "caldwell": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cape-fear": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "carteret": [
+          "2026FA",
+          "2026SU"
+        ],
+        "catawba-valley": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "central-carolina": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "central-piedmont": [
+          "2026SP",
+          "2026SU"
+        ],
+        "cleveland": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "coastal-carolina": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "college-of-the-albemarle": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "craven": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "davidson-davie": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "durham-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "edgecombe": [
+          "2026FA",
+          "2026SU"
+        ],
+        "fayetteville-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "forsyth-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "gaston": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "guilford-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "halifax": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "haywood": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "isothermal": [
+          "2026FA",
+          "2026SU"
+        ],
+        "james-sprunt": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "johnston": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "lenoir": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "martin": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mayland": [
+          "2026SP",
+          "2026SU"
+        ],
+        "mcdowell-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mitchell": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "montgomery": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "nash": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "pamlico": [
+          "2026SP"
+        ],
+        "piedmont": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "pitt": [
+          "2026SP",
+          "2026SU"
+        ],
+        "randolph": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "richmond": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "roanoke-chowan": [
+          "2026FA",
+          "2026SU"
+        ],
+        "robeson": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "rockingham": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "rowan-cabarrus": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "sampson": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "sandhills": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "south-piedmont": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southeastern": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southwestern": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "stanly": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "surry": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "tri-county": [
+          "2026SP"
+        ],
+        "vance-granville": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wake-technical": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wayne": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "western-piedmont": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wilkes": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "wilson": [
+          "2026FA",
+          "2026U1"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2026U1"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026U1"
+      ],
+      "totalSections": 85969,
+      "zeroCreditSections": 577,
+      "sectionsByCollege": {
+        "alamance": 2110,
+        "asheville-buncombe-technical": 1892,
+        "beaufort-county": 960,
+        "bladen": 559,
+        "blue-ridge": 1176,
+        "brunswick": 800,
+        "caldwell": 1495,
+        "cape-fear": 4080,
+        "carteret": 437,
+        "catawba-valley": 1845,
+        "central-carolina": 2501,
+        "central-piedmont": 4982,
+        "cleveland": 492,
+        "coastal-carolina": 1603,
+        "college-of-the-albemarle": 1255,
+        "craven": 1440,
+        "davidson-davie": 1621,
+        "durham-technical": 2134,
+        "edgecombe": 462,
+        "fayetteville-technical": 4675,
+        "forsyth-technical": 3561,
+        "gaston": 1701,
+        "guilford-technical": 4211,
+        "halifax": 496,
+        "haywood": 626,
+        "isothermal": 529,
+        "james-sprunt": 624,
+        "johnston": 2268,
+        "lenoir": 1076,
+        "martin": 466,
+        "mayland": 179,
+        "mcdowell-technical": 750,
+        "mitchell": 1367,
+        "montgomery": 521,
+        "nash": 1154,
+        "pamlico": 93,
+        "piedmont": 758,
+        "pitt": 1742,
+        "randolph": 1092,
+        "richmond": 862,
+        "roanoke-chowan": 180,
+        "robeson": 845,
+        "rockingham": 677,
+        "rowan-cabarrus": 2607,
+        "sampson": 819,
+        "sandhills": 1696,
+        "south-piedmont": 1512,
+        "southeastern": 343,
+        "southwestern": 1030,
+        "stanly": 1072,
+        "surry": 1187,
+        "tri-county": 292,
+        "vance-granville": 1007,
+        "wake-technical": 7849,
+        "wayne": 1492,
+        "western-piedmont": 918,
+        "wilkes": 1240,
+        "wilson": 608
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2367,
+      "htmlContaminated": 8,
+      "htmlSamples": [
+        "BTB 103: Take BTB-102 - Must be taken either prior to or at the same time as this course.,<br>Take BTB-101 - Must be completed pr...",
+        "EDU 234A: Take EDU-119 - Must be completed prior to taking this course.,<br>Take EDU-234 - Must be taken either prior to or at the...",
+        "MRN 121: Take TRN-110 - Must be completed prior to taking this course.,<br>Take HET-110 - Must be taken either prior to or at the..."
+      ],
+      "emptyCourseArrays": 78,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 25687,
+      "universities": [
+        "appstate",
+        "catawba",
+        "ecsu",
+        "ecu",
+        "elon",
+        "fsu",
+        "high-point",
+        "ncat",
+        "ncstate",
+        "unc-ch",
+        "unc-system",
+        "unca",
+        "uncc",
+        "uncg",
+        "uncp",
+        "uncsa",
+        "uncw",
+        "wcu",
+        "wingate",
+        "wssu"
+      ],
+      "universityCount": 20,
+      "directMatches": 14313,
+      "electiveOnly": 11373,
+      "noCredit": 1,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 58,
+      "collegeCount": 58
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Acalog program scraper not yet wired up for this state."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "1 suspicious term(s)"
+      },
+      "prereqs": {
+        "grade": "C",
+        "reason": "8 entries have HTML contamination"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "20 universities, 25687 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "58/58 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "prereqs",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "nd",
+    "name": "North Dakota",
+    "collegeCount": 8,
+    "courses": {
+      "coveredColleges": 5,
+      "collegeCount": 8,
+      "missingColleges": [
+        "nueta-hidatsa-sahnish-college",
+        "sitting-bull-college",
+        "cankdeska-cikana-community-college"
+      ],
+      "termsByCollege": {
+        "bismarck-state-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "dakota-college-at-bottineau": [
+          "2026FA",
+          "2026SP"
+        ],
+        "lake-region-state-college": [
+          "2026FA",
+          "2026SP"
+        ],
+        "north-dakota-state-college-of-science": [
+          "2026FA",
+          "2026SP"
+        ],
+        "williston-state-college": [
+          "2026SP"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 4388,
+      "zeroCreditSections": 0,
+      "sectionsByCollege": {
+        "bismarck-state-college": 2054,
+        "dakota-college-at-bottineau": 595,
+        "lake-region-state-college": 583,
+        "north-dakota-state-college-of-science": 859,
+        "williston-state-college": 297
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 543,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 162,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 5694,
+      "universities": [
+        "dickinson-state-university",
+        "mayville-state-university",
+        "minot-state-university",
+        "north-dakota-state-university",
+        "university-of-north-dakota",
+        "valley-city-state-university"
+      ],
+      "universityCount": 6,
+      "directMatches": 5694,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 8,
+      "collegeCount": 8
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 6 found no templated catalog on any college."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 63% (5/8)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "543 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 5694 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "8/8 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ne",
+    "name": "Nebraska",
+    "collegeCount": 9,
+    "courses": {
+      "coveredColleges": 8,
+      "collegeCount": 9,
+      "missingColleges": [
+        "nebraska-college-of-technical-agriculture"
+      ],
+      "termsByCollege": {
+        "central-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "little-priest-tribal-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "metropolitan-community-college-area": [
+          "2026FA",
+          "2026SS"
+        ],
+        "mid-plains-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP"
+        ],
+        "nebraska-indian-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "northeast-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southeast-community-college-area": [
+          "2026FA",
+          "2026SU"
+        ],
+        "western-nebraska-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SS",
+        "2026SU",
+        "2027SP"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026SS"
+      ],
+      "totalSections": 13124,
+      "zeroCreditSections": 2462,
+      "sectionsByCollege": {
+        "central-community-college": 1741,
+        "little-priest-tribal-college": 148,
+        "metropolitan-community-college-area": 3488,
+        "mid-plains-community-college": 2224,
+        "nebraska-indian-community-college": 300,
+        "northeast-community-college": 1103,
+        "southeast-community-college-area": 3132,
+        "western-nebraska-community-college": 988
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1088,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 9,
+      "collegeCount": 9
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 no articulation portal registered for NE."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 8,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "coverage 89%; 1 suspicious term(s)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1088 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "9/9 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "nh",
+    "name": "New Hampshire",
+    "collegeCount": 7,
+    "courses": {
+      "coveredColleges": 7,
+      "collegeCount": 7,
+      "missingColleges": [],
+      "termsByCollege": {
+        "gbcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "lrcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "mccnh": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "nashuacc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "nhti": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "rvcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "wmcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 7245,
+      "zeroCreditSections": 791,
+      "sectionsByCollege": {
+        "gbcc": 996,
+        "lrcc": 597,
+        "mccnh": 1566,
+        "nashuacc": 1033,
+        "nhti": 1719,
+        "rvcc": 684,
+        "wmcc": 650
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 600,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 2680,
+      "universities": [
+        "keene"
+      ],
+      "universityCount": 1,
+      "directMatches": 834,
+      "electiveOnly": 1846,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 7,
+      "collegeCount": 7
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": true,
+      "transfersReason": "UNH and Plymouth State publish no public CC-to-4-year articulation database. Keene scraper covers what is reachable; the remaining USNH receivers are a hard ceiling.",
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (7/7), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "600 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "B",
+        "reason": "ceiling: UNH and Plymouth State publish no public CC-to-4-year articulation database. Keene scraper covers what is reachable; the remaining USNH receivers are a hard ceiling."
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "7/7 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "transfers",
+      "ceilingsApplied": [
+        {
+          "dimension": "transfers",
+          "reason": "UNH and Plymouth State publish no public CC-to-4-year articulation database. Keene scraper covers what is reachable; the remaining USNH receivers are a hard ceiling."
+        }
+      ]
+    }
+  },
+  {
+    "slug": "nj",
+    "name": "New Jersey",
+    "collegeCount": 18,
+    "courses": {
+      "coveredColleges": 14,
+      "collegeCount": 18,
+      "missingColleges": [
+        "camden",
+        "ocean",
+        "salem",
+        "sussex",
+        "warren"
+      ],
+      "termsByCollege": {
+        "atlantic-cape": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bergen": [
+          "2026FA",
+          "2026S1"
+        ],
+        "brookdale": [
+          "26FA",
+          "26SU1"
+        ],
+        "ccm": [
+          "26FA15",
+          "26SU7E"
+        ],
+        "essex": [
+          "2026FA",
+          "2026SU"
+        ],
+        "hccc": [
+          "2026FA",
+          "2026SP",
+          "2026SU1"
+        ],
+        "mercer": [
+          "2026F",
+          "2026U"
+        ],
+        "middlesex": [
+          "26-FA",
+          "26-PS"
+        ],
+        "passaic": [
+          "26-FA",
+          "26-SU1"
+        ],
+        "rcbc": [
+          "2026FA",
+          "2026S1"
+        ],
+        "rcsj-cumberland": [
+          "2026FA",
+          "2026SU"
+        ],
+        "rcsj-gloucester": [
+          "2026FA",
+          "2026SU"
+        ],
+        "rvcc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "ucnj": [
+          "2026FA",
+          "2026S1",
+          "2026SP"
+        ]
+      },
+      "uniqueTerms": [
+        "2026F",
+        "2026FA",
+        "2026S1",
+        "2026SP",
+        "2026SU",
+        "2026SU1",
+        "2026U",
+        "26-FA",
+        "26-PS",
+        "26-SU1",
+        "26FA",
+        "26FA15",
+        "26SU1",
+        "26SU7E"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026F",
+        "2026S1",
+        "2026SU1",
+        "2026U",
+        "26-FA",
+        "26-PS",
+        "26-SU1",
+        "26FA",
+        "26FA15",
+        "26SU1",
+        "26SU7E"
+      ],
+      "totalSections": 21682,
+      "zeroCreditSections": 779,
+      "sectionsByCollege": {
+        "atlantic-cape": 1431,
+        "bergen": 2179,
+        "brookdale": 1617,
+        "ccm": 1048,
+        "essex": 1229,
+        "hccc": 3659,
+        "mercer": 1069,
+        "middlesex": 1710,
+        "passaic": 809,
+        "rcbc": 1594,
+        "rcsj-cumberland": 12,
+        "rcsj-gloucester": 583,
+        "rvcc": 1368,
+        "ucnj": 3374
+      },
+      "lowSectionColleges": [
+        "rcsj-cumberland"
+      ]
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 3002,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 102105,
+      "universities": [
+        "berkeley-college",
+        "caldwell-university",
+        "centenary-university",
+        "devry-university",
+        "drew-university",
+        "fairleigh-dickinson-florham",
+        "fairleigh-dickinson-metropolitan",
+        "felician-university",
+        "georgian-court-university",
+        "kean",
+        "monmouth",
+        "montclair",
+        "njcu",
+        "njit",
+        "ramapo",
+        "rider",
+        "rowan",
+        "rutgers-bus",
+        "rutgers-camden",
+        "rutgers-camden-school-of-business",
+        "rutgers-edward-bloustein-sch-of-planning-amp-policy",
+        "rutgers-eng",
+        "rutgers-ernest-mario-school-of-pharmacy",
+        "rutgers-mason-gross-school-of-arts",
+        "rutgers-newark",
+        "rutgers-newark-rutgers-business-school",
+        "rutgers-newark-school-of-criminal-justice",
+        "rutgers-newark-school-of-public-affairs-and-admin",
+        "rutgers-newark-university-college",
+        "rutgers-sas",
+        "rutgers-school-of-env-biological-sciences",
+        "rutgers-school-of-management-and-labor-relations",
+        "rutgers-school-of-nursing",
+        "saint-elizabeth-university",
+        "saint-peter-s-university",
+        "seton-hall",
+        "stockton",
+        "tcnj",
+        "tesu",
+        "william-paterson"
+      ],
+      "universityCount": 40,
+      "directMatches": 66166,
+      "electiveOnly": 0,
+      "noCredit": 35939,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 19,
+      "collegeCount": 18
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 78% (14/18)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "3002 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "40 universities, 102105 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "19/18 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "nm",
+    "name": "New Mexico",
+    "collegeCount": 12,
+    "courses": {
+      "coveredColleges": 7,
+      "collegeCount": 12,
+      "missingColleges": [
+        "clovis-community-college",
+        "new-mexico-military-institute",
+        "mesalands-community-college",
+        "luna-community-college",
+        "eastern-new-mexico-university-ruidoso-branch-community-college"
+      ],
+      "termsByCollege": {
+        "central-new-mexico-community-college": [
+          "2026SU"
+        ],
+        "new-mexico-junior-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "northern-new-mexico-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "san-juan-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "santa-fe-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southeast-new-mexico-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southwestern-indian-polytechnic-institute": [
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 5717,
+      "zeroCreditSections": 71,
+      "sectionsByCollege": {
+        "central-new-mexico-community-college": 1567,
+        "new-mexico-junior-college": 439,
+        "northern-new-mexico-college": 498,
+        "san-juan-college": 2120,
+        "santa-fe-community-college": 892,
+        "southeast-new-mexico-college": 118,
+        "southwestern-indian-polytechnic-institute": 83
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 255,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 42,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 8837,
+      "universities": [
+        "enmu",
+        "nmhu",
+        "nmsu",
+        "nmt",
+        "unm",
+        "wnmu"
+      ],
+      "universityCount": 6,
+      "directMatches": 8837,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 12,
+      "collegeCount": 12
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 6 catalog discovery yielded no templated catalogs."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 58% (7/12)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "255 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 8837 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "12/12 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "nv",
+    "name": "Nevada",
+    "collegeCount": 4,
+    "courses": {
+      "coveredColleges": 4,
+      "collegeCount": 4,
+      "missingColleges": [],
+      "termsByCollege": {
+        "college-of-southern-nevada": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "great-basin-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "truckee-meadows-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "western-nevada-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 10903,
+      "zeroCreditSections": 0,
+      "sectionsByCollege": {
+        "college-of-southern-nevada": 7009,
+        "great-basin-college": 804,
+        "truckee-meadows-community-college": 2296,
+        "western-nevada-college": 794
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1398,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 536,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 7780,
+      "universities": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "nsu",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "universityCount": 5,
+      "directMatches": 3176,
+      "electiveOnly": 3012,
+      "noCredit": 1592,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 4,
+      "collegeCount": 4
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (4/4), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1398 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "5 universities, 7780 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "4/4 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ny",
+    "name": "New York",
+    "collegeCount": 37,
+    "courses": {
+      "coveredColleges": 18,
+      "collegeCount": 37,
+      "missingColleges": [
+        "clinton-cc",
+        "north-country-cc",
+        "jefferson-cc",
+        "hudson-valley-cc",
+        "suny-orange",
+        "fmcc",
+        "genesee-cc",
+        "mvcc",
+        "tompkins-cortland-cc",
+        "suny-broome-cc",
+        "jamestown-cc",
+        "erie-cc",
+        "suny-niagara",
+        "monroe-cc",
+        "suny-sullivan",
+        "suny-ulster",
+        "nassau-cc",
+        "westchester-cc",
+        "fit"
+      ],
+      "termsByCollege": {
+        "bmcc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "bronx-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "cayuga-cc": [
+          "2026FA",
+          "2026SU",
+          "2027IN"
+        ],
+        "columbia-greene-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "corning-cc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "dutchess-cc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "finger-lakes-cc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "guttman-cc": [
+          "2026SP"
+        ],
+        "herkimer-cc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "hostos-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "kingsborough-cc": [
+          "2026FA",
+          "2026SP"
+        ],
+        "laguardia-cc": [
+          "2026FA",
+          "2026SP"
+        ],
+        "onondaga-cc": [
+          "UG26FA",
+          "UG26SU"
+        ],
+        "queensborough-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "rockland-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "suffolk-cc": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "suny-adirondack": [
+          "2026FA",
+          "2026SU"
+        ],
+        "suny-schenectady": [
+          "2026FA"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027IN",
+        "UG26FA",
+        "UG26SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2027IN",
+        "UG26FA",
+        "UG26SU"
+      ],
+      "totalSections": 21022,
+      "zeroCreditSections": 1676,
+      "sectionsByCollege": {
+        "bmcc": 1472,
+        "bronx-cc": 742,
+        "cayuga-cc": 712,
+        "columbia-greene-cc": 594,
+        "corning-cc": 573,
+        "dutchess-cc": 1404,
+        "finger-lakes-cc": 1033,
+        "guttman-cc": 85,
+        "herkimer-cc": 473,
+        "hostos-cc": 605,
+        "kingsborough-cc": 833,
+        "laguardia-cc": 1027,
+        "onondaga-cc": 1584,
+        "queensborough-cc": 1011,
+        "rockland-cc": 1250,
+        "suffolk-cc": 6452,
+        "suny-adirondack": 622,
+        "suny-schenectady": 550
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 4188,
+      "htmlContaminated": 250,
+      "htmlSamples": [
+        "ACC 1100: <p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics development...",
+        "ACC 360: <p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite...",
+        "ACC 370: <p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite..."
+      ],
+      "emptyCourseArrays": 744,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 254448,
+      "universities": [
+        "baruch",
+        "brooklyn",
+        "ccny",
+        "city-tech",
+        "csi",
+        "cuny-slu",
+        "cuny-sps",
+        "grad-center",
+        "hunter",
+        "john-jay",
+        "lehman",
+        "medgar-evers",
+        "queens",
+        "suny-alfred-state",
+        "suny-binghamton",
+        "suny-brockport",
+        "suny-buffalo",
+        "suny-buffalo-state",
+        "suny-canton",
+        "suny-cobleskill",
+        "suny-cortland",
+        "suny-delhi",
+        "suny-empire-state",
+        "suny-farmingdale",
+        "suny-fredonia",
+        "suny-geneseo",
+        "suny-morrisville",
+        "suny-new-paltz",
+        "suny-old-westbury",
+        "suny-oneonta",
+        "suny-oswego",
+        "suny-plattsburgh",
+        "suny-polytechnic",
+        "suny-potsdam",
+        "suny-purchase",
+        "york"
+      ],
+      "universityCount": 36,
+      "directMatches": 136132,
+      "electiveOnly": 112347,
+      "noCredit": 5969,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 19,
+      "collegeCount": 37
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 49% (18/37)"
+      },
+      "prereqs": {
+        "grade": "C",
+        "reason": "250 entries have HTML contamination"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "36 universities, 254448 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "C",
+        "reason": "19/37 scorecards (51%)"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "D",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "oh",
+    "name": "Ohio",
+    "collegeCount": 22,
+    "courses": {
+      "coveredColleges": 9,
+      "collegeCount": 22,
+      "missingColleges": [
+        "clark-state-college",
+        "lorain-county-community-college",
+        "marion-technical-college",
+        "zane-state-college",
+        "sinclair-community-college",
+        "belmont-college",
+        "columbus-state-community-college",
+        "edison-state-community-college",
+        "eastern-gateway-community-college",
+        "lakeland-community-college",
+        "northwest-state-community-college",
+        "owens-community-college",
+        "southern-state-community-college"
+      ],
+      "termsByCollege": {
+        "central-ohio-technical-college": [
+          "26SM"
+        ],
+        "cincinnati-state-technical-and-community-college": [
+          "2026FA",
+          "26-FA",
+          "26-SU"
+        ],
+        "cuyahoga-community-college-district": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "hocking-college": [
+          "2026SM"
+        ],
+        "james-a-rhodes-state-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "north-central-state-college": [
+          "FA2026",
+          "SU2026"
+        ],
+        "stark-state-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "terra-state-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "washington-state-community-college": [
+          "2026-FA",
+          "2026-SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-FA",
+        "2026-SU",
+        "2026FA",
+        "2026SM",
+        "2026SP",
+        "2026SU",
+        "26-FA",
+        "26-SU",
+        "26SM",
+        "FA2026",
+        "SU2026"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-FA",
+        "2026-SU",
+        "2026SM",
+        "26-FA",
+        "26-SU",
+        "26SM",
+        "FA2026",
+        "SU2026"
+      ],
+      "totalSections": 18265,
+      "zeroCreditSections": 1285,
+      "sectionsByCollege": {
+        "central-ohio-technical-college": 340,
+        "cincinnati-state-technical-and-community-college": 3836,
+        "cuyahoga-community-college-district": 7736,
+        "hocking-college": 91,
+        "james-a-rhodes-state-college": 495,
+        "north-central-state-college": 641,
+        "stark-state-college": 3724,
+        "terra-state-community-college": 1039,
+        "washington-state-community-college": 363
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1721,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 5348,
+      "universities": [
+        "osu"
+      ],
+      "universityCount": 1,
+      "directMatches": 2820,
+      "electiveOnly": 2528,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 21,
+      "collegeCount": 22
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 41% (9/22)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1721 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 5348 mappings"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "21/22 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "D",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ok",
+    "name": "Oklahoma",
+    "collegeCount": 13,
+    "courses": {
+      "coveredColleges": 7,
+      "collegeCount": 13,
+      "missingColleges": [
+        "eastern-oklahoma-state-college",
+        "northern-oklahoma-college",
+        "northeastern-oklahoma-aandm-college",
+        "rose-state-college",
+        "seminole-state-college",
+        "college-of-the-muscogee-nation"
+      ],
+      "termsByCollege": {
+        "carl-albert-state-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "connors-state-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "murray-state-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "oklahoma-city-community-college": [
+          "26SU"
+        ],
+        "redlands-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "tulsa-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "western-oklahoma-state-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU",
+        "26SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "26SU"
+      ],
+      "totalSections": 5304,
+      "zeroCreditSections": 71,
+      "sectionsByCollege": {
+        "carl-albert-state-college": 381,
+        "connors-state-college": 453,
+        "murray-state-college": 623,
+        "oklahoma-city-community-college": 346,
+        "redlands-community-college": 354,
+        "tulsa-community-college": 2818,
+        "western-oklahoma-state-college": 329
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 530,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 13,
+      "collegeCount": 13
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": true,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "rose-state-college \u2014 PeopleSoft Community Access at",
+        "northern-oklahoma-college, seminole-state-college \u2014 Jenzabar",
+        "eastern-oklahoma-state-college \u2014 no public guest course-search",
+        "transfers \u2014 Oklahoma Course Equivalency Project (OCEP) at",
+        "programs \u2014 none of the 13 catalogs matched a templated"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 54% (7/13)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "530 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "13/13 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "or",
+    "name": "Oregon",
+    "collegeCount": 17,
+    "courses": {
+      "coveredColleges": 9,
+      "collegeCount": 17,
+      "missingColleges": [
+        "mt-hood-community-college",
+        "blue-mountain-community-college",
+        "clackamas-community-college",
+        "portland-community-college",
+        "rogue-community-college",
+        "southwestern-oregon-community-college",
+        "umpqua-community-college",
+        "tillamook-bay-community-college"
+      ],
+      "termsByCollege": {
+        "central-oregon-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "chemeketa-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "clatsop-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "columbia-gorge-community-college": [
+          "2026FA",
+          "2026SP",
+          "2027SU"
+        ],
+        "klamath-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2026WI"
+        ],
+        "lane-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP"
+        ],
+        "linn-benton-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "oregon-coast-community-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "treasure-valley-community-college": [
+          "2025SP",
+          "2025WI",
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2025SP",
+        "2025WI",
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2026WI",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2025WI",
+        "2026WI"
+      ],
+      "totalSections": 13527,
+      "zeroCreditSections": 814,
+      "sectionsByCollege": {
+        "central-oregon-community-college": 1644,
+        "chemeketa-community-college": 2956,
+        "clatsop-community-college": 717,
+        "columbia-gorge-community-college": 142,
+        "klamath-community-college": 1807,
+        "lane-community-college": 2522,
+        "linn-benton-community-college": 2196,
+        "oregon-coast-community-college": 121,
+        "treasure-valley-community-college": 1422
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 946,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 11479,
+      "universities": [
+        "oregon-state"
+      ],
+      "universityCount": 1,
+      "directMatches": 1753,
+      "electiveOnly": 9726,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 17,
+      "collegeCount": 17
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 53% (9/17)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "946 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 11479 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "17/17 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "pa",
+    "name": "Pennsylvania",
+    "collegeCount": 15,
+    "courses": {
+      "coveredColleges": 10,
+      "collegeCount": 15,
+      "missingColleges": [
+        "bucks",
+        "butler",
+        "ccbc",
+        "pa-highlands",
+        "penn-college"
+      ],
+      "termsByCollege": {
+        "ccac": [
+          "26FA",
+          "26SU"
+        ],
+        "ccp": [
+          "2026FA",
+          "2026SU"
+        ],
+        "dccc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "hacc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lccc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "luzerne": [
+          "FA-2026",
+          "S1-2026"
+        ],
+        "mc3": [
+          "2026-FA",
+          "2026-SR"
+        ],
+        "northampton": [
+          "2026FA",
+          "2026SU"
+        ],
+        "racc": [
+          "2026FA",
+          "2026SU"
+        ],
+        "westmoreland": [
+          "2026FA",
+          "2026SU",
+          "2026WI"
+        ]
+      },
+      "uniqueTerms": [
+        "2026-FA",
+        "2026-SR",
+        "2026FA",
+        "2026SU",
+        "2026WI",
+        "26FA",
+        "26SU",
+        "FA-2026",
+        "S1-2026"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2026-FA",
+        "2026-SR",
+        "2026WI",
+        "26FA",
+        "26SU",
+        "FA-2026",
+        "S1-2026"
+      ],
+      "totalSections": 17569,
+      "zeroCreditSections": 1326,
+      "sectionsByCollege": {
+        "ccac": 3178,
+        "ccp": 3039,
+        "dccc": 1566,
+        "hacc": 2256,
+        "lccc": 1613,
+        "luzerne": 1079,
+        "mc3": 1911,
+        "northampton": 1746,
+        "racc": 734,
+        "westmoreland": 447
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1351,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 54529,
+      "universities": [
+        "commonwealth",
+        "kutztown",
+        "millersville",
+        "penn-state",
+        "pitt",
+        "slippery-rock",
+        "west-chester"
+      ],
+      "universityCount": 7,
+      "directMatches": 35131,
+      "electiveOnly": 19398,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 15,
+      "collegeCount": 15
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Acalog program scraper not yet wired up for this state."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 67% (10/15)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1351 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "7 universities, 54529 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "15/15 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ri",
+    "name": "Rhode Island",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ccri": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 4341,
+      "zeroCreditSections": 50,
+      "sectionsByCollege": {
+        "ccri": 4341
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 507,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 4,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 1291,
+      "universities": [
+        "ric",
+        "uri"
+      ],
+      "universityCount": 2,
+      "directMatches": 562,
+      "electiveOnly": 707,
+      "noCredit": 22,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "507 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "B",
+        "reason": "2 universities, 1291 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "B",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "sc",
+    "name": "South Carolina",
+    "collegeCount": 16,
+    "courses": {
+      "coveredColleges": 16,
+      "collegeCount": 16,
+      "missingColleges": [],
+      "termsByCollege": {
+        "aiken": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "central-carolina": [
+          "2026FA"
+        ],
+        "denmark": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "florence-darlington": [
+          "2026FA",
+          "2026SU"
+        ],
+        "greenville": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "horry-georgetown": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "lowcountry": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "midlands": [
+          "2026SU"
+        ],
+        "northeastern": [
+          "2026SU"
+        ],
+        "orangeburg-calhoun": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "piedmont": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "spartanburg": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "tri-county": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "trident": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "williamsburg": [
+          "2026SP",
+          "2026SU"
+        ],
+        "york": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 21428,
+      "zeroCreditSections": 1442,
+      "sectionsByCollege": {
+        "aiken": 865,
+        "central-carolina": 368,
+        "denmark": 456,
+        "florence-darlington": 709,
+        "greenville": 3563,
+        "horry-georgetown": 3439,
+        "lowcountry": 676,
+        "midlands": 846,
+        "northeastern": 136,
+        "orangeburg-calhoun": 298,
+        "piedmont": 2861,
+        "spartanburg": 2076,
+        "tri-county": 3469,
+        "trident": 1106,
+        "williamsburg": 179,
+        "york": 381
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 934,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 9463,
+      "universities": [
+        "clemson",
+        "cofc",
+        "usc",
+        "usc-upstate"
+      ],
+      "universityCount": 4,
+      "directMatches": 7905,
+      "electiveOnly": 1558,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 16,
+      "collegeCount": 16
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (16/16), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "934 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "4 universities, 9463 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "16/16 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "sd",
+    "name": "South Dakota",
+    "collegeCount": 6,
+    "courses": {
+      "coveredColleges": 2,
+      "collegeCount": 6,
+      "missingColleges": [
+        "sisseton-wahpeton-college",
+        "lake-area-technical-college",
+        "mitchell-technical-college",
+        "western-dakota-technical-college"
+      ],
+      "termsByCollege": {
+        "oglala-lakota-college": [
+          "fall-2026",
+          "summer-2026"
+        ],
+        "southeast-technical-college": [
+          "fall-2026",
+          "spring-2026",
+          "summer-2026"
+        ]
+      },
+      "uniqueTerms": [
+        "fall-2026",
+        "spring-2026",
+        "summer-2026"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "fall-2026",
+        "spring-2026",
+        "summer-2026"
+      ],
+      "totalSections": 753,
+      "zeroCreditSections": 41,
+      "sectionsByCollege": {
+        "oglala-lakota-college": 374,
+        "southeast-technical-college": 379
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 98,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 15,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 255,
+      "universities": [
+        "usd"
+      ],
+      "universityCount": 1,
+      "directMatches": 147,
+      "electiveOnly": 108,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 6,
+      "collegeCount": 6
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": true,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "lake-area-technical-college, western-dakota-technical-college,",
+        "SDSU, SDSMT, BHSU, NSU, DSU \u2014 the SD Board of Regents",
+        "western-dakota-technical-college \u2014 catalog is PDF only.",
+        "lake-area-technical-college, oglala-lakota-college,",
+        "mitchell-technical-college \u2014 Coursedog course descriptions"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": false,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 33% (2/6)"
+      },
+      "prereqs": {
+        "grade": "B",
+        "reason": "98 entries"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 255 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "6/6 scorecards"
+      },
+      "config": {
+        "grade": "B",
+        "reason": "seniorWaiver missing"
+      },
+      "composite": "D",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "tn",
+    "name": "Tennessee",
+    "collegeCount": 12,
+    "courses": {
+      "coveredColleges": 12,
+      "collegeCount": 12,
+      "missingColleges": [],
+      "termsByCollege": {
+        "chattanooga-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "cleveland-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "columbia-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "dyersburg-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "jackson-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "motlow-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "nashville-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "northeast-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "pellissippi-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "southwest-tn": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "volunteer-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "walters-state": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 34599,
+      "zeroCreditSections": 2394,
+      "sectionsByCollege": {
+        "chattanooga-state": 4698,
+        "cleveland-state": 1519,
+        "columbia-state": 2458,
+        "dyersburg-state": 1948,
+        "jackson-state": 2224,
+        "motlow-state": 2858,
+        "nashville-state": 3035,
+        "northeast-state": 3209,
+        "pellissippi-state": 4163,
+        "southwest-tn": 2979,
+        "volunteer-state": 2987,
+        "walters-state": 2521
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 628,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 98,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 62959,
+      "universities": [
+        "apsu",
+        "mtsu",
+        "ttu",
+        "utk",
+        "utm"
+      ],
+      "universityCount": 5,
+      "directMatches": 34266,
+      "electiveOnly": 26337,
+      "noCredit": 2356,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 12,
+      "collegeCount": 12
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (12/12), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "628 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "5 universities, 62959 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "12/12 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "tx",
+    "name": "Texas",
+    "collegeCount": 59,
+    "courses": {
+      "coveredColleges": 37,
+      "collegeCount": 59,
+      "missingColleges": [
+        "austin-community-college-district",
+        "brazosport-college",
+        "dallas-college",
+        "galveston-college",
+        "grayson-college",
+        "trinity-valley-community-college",
+        "midland-college",
+        "san-jacinto-community-college",
+        "tyler-junior-college",
+        "angelina-college",
+        "central-texas-college",
+        "north-central-texas-college",
+        "el-paso-community-college",
+        "hill-college",
+        "lamar-state-college-orange",
+        "lee-college",
+        "texas-southmost-college",
+        "ranger-college",
+        "southwest-texas-junior-college",
+        "western-texas-college",
+        "wharton-county-junior-college",
+        "texas-state-technical-college"
+      ],
+      "termsByCollege": {
+        "alvin-community-college": [
+          "226FA",
+          "226SU1"
+        ],
+        "amarillo-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "blinn-college-district": [
+          "2026FA",
+          "2026SU"
+        ],
+        "cisco-college": [
+          "2026FA",
+          "2026FA2",
+          "2026SU1",
+          "2026SU2",
+          "2026SUL"
+        ],
+        "clarendon-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "coastal-bend-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "college-of-the-mainland": [
+          "FA2026",
+          "S12026"
+        ],
+        "collin-county-community-college-district": [
+          "2026SU"
+        ],
+        "del-mar-college": [
+          "2026FA",
+          "2026S1"
+        ],
+        "frank-phillips-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU1",
+          "2026SU2",
+          "2026SUL",
+          "2026SUMINI"
+        ],
+        "houston-community-college": [
+          "2026FA"
+        ],
+        "howard-college": [
+          "2025FA",
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "kilgore-college": [
+          "2026FA"
+        ],
+        "lamar-institute-of-technology": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lamar-state-college-port-arthur": [
+          "2026FA",
+          "2026SU"
+        ],
+        "laredo-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lone-star-college-system": [
+          "2026FA"
+        ],
+        "mclennan-community-college": [
+          "2026-FA",
+          "2026-SM"
+        ],
+        "navarro-college": [
+          "26-FA"
+        ],
+        "northeast-lakeview-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "northeast-texas-community-college": [
+          "2026DEC",
+          "2026FA",
+          "2026MAY",
+          "2026SP",
+          "2026SU"
+        ],
+        "northwest-vista-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "odessa-college": [
+          "2026FA",
+          "26-FA",
+          "26-S1"
+        ],
+        "palo-alto-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "panola-college": [
+          "2025FA",
+          "2025SP",
+          "2025SU",
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "paris-junior-college": [
+          "2026FA"
+        ],
+        "san-antonio-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "south-plains-college": [
+          "2026FA"
+        ],
+        "south-texas-college": [
+          "2026SP",
+          "2026SU"
+        ],
+        "southwest-college-for-the-deaf": [
+          "2026FA"
+        ],
+        "st-philips-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ],
+        "tarrant-county-college-district": [
+          "2026SU"
+        ],
+        "temple-college": [
+          "FA2026",
+          "Q32026"
+        ],
+        "texarkana-college": [
+          "2025FA",
+          "2025SP",
+          "2025SU",
+          "2025WI",
+          "2026FA",
+          "2026SP",
+          "2026SU",
+          "2026WI",
+          "2027FA",
+          "2027SP",
+          "2027SU",
+          "2028FA",
+          "2028SP",
+          "2028SU",
+          "2029FA",
+          "2029SP"
+        ],
+        "vernon-college": [
+          "2026FA",
+          "SU26CE"
+        ],
+        "victoria-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "weatherford-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2025FA",
+        "2025SP",
+        "2025SU",
+        "2025WI",
+        "2026-FA",
+        "2026-SM",
+        "2026DEC",
+        "2026FA",
+        "2026FA2",
+        "2026MAY",
+        "2026S1",
+        "2026SP",
+        "2026SU",
+        "2026SU1",
+        "2026SU2",
+        "2026SUL",
+        "2026SUMINI",
+        "2026WI",
+        "2027FA",
+        "2027SP",
+        "2027SU",
+        "2028FA",
+        "2028SP",
+        "2028SU",
+        "2029FA",
+        "2029SP",
+        "226FA",
+        "226SU1",
+        "26-FA",
+        "26-S1",
+        "FA2026",
+        "Q32026",
+        "S12026",
+        "SU26CE"
+      ],
+      "staleTerms": [
+        "2025FA"
+      ],
+      "suspiciousTerms": [
+        "2025WI",
+        "2026-FA",
+        "2026-SM",
+        "2026DEC",
+        "2026FA2",
+        "2026MAY",
+        "2026S1",
+        "2026SU1",
+        "2026SU2",
+        "2026SUL",
+        "2026SUMINI",
+        "2026WI",
+        "2028FA",
+        "2028SP",
+        "2028SU",
+        "2029FA",
+        "2029SP",
+        "226FA",
+        "226SU1",
+        "26-FA",
+        "26-S1",
+        "FA2026",
+        "Q32026",
+        "S12026",
+        "SU26CE"
+      ],
+      "totalSections": 77630,
+      "zeroCreditSections": 7616,
+      "sectionsByCollege": {
+        "alvin-community-college": 287,
+        "amarillo-college": 2187,
+        "blinn-college-district": 125,
+        "cisco-college": 949,
+        "clarendon-college": 205,
+        "coastal-bend-college": 447,
+        "college-of-the-mainland": 1369,
+        "collin-county-community-college-district": 1948,
+        "del-mar-college": 2921,
+        "frank-phillips-college": 784,
+        "houston-community-college": 4934,
+        "howard-college": 987,
+        "kilgore-college": 881,
+        "lamar-institute-of-technology": 876,
+        "lamar-state-college-port-arthur": 519,
+        "laredo-college": 972,
+        "lone-star-college-system": 6939,
+        "mclennan-community-college": 1224,
+        "navarro-college": 984,
+        "northeast-lakeview-college": 2876,
+        "northeast-texas-community-college": 1784,
+        "northwest-vista-college": 6547,
+        "odessa-college": 3731,
+        "palo-alto-college": 4853,
+        "panola-college": 3396,
+        "paris-junior-college": 665,
+        "san-antonio-college": 7998,
+        "south-plains-college": 1678,
+        "south-texas-college": 46,
+        "southwest-college-for-the-deaf": 61,
+        "st-philips-college": 6954,
+        "tarrant-county-college-district": 2952,
+        "temple-college": 972,
+        "texarkana-college": 766,
+        "vernon-college": 726,
+        "victoria-college": 1142,
+        "weatherford-college": 945
+      },
+      "lowSectionColleges": [
+        "south-texas-college"
+      ]
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 2511,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 554,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 187494,
+      "universities": [
+        "abilene-christian-university",
+        "angelo-state-university",
+        "baylor-university",
+        "dallas-baptist-university",
+        "east-texas-a-m-university-commerce",
+        "howard-payne-university",
+        "lamar-university",
+        "letourneau-university",
+        "mcmurry-university",
+        "midwestern-state-university",
+        "nelson-university",
+        "our-lady-of-the-lake-university",
+        "prairie-view-a-m-university",
+        "sam-houston-state-university",
+        "schreiner-university",
+        "southwestern-adventist-university",
+        "southwestern-university",
+        "st-mary-s-university",
+        "stephen-f-austin-state-university",
+        "tarleton-state-university",
+        "texas-a-m-international-university",
+        "texas-a-m-university",
+        "texas-a-m-university-central-texas",
+        "texas-a-m-university-corpus-christi",
+        "texas-a-m-university-galveston",
+        "texas-a-m-university-kingsville",
+        "texas-a-m-university-san-antonio",
+        "texas-a-m-university-texarkana",
+        "texas-a-m-university-victoria-formerly-university-of-houston-victoria",
+        "texas-christian-university",
+        "texas-southern-university",
+        "texas-state-university",
+        "texas-tech-university",
+        "texas-woman-s-university",
+        "university-of-houston",
+        "university-of-north-texas",
+        "university-of-north-texas-at-dallas",
+        "university-of-st-thomas",
+        "university-of-texas-at-arlington",
+        "university-of-texas-at-dallas",
+        "university-of-texas-at-san-antonio",
+        "university-of-texas-rio-grande-valley",
+        "west-texas-a-m-university"
+      ],
+      "universityCount": 43,
+      "directMatches": 172230,
+      "electiveOnly": 15264,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 56,
+      "collegeCount": 59
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "C",
+        "reason": "coverage 63% (37/59)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "2511 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "43 universities, 187494 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "56/59 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "ut",
+    "name": "Utah",
+    "collegeCount": 2,
+    "courses": {
+      "coveredColleges": 2,
+      "collegeCount": 2,
+      "missingColleges": [],
+      "termsByCollege": {
+        "salt-lake-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "snow-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 9141,
+      "zeroCreditSections": 109,
+      "sectionsByCollege": {
+        "salt-lake-community-college": 7029,
+        "snow-college": 2112
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 703,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 22727,
+      "universities": [
+        "southern-utah-university",
+        "university-of-utah",
+        "utah-state-university",
+        "utah-tech-university",
+        "utah-valley-university",
+        "weber-state-university"
+      ],
+      "universityCount": 6,
+      "directMatches": 19584,
+      "electiveOnly": 3143,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 2,
+      "collegeCount": 2
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (2/2), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "703 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "A",
+        "reason": "6 universities, 22727 mappings, wired"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "2/2 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "A",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "va",
+    "name": "Virginia",
+    "collegeCount": 23,
+    "courses": {
+      "coveredColleges": 23,
+      "collegeCount": 23,
+      "missingColleges": [],
+      "termsByCollege": {
+        "brcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "brightpoint": [
+          "2026SP",
+          "2026SU"
+        ],
+        "camp": [
+          "2026SP",
+          "2026SU"
+        ],
+        "cvcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "dcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "escc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "gcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "laurelridge": [
+          "2026SP",
+          "2026SU"
+        ],
+        "mecc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "mgcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "nova": [
+          "2026SP",
+          "2026SU"
+        ],
+        "nrcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "phcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "pvcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "rcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "reynolds": [
+          "2026SP",
+          "2026SU"
+        ],
+        "svcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "swcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "tcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "vhcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "vpcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "vwcc": [
+          "2026SP",
+          "2026SU"
+        ],
+        "wcc": [
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 26236,
+      "zeroCreditSections": 2207,
+      "sectionsByCollege": {
+        "brcc": 876,
+        "brightpoint": 1525,
+        "camp": 462,
+        "cvcc": 826,
+        "dcc": 659,
+        "escc": 281,
+        "gcc": 1309,
+        "laurelridge": 843,
+        "mecc": 529,
+        "mgcc": 369,
+        "nova": 6377,
+        "nrcc": 933,
+        "phcc": 738,
+        "pvcc": 687,
+        "rcc": 555,
+        "reynolds": 1385,
+        "svcc": 560,
+        "swcc": 588,
+        "tcc": 3585,
+        "vhcc": 487,
+        "vpcc": 1204,
+        "vwcc": 1140,
+        "wcc": 318
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 374,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 72,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 15483,
+      "universities": [
+        "gmu",
+        "odu",
+        "umw",
+        "uva",
+        "vcu",
+        "vsu",
+        "vt",
+        "vwu"
+      ],
+      "universityCount": 8,
+      "directMatches": 4108,
+      "electiveOnly": 10311,
+      "noCredit": 1064,
+      "transferSupported": true,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 23,
+      "collegeCount": 23
+    },
+    "scrapers": {
+      "coursesWired": false,
+      "coursesManualOnly": true,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "courses \u2014 VA PeopleSoft scraper consistently exceeds the 6h GitHub Actions timeout; run manually when needed.",
+        "transfers \u2014 disabled alongside courses to avoid partial-refresh drift.",
+        "programs \u2014 disabled alongside courses."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 8,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (23/23), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "374 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "D",
+        "reason": "data exists (15483) but scraper not wired \u2014 will go stale"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "23/23 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "D",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "vt",
+    "name": "Vermont",
+    "collegeCount": 1,
+    "courses": {
+      "coveredColleges": 1,
+      "collegeCount": 1,
+      "missingColleges": [],
+      "termsByCollege": {
+        "ccv": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 3813,
+      "zeroCreditSections": 491,
+      "sectionsByCollege": {
+        "ccv": 3813
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 759,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 346,
+      "universities": [
+        "uvm"
+      ],
+      "universityCount": 1,
+      "directMatches": 134,
+      "electiveOnly": 212,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 1,
+      "collegeCount": 1
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": []
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "A",
+        "reason": "full coverage (1/1), terms clean"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "759 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 346 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "1/1 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "C",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "wa",
+    "name": "Washington",
+    "collegeCount": 34,
+    "courses": {
+      "coveredColleges": 33,
+      "collegeCount": 34,
+      "missingColleges": [
+        "northwest-indian-college"
+      ],
+      "termsByCollege": {
+        "bates-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "bellevue-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "bellingham-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "big-bend-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "cascadia-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "centralia-college": [
+          "2026FA",
+          "2026SU",
+          "2027WI"
+        ],
+        "clark-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "clover-park-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "columbia-basin-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "edmonds-college": [
+          "2026FA",
+          "2026SU",
+          "2027WI"
+        ],
+        "everett-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "grays-harbor-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "green-river-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "highline-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "lake-washington-institute-of-technology": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "lower-columbia-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "north-seattle-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "olympic-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "peninsula-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "pierce-college-district": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "renton-technical-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "seattle-central-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "shoreline-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "skagit-valley-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "south-puget-sound-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "south-seattle-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "spokane-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "spokane-falls-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027WI"
+        ],
+        "tacoma-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "walla-walla-community-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "wenatchee-valley-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "whatcom-community-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ],
+        "yakima-valley-college": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027WI"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SU",
+        "2027SP",
+        "2027WI"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "2027WI"
+      ],
+      "totalSections": 74273,
+      "zeroCreditSections": 12455,
+      "sectionsByCollege": {
+        "bates-technical-college": 2560,
+        "bellevue-college": 4392,
+        "bellingham-technical-college": 1486,
+        "big-bend-community-college": 1416,
+        "cascadia-college": 464,
+        "centralia-college": 728,
+        "clark-college": 5436,
+        "clover-park-technical-college": 3589,
+        "columbia-basin-college": 3609,
+        "edmonds-college": 1532,
+        "everett-community-college": 1375,
+        "grays-harbor-college": 1418,
+        "green-river-college": 6191,
+        "highline-college": 1577,
+        "lake-washington-institute-of-technology": 2833,
+        "lower-columbia-college": 1993,
+        "north-seattle-college": 804,
+        "olympic-college": 2733,
+        "peninsula-college": 318,
+        "pierce-college-district": 4219,
+        "renton-technical-college": 1933,
+        "seattle-central-college": 1040,
+        "shoreline-community-college": 2138,
+        "skagit-valley-college": 2959,
+        "south-puget-sound-community-college": 2742,
+        "south-seattle-college": 653,
+        "spokane-community-college": 3321,
+        "spokane-falls-community-college": 997,
+        "tacoma-community-college": 3110,
+        "walla-walla-community-college": 793,
+        "wenatchee-valley-college": 1848,
+        "whatcom-community-college": 2056,
+        "yakima-valley-college": 2010
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": false,
+      "count": 0,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": true,
+      "scraperManualOnly": true
+    },
+    "transfers": {
+      "exists": true,
+      "count": 37902,
+      "universities": [
+        "university-of-washington"
+      ],
+      "universityCount": 1,
+      "directMatches": 37471,
+      "electiveOnly": 7,
+      "noCredit": 424,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 33,
+      "collegeCount": 34
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": true,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": true,
+      "manualOnlyReasons": [
+        "prereqs \u2014 ctcLink course search exposes no prerequisite text,",
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "1 suspicious term(s)"
+      },
+      "prereqs": {
+        "grade": "F",
+        "reason": "no prereqs file"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 37902 mappings"
+      },
+      "scorecard": {
+        "grade": "B",
+        "reason": "33/34 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "prereqs",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "wi",
+    "name": "Wisconsin",
+    "collegeCount": 16,
+    "courses": {
+      "coveredColleges": 4,
+      "collegeCount": 16,
+      "missingColleges": [
+        "madison-area-technical-college",
+        "blackhawk-technical-college",
+        "fox-valley-technical-college",
+        "gateway-technical-college",
+        "lakeshore-technical-college",
+        "mid-state-technical-college",
+        "milwaukee-area-technical-college",
+        "moraine-park-technical-college",
+        "nicolet-area-technical-college",
+        "northeast-wisconsin-technical-college",
+        "waukesha-county-technical-college",
+        "northwood-technical-college"
+      ],
+      "termsByCollege": {
+        "chippewa-valley-technical-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "northcentral-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "southwest-wisconsin-technical-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "western-technical-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 4468,
+      "zeroCreditSections": 29,
+      "sectionsByCollege": {
+        "chippewa-valley-technical-college": 1557,
+        "northcentral-technical-college": 1442,
+        "southwest-wisconsin-technical-college": 525,
+        "western-technical-college": 944
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": false,
+      "count": 0,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 0,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 16,
+      "collegeCount": 16
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": true,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": false,
+      "prereqsManualOnly": true,
+      "manualOnlyReasons": [
+        "transfers \u2014 No WI articulation portal registered. CollegeTransfer.Net fallback available.",
+        "prereqs \u2014 Coursedog catalog data for Nicolet Area TC at data/wi/coursedog-catalog/; aggregate into prereqs.json manually.",
+        "programs \u2014 Phase 6 discovery found no matching catalog platforms; manual investigation needed."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 25% (4/16)"
+      },
+      "prereqs": {
+        "grade": "F",
+        "reason": "no prereqs file"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "16/16 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "prereqs",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "wv",
+    "name": "West Virginia",
+    "collegeCount": 9,
+    "courses": {
+      "coveredColleges": 3,
+      "collegeCount": 9,
+      "missingColleges": [
+        "blueridge",
+        "bridgevalley",
+        "newriver",
+        "pierpont",
+        "southern",
+        "wvncc"
+      ],
+      "termsByCollege": {
+        "eastern": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "mountwest": [
+          "2026FA",
+          "2026SU"
+        ],
+        "wvup": [
+          "2026FA",
+          "2026SU",
+          "2027SP",
+          "2027SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "2027SP",
+        "2027SU"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [],
+      "totalSections": 1722,
+      "zeroCreditSections": 81,
+      "sectionsByCollege": {
+        "eastern": 462,
+        "mountwest": 529,
+        "wvup": 731
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 1602,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 459,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 1604,
+      "universities": [
+        "marshall"
+      ],
+      "universityCount": 1,
+      "directMatches": 458,
+      "electiveOnly": 1146,
+      "noCredit": 0,
+      "transferSupported": true,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "scorecard": {
+      "files": 9,
+      "collegeCount": 9
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": true,
+      "transfersManualOnly": false,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "blueridge \u2014 JS-rendered WP schedule, data source unknown",
+        "bridgevalley, pierpont, southern \u2014 Ellucian Experience SSO",
+        "newriver \u2014 Banner SSB but visual CAPTCHA (sgcaptcha WAF)",
+        "wvncc \u2014 Pathify SAML portal, no public SIS endpoint",
+        "programs \u2014 Phase 5+."
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 6,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "D",
+        "reason": "coverage 33% (3/9)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "1602 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "C",
+        "reason": "thin: 1 university, 1604 mappings"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "9/9 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "D",
+      "limitedBy": "courses",
+      "ceilingsApplied": []
+    }
+  },
+  {
+    "slug": "wy",
+    "name": "Wyoming",
+    "collegeCount": 7,
+    "courses": {
+      "coveredColleges": 6,
+      "collegeCount": 7,
+      "missingColleges": [
+        "central-wyoming-college"
+      ],
+      "termsByCollege": {
+        "casper-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "eastern-wyoming-college": [
+          "2026FA",
+          "2026SU"
+        ],
+        "laramie-county-community-college": [
+          "2026FA"
+        ],
+        "northern-wyoming-community-college-district": [
+          "2026SU",
+          "26-FA1"
+        ],
+        "northwest-college": [
+          "2026FA",
+          "2026SP",
+          "2026SU"
+        ],
+        "western-wyoming-community-college": [
+          "2026FA",
+          "2026SU"
+        ]
+      },
+      "uniqueTerms": [
+        "2026FA",
+        "2026SP",
+        "2026SU",
+        "26-FA1"
+      ],
+      "staleTerms": [],
+      "suspiciousTerms": [
+        "26-FA1"
+      ],
+      "totalSections": 3793,
+      "zeroCreditSections": 305,
+      "sectionsByCollege": {
+        "casper-college": 979,
+        "eastern-wyoming-college": 388,
+        "laramie-county-community-college": 810,
+        "northern-wyoming-community-college-district": 163,
+        "northwest-college": 954,
+        "western-wyoming-community-college": 499
+      },
+      "lowSectionColleges": []
+    },
+    "prereqs": {
+      "exists": true,
+      "count": 668,
+      "htmlContaminated": 0,
+      "htmlSamples": [],
+      "emptyCourseArrays": 46,
+      "scraperDeclared": true,
+      "scraperManualOnly": false
+    },
+    "transfers": {
+      "exists": true,
+      "count": 0,
+      "universities": [],
+      "universityCount": 0,
+      "directMatches": 0,
+      "electiveOnly": 0,
+      "noCredit": 0,
+      "transferSupported": false,
+      "scraperDeclared": false,
+      "scraperManualOnly": true
+    },
+    "scorecard": {
+      "files": 7,
+      "collegeCount": 7
+    },
+    "scrapers": {
+      "coursesWired": true,
+      "coursesManualOnly": false,
+      "transfersWired": false,
+      "transfersManualOnly": true,
+      "prereqsWired": true,
+      "prereqsManualOnly": false,
+      "manualOnlyReasons": [
+        "transfers \u2014 Wyoming has no registered articulation portal",
+        "programs \u2014 Phase 6 wrapper at scripts/wy/scrape-programs.ts"
+      ]
+    },
+    "config": {
+      "seniorWaiverSet": true,
+      "seniorWaiverPlaceholder": false,
+      "popularCoursesCount": 5,
+      "brandingComplete": true,
+      "brandingGaps": [],
+      "defaultZipSet": true
+    },
+    "documentedCeilings": {
+      "transfers": false,
+      "scorecard": false,
+      "courseColleges": []
+    },
+    "grades": {
+      "courses": {
+        "grade": "B",
+        "reason": "coverage 86%; 1 suspicious term(s)"
+      },
+      "prereqs": {
+        "grade": "A",
+        "reason": "668 entries, wired, clean"
+      },
+      "transfers": {
+        "grade": "F",
+        "reason": "no transfer data"
+      },
+      "scorecard": {
+        "grade": "A",
+        "reason": "7/7 scorecards"
+      },
+      "config": {
+        "grade": "A",
+        "reason": "all config fields populated"
+      },
+      "composite": "F",
+      "limitedBy": "transfers",
+      "ceilingsApplied": []
+    }
+  }
+]

--- a/docs/state-goals/ak.md
+++ b/docs/state-goals/ak.md
@@ -1,0 +1,30 @@
+# Alaska (ak) — state goals
+
+> **Current tier: F** · Rank **#5 of 40** · Tranche: **NOW** · Impact 1/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=A` `prq=B` `trf=F` `sc=A` `cfg=B`
+>
+> _Single tribal college; F only because no-portal transfers isn't recorded as a ceiling — a metadata edit flips F->B+/A with everything else already A/B._
+
+## Diagnosis
+
+- **Primary gap:** Transfers F is the sole drag (composite F); but AK = 1 tribal college (Ilisagvik), no statewide articulation portal — a genuine documented ceiling not yet recorded in the audit. Courses A, prereqs B (clean), programs 24 + aligned + planner-ready.
+- **Cheapest lever** (documented-ceiling-accept): Mark transfers as a documented ceiling (1 tribal college, no AK articulation portal; config already states transferSupported:false) so the audit excuses it — lifts composite from F to B+/A.
+- **Effort:** cheap — No scraping needed. The only real work is recording the transfers documented-ceiling (config already has transferSupported:false + full rationale) and optionally a senior-waiver citation. Both are <1hr config/metadata edits; then re-run scorecard.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 1 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: courses A (1/1, clean terms); prereqs B (71 entries, 0 HTML tags, wired); scorecard A (1/1); config B only because seniorWaiver:null — but that null is intentional and documented (no AK statutory waiver binds tribally-controlled Ilisagvik; UA's AS 14.40.130 60+ reduction does not apply). transfer-equiv.json is [] and transferSupported:false in lib/states/ak/config.ts. Programs: data/ak/programs/ilisagvik-college.json (24 programs) filename == college_slug, catalog_year 2026-2027, planner-ready. Only F is transfers, a real ceiling for a single tribal college with no statewide articulation infra. manualOnly already says "Alaska has no registered articulation portal."
+
+## Goal checklist
+
+### AK — current tier F (transfers-limited; all other dims A/B and planner-ready)
+
+Alaska = one college (Ilisagvik, tribally-controlled, Utqiagvik). Courses A, prereqs B (71 clean entries), scorecard A, programs aligned + planner-ready. Composite F is driven solely by transfers, which is a genuine ceiling — no statewide articulation portal exists.
+
+- [ ] Record the transfers documented-ceiling so the audit excuses it. The justification already lives in `lib/states/ak/config.ts` (`transferSupported: false`, manual-only comment) and `data/ak/institutions.json`. Add `ak` transfers to the audit's documentedCeilings source so `documentedCeilings.transfers=true`.
+- [ ] (Optional, A-tier config) In `lib/states/ak/config.ts` / `data/ak/institutions.json`, add a `source_url` for the senior-waiver note (cite AS 14.40.130 + a registrar/Ilisagvik policy page) — or leave `seniorWaiver: null` as the documented-correct value.
+- [ ] Re-run the scorecard/state-audit for `ak`; confirm transfers no longer counts as an open F and composite lands B+/A.
+
+Definition of done: audit shows `ak` transfers as a documented ceiling (not an open F), courses/prereqs/config/scorecard all green, composite ≥ B; no new scrapers required.

--- a/docs/state-goals/ar.md
+++ b/docs/state-goals/ar.md
@@ -1,0 +1,32 @@
+# Arkansas (ar) — state goals
+
+> **Current tier: C** · Rank **#20 of 40** · Tranche: **NEXT** · Impact 2/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _All dims A except courses 12/14; build 2 bespoke scrapers (ANC, SouthArk) after a quick SIS probe, adapting existing AR colleague/Jenzabar templates -> A._
+
+## Diagnosis
+
+- **Primary gap:** 2 of 14 colleges (arkansas-northeastern-college, south-arkansas-college) have no course data and no detected SIS platform; transfers/prereqs/scorecard/config all A.
+- **Cheapest lever** (build-course-scrapers): Build 2 bespoke course scrapers for Arkansas Northeastern College (anc.edu) and South Arkansas College (southark.edu) — probe each for a public SIS endpoint (Colleague Self-Service guest / Banner SSB / Jenzabar AddDrop like EACC / CollegeScheduler GraphQL) and adapt the closest existing AR template, lifting courses C→A.
+- **Effort:** medium — Only 2 colleges remain (ANC, SouthArk). Neither has a scraper or a detected SIS platform — clusters.json shows 0 clusters / all singletons and no fingerprint baseline match, so each needs a fresh SIS probe before authoring. But AR already has rich reusable templates (scrape-colleague.ts multi-host, scrape-eacc.ts Jenzabar AddDrop), so once the platform is identified each scraper is a template adaptation, not greenfield. 1-4 hours total.
+- **Course colleges:** 2 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 3 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: The audit's courses ceiling (courseColleges = the 2 missing) appears not applied to the coverage denominator (reason still says "coverage 83% (10/12)" and composite stays C limited by courses), so these read as a real buildable gap, not an accepted ceiling. Transfers has a genuine documented ceiling (HSU Azure AD App Proxy, UAPB no public ACTS table) — accept as-is, 7 universities / 13440 mappings already wired. Fingerprint-baseline.json has no entry for these AR colleges (the "northeastern" hit is SC's Northeastern Technical College). All 3 program files have real data (97/90/43 entries) and filenames match institutions.json college_slug values — aligned, no hidden-program bug.
+
+## Goal checklist
+
+### AR — current tier C (limited by courses; all other dims A)
+
+Courses is the only blocker: 12/14 colleges have data; ANC + SouthArk missing, no SIS platform detected (clusters.json = all singletons, 0 clusters).
+
+- [ ] Probe **arkansas-northeastern-college** (anc.edu) for a public class-search endpoint: try Colleague Self-Service (`selfservice.*`, `ss-prod.*`), Banner SSB, Jenzabar JICS AddDrop_Courses (pattern in `scripts/ar/scrape-eacc.ts`), CollegeScheduler GraphQL. Author `scripts/ar/scrape-anc.ts` adapting the matching template; write to `data/ar/courses/arkansas-northeastern-college/`.
+- [ ] Probe **south-arkansas-college** (southark.edu) the same way; author `scripts/ar/scrape-southark.ts`; write to `data/ar/courses/south-arkansas-college/`.
+- [ ] If either is genuinely SSO/WAF/PDF-gated, add it to `documentedCeilings.courseColleges` with a one-line reason (mirrors the transfers ceiling pattern) instead of leaving it as a silent gap.
+- [ ] Declare both new scrapers in `StateConfig.scrapers` (lib/states/ar/config.ts) so `check:scrapers` passes and they run on cron.
+- [ ] Optional GOLD: expand programs beyond the 3 aligned files (national-park, north-arkansas, southeast-arkansas) to more colleges to lift planner from partial→full.
+
+Definition of done: courses ≥90% (12/12 buildable or remaining colleges in courseColleges ceiling), new scrapers cron-wired, composite reaches A/B+.

--- a/docs/state-goals/az.md
+++ b/docs/state-goals/az.md
@@ -1,0 +1,30 @@
+# Arizona (az) — state goals
+
+> **Current tier: C** · Rank **#4 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A._
+
+## Diagnosis
+
+- **Primary gap:** Courses at 84% (16/19 system colleges); transfers (3 unis/31k mappings), prereqs (2788, clean), config, scorecard all A. 2 of 3 missing colleges are buildable, 1 is a documented ceiling.
+- **Cheapest lever** (wire-existing-scraper): Re-run scripts/az/scrape-colleague.ts --college arizona-western-college (transient 502 at last run; scraper already wired) to land AWC course data, then add central-arizona-college via a coursedog course scrape.
+- **Effort:** cheap — AWC already has a wired Colleague scraper (scripts/az/scrape-colleague.ts, host colss-prod.ec.azwestern.edu) that only failed on a transient 502 — re-run, no new code. central-arizona-college is public coursedog (catalog.centralaz.edu) with a reusable template (scripts/lib/scrape-coursedog.ts) and catalog data already on disk. Landing both takes courses to ~95%, clearing the 90% bar. No SSO/CAPTCHA blockers.
+- **Course colleges:** 2 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: composite C, limitedBy courses only. tohono-oodham-community-college (jenzabar behind my.tocc.edu ICS login, tiny tribal college) is already in documentedCeilings.courseColleges — accept. No data/az/programs/ dir exists, so planner is not GOLD; that's the only thing between B+ and A-tier. central-az coursedog json on disk is catalog/program data (no sections), so a real course-section scrape is still needed for that college.
+
+## Goal checklist
+
+### AZ — current tier C (limited only by courses; transfers/prereqs/config/scorecard all A)
+
+- [ ] Re-run the already-wired Colleague scraper for Arizona Western (transient 502 last time): `npx tsx scripts/az/scrape-colleague.ts --college arizona-western-college` (host colss-prod.ec.azwestern.edu). Confirm data lands in `data/az/courses/arizona-western-college/`.
+- [ ] Add central-arizona-college course sections via coursedog: adapt `scripts/lib/scrape-coursedog.ts` for `catalog.centralaz.edu` (catalog data already at `data/az/coursedog-catalog/central-arizona-college.json`, 913/1412 have credits). Wire into a new `scripts/az/scrape-coursedog-courses.ts` and declare in `StateConfig.scrapers`.
+- [ ] Verify courses coverage: 18/19 ≈ 95% (tohono-oodham excused as documented ceiling) → courses clears 90% → composite A-/A.
+- [ ] Pre-PR check: load `/az`, search a course at AWC and Central AZ, confirm sections render.
+- [ ] (A-tier extra, optional) Create `data/az/programs/` aligned to institutions.json college_slug values to unlock the degree-path planner — currently 0 program files.
+
+Definition of done: AWC + Central AZ course data present and wired; courses ≥90% with tohono-oodham as documented ceiling; composite lifts to A-/A.

--- a/docs/state-goals/ca.md
+++ b/docs/state-goals/ca.md
@@ -1,0 +1,33 @@
+# California (ca) — state goals
+
+> **Current tier: C** · Rank **#29 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=B` `cfg=A`
+>
+> _Highest student reach; ~9 detected colleges wire into existing templates (65%->85%) but the 90% bar needs ~27 custom re-fingerprints — biggest partial win, not a clean finish._
+
+## Diagnosis
+
+- **Primary gap:** 41 of 117 colleges have no course data (65% coverage, dim C); transfers/prereqs/config/scorecard all healthy (A/A/A/B). ~9 missing are buildable on existing generic templates; ~5 SSO-blocked; ~27 custom/unknown need re-fingerprint.
+- **Cheapest lever** (wire-existing-scraper): Wire the ~9 already-detected buildable colleges into the existing generic templates: add Colleague HOSTS entries (modesto, mt-san-jacinto, las-positas) and Banner SSB targets (glendale, ohlone, california-indian-nations, chabot banner-8), plus miracosta PeopleSoft and one new courseleaf scraper for long-beach. Lifts 76→~85/117.
+- **Effort:** medium — Generic scrape-banner-ssb.ts and scrape-colleague.ts templates already exist and are cron-wired; ~9 confirmed-buildable colleges have high-confidence guest courseSearchUrls in fingerprint-baseline.json and join via a HOSTS-map/target-list edit (cheap each). But reaching the 90% B+ bar requires the ~27 custom/unknown colleges too, which need re-fingerprinting (Ellucian-cloud subdomain probe) and likely several bespoke/cluster scrapers — a multi-hour body of work, not config-only.
+- **Course colleges:** 9 buildable / 5 blocked (of the missing set)
+- **Programs / planner:** 18 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** no
+
+> Notes: Fingerprint baseline (data/state-health/fingerprint-baseline.json, perCollege keyed {state}-{slug}) shows 115 ca colleges: 13 banner-ssb-9, 18 colleague, 1 banner-8, 1 courseleaf, 1 peoplesoft, 1 coursedog (all buildable), vs 52 custom + 23 unknown + 3 ellucian-experience + 2 auth-gated. Of the 41 missing: 9 buildable, 5 SSO-blocked (irvine-valley, mendocino, lake-tahoe, college-of-the-canyons + copper-mountain — last two flagged SAML/SSO inside scripts/ca/scrape-colleague.ts despite a Colleague detection), 27 custom/unknown. Many custom/unknown are district members (san-bernardino/crafton-hills, riverside/norco/moreno-valley) that may yield to re-fingerprint or cluster scrapers. Generic templates scrape-banner-ssb.ts/scrape-colleague.ts are cron-declared in lib/states/ca/config.ts; colleague template uses a HOSTS map so adding a college is a one-line edit. Programs (18 files in data/ca/programs) all align to college_slug — planner-visible. No documented course ceilings recorded.
+
+## Goal checklist
+
+### CA — current tier C (limited by courses, 65% / 76-117)
+
+Wire/build course scrapers; transfers, prereqs, config, scorecard already A/A/A/B.
+
+- [ ] Add Colleague HOSTS entries in `scripts/ca/scrape-colleague.ts` for `mt-san-jacinto-community-college-district` (msjc.edu/Student/Courses), `las-positas-college` (laspositascollege.edu/Student/Courses); run + import.
+- [ ] Add Banner SSB targets to `scripts/ca/scrape-banner-ssb.ts` for `glendale-community-college` (portal.glendale.edu), `ohlone-college` (my.ohlone.edu), `california-indian-nations-college` (cincollege.org) — all have high-confidence guest URLs in `data/state-health/fingerprint-baseline.json`.
+- [ ] Build small scrapers: `chabot-college` (Banner 8 bwckschd at chabotcollege.edu), `miracosta-college` (PeopleSoft surf.miracosta.edu), `long-beach-city-college` (CourseLeaf lbcc-public.courseleaf.com), `modesto-junior-college` (WebAdvisor piratesnet.mjc.edu). Declare each in `lib/states/ca/config.ts` scrapers.courses.
+- [ ] Re-fingerprint the 27 custom/unknown (santa-monica, palomar, el-camino, riverside-city, cerritos, etc.) using Ellucian-cloud subdomain probe (colss-prod.ec/selfservice/reg-prod patterns) to convert to Colleague/Banner; build cluster scrapers (e.g. SBCCD: san-bernardino-valley+crafton-hills; RCCD: riverside-city+norco+moreno-valley).
+- [ ] Accept 5 SSO-blocked (irvine-valley, mendocino, lake-tahoe, college-of-the-canyons, copper-mountain) as documented ceilings.
+- [ ] Re-run state-audit; confirm coverage >=90% (>=105/117) for B+.
+
+Definition of done: courses dim >=B+ (>=90% covered or remainder documented ceilings), all new scrapers cron-declared, audit re-run green.

--- a/docs/state-goals/co.md
+++ b/docs/state-goals/co.md
@@ -1,0 +1,32 @@
+# Colorado (co) — state goals
+
+> **Current tier: B** · Rank **#12 of 40** · Tranche: **NOW** · Impact 3/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=A` `prq=A` `trf=B` `sc=A` `cfg=A`
+>
+> _Shippable bar met (courses/prereqs/config/scorecard A, transfers documented ceiling); only GOLD programs remain (curate catalog configs) — accept as B or pursue planner._
+
+## Diagnosis
+
+- **Primary gap:** Programs absent (data/co/programs/ does not exist); the only non-A dimension is transfers, which is a verified documented ceiling. Courses 15/15, prereqs 868 clean, config + scorecard all A.
+- **Cheapest lever** (build-programs): Curate scripts/co/scrape-programs.ts catalog configs (correct baseUrls + catoids per college), run it to emit data/co/programs/<slug>.json aligned to institutions.json slugs, unblocking the degree-path planner (GOLD).
+- **Effort:** medium — Core B+ bar already met — courses/prereqs/config/scorecard all A, transfers a documented ceiling (accept). Remaining work is GOLD-only: scripts/co/scrape-programs.ts is an unvalidated auto-generated wrapper with wrong catalog baseUrls (catalog.colorado.edu/lamar.edu/northeastern.edu point at out-of-state schools) and catoid 0; curating correct per-college acalog/courseleaf configs and running it is a 1-4hr investigation, not a one-line wire.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: No missing course colleges — courses dim is A (15/15). Transfers B but documentedCeilings.transfers=true (only Univ of Denver exposes public Banner bwcktart articulation; all other CO receivers SSO/Transferology-gated, verified 2026-05-31) so accept as-is. manualOnly lists only "programs — Phase 6 (catalog discovery emitted a wrapper". scripts/co/scrape-programs.ts exists but has placeholder/incorrect catalog baseUrls and catoidFallback:0 — must be curated before it yields real data.
+
+## Goal checklist
+
+### CO — current tier B (shippable bar met; transfers = documented ceiling, accept)
+
+Core dimensions are all A (courses 15/15, prereqs 868 clean+wired, config, scorecard). Transfers (1 receiver, Univ of Denver) is a verified public-articulation ceiling — do NOT re-pitch. Remaining work is GOLD-tier programs only.
+
+- [ ] Curate `scripts/co/scrape-programs.ts`: the auto-generated wrapper has wrong baseUrls — acalog colleges (aims/arapahoe/morgan) need real `catalog.*.edu` hosts + discovered catoids; courseleaf entries currently point at out-of-state schools (`catalog.colorado.edu` = CU Boulder, `catalog.lamar.edu` = Lamar TX, `catalog.northeastern.edu` = NEU Boston) — replace with the actual CCCS college catalog hosts or drop those colleges.
+- [ ] Run `npx tsx scripts/co/scrape-programs.ts`; confirm it writes `data/co/programs/<slug>.json` with non-empty `programs[]`.
+- [ ] Verify output filenames equal `college_slug` values in `data/co/institutions.json` (aims-community-college, arapahoe-community-college, etc.) so the planner sees them.
+- [ ] Declare the programs scraper in `StateConfig.scrapers` (lib/states/co/config.ts) to wire cron.
+- [ ] Local check: load the semester planner for a CO college, confirm a program's requirements resolve.
+
+Definition of done: ≥1 aligned `data/co/programs/<slug>.json` with real program data, filenames match institution slugs, scraper cron-declared, planner shows CO programs.

--- a/docs/state-goals/dc.md
+++ b/docs/state-goals/dc.md
@@ -1,0 +1,32 @@
+# DC (dc) — state goals
+
+> **Current tier: B** · Rank **#11 of 40** · Tranche: **NOW** · Impact 1/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=A` `prq=A` `trf=B` `sc=A` `cfg=A`
+>
+> _Single college, all dims A except transfers which is an in-state-rule ceiling (no in-jurisdiction receiver) — already at finish line, just confirm ceiling._
+
+## Diagnosis
+
+- **Primary gap:** Transfers empty (B) by documented ceiling: UDC's 1,400+ CollegeTransfer.Net equivalencies all target out-of-state schools and are stripped by the in-state-only rule; DC has no in-state CC→4yr articulation pipeline. Courses/prereqs/scorecard/config all A. No programs dir (planner not gold-ready).
+- **Cheapest lever** (documented-ceiling-accept): Accept transfers ceiling — state is already at its B finish line; optionally wire Acalog programs scraper for udc-cc for planner visibility (gold extra).
+- **Effort:** cheap — The only B-dimension (transfers) is an accepted documented ceiling — no work moves it. The single shippable-affecting gap is closed. The lone optional lever is wiring an Acalog programs scraper for udc-cc (GOLD-tier extra), which is a medium one-scraper task but does not raise the composite past B's ceiling. Nothing cheap-or-otherwise lifts composite here.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: DC has exactly 1 community college (udc-cc / UDC-CC). Composite B is structurally capped: the in-state-only transfer rule (a hard project invariant) zeroes out the only available articulation data because DC's lone university receiver is out-of-jurisdiction relative to the in-state filter. This is correctly recorded in ceilingsApplied and documentedCeilings. Do not attempt to re-add the stripped CollegeTransfer.Net rows. No course gaps (missing[]=[]). No programs directory exists.
+
+## Goal checklist
+
+### DC — current tier B (at documented ceiling, shippable)
+
+DC is a single-college district (udc-cc). Courses A (1/1, terms clean), prereqs A (510 entries, wired, clean), scorecard A (1/1), config A (all fields populated). The only sub-A dimension is transfers, and it is a genuine ceiling — UDC's 1,400+ CollegeTransfer.Net equivalencies all target out-of-state receivers, which the in-state-only rule correctly strips to empty. There is no in-state CC→4yr articulation pipeline to wire.
+
+- [x] Courses — udc-cc covered, terms clean (no action)
+- [x] Prereqs — 510 entries wired and clean (no action)
+- [x] Config — seniorWaiver/branding/popularCourses all populated (no action)
+- [x] Transfers — accept documented ceiling; do NOT re-pitch (no in-state receiver exists; `transferSupported=false` comment in `lib/states/dc/config.ts` documents this)
+- [ ] OPTIONAL (gold/planner extra, not required for shippable): wire an Acalog program scraper for udc-cc — create `data/dc/programs/`, write `scripts/dc/scrape-programs.ts`, name output file `udc-cc.json` to match `institutions.json` college_slug, declare in `StateConfig.scrapers`. Per audit manualOnly: "Acalog program scraper not yet wired up for this state."
+
+Definition of done: B finish line is already met (courses+prereqs+config+scorecard all A, transfers accepted as documented ceiling). No further work needed to ship; programs scraper is the only path to A and is purely optional.

--- a/docs/state-goals/fl.md
+++ b/docs/state-goals/fl.md
@@ -1,0 +1,30 @@
+# Florida (fl) — state goals
+
+> **Current tier: B** · Rank **#13 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Huge state already at 93%; wire fscj's on-disk 2,963-course catalog + document pensacolastate Workday ceiling -> courses A, composite A._
+
+## Diagnosis
+
+- **Primary gap:** 2 of 28 colleges lack section data (93% coverage); fscj has a 2,963-course Coursedog catalog already scraped to data/fl/coursedog-catalog/fscj.json but it's not wired as fscj's course source; pensacolastate is Workday-only (blocked). Transfers/prereqs/config/scorecard all A.
+- **Cheapest lever** (wire-existing-scraper): Wire the already-scraped data/fl/coursedog-catalog/fscj.json as fscj's course source so it counts toward coverage (96%), and document pensacolastate (Workday) as a ceiling.
+- **Effort:** cheap — FSCJ's full course catalog is already on disk (data/fl/coursedog-catalog/fscj.json, 2,963 courses scraped via existing scripts/fl/scrape-coursedog.ts). Surfacing it as fscj's per-college course list — exactly the "fallback course list" the scraper header documents — lifts coverage 26/28→27/28 (96%) with no new scraping. Pensacolastate (Workday SPA, no public guest endpoint) is a genuine ceiling, not worth chasing.
+- **Course colleges:** 1 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: Composite already B; courses 93% already clears the >=90% B+ shippable bar. Transfers A (12 univ, 5240 mappings, wired), prereqs A (2225 entries, clean, wired), config A, scorecard 28/28. The only two missing colleges: fscj (coursedog, public catalog already on disk) and pensacolastate (workday, blocked). Programs absent (manualOnly: "programs — Phase 5+") so planner not reachable — GOLD-tier only, not a finish-line blocker.
+
+## Goal checklist
+
+### FL — current tier B (limited by courses, 93%)
+
+FL already clears the B+ shippable bar (courses >=90%; transfers/prereqs/config/scorecard all A). These lift it toward A:
+
+- [ ] Wire fscj's already-scraped catalog: `data/fl/coursedog-catalog/fscj.json` (2,963 courses, no sections) is the documented "fallback course list" from `scripts/fl/scrape-coursedog.ts`. Surface it as fscj's per-college course source so it counts toward coverage → 27/28 = 96%. No new scraping needed.
+- [ ] Document pensacolastate as a ceiling: platform `workday` (`wd501.myworkday.com/pensacolastate/...`), SPA/SSO, no public guest course search. Add to documentedCeilings.courseColleges with reason "Workday Student, no public class search". This excuses it from coverage → effective 27/27 = 100%.
+- [ ] (GOLD-tier, optional) Programs: none on disk (`data/fl/programs/` absent; manualOnly "programs — Phase 5+"). Scrape FL program/degree plans, name files to match `college_slug` in `data/fl/institutions.json`, to make the degree-path planner see FL. Medium effort; not required for A.
+
+Definition of done: fscj catalog wired as a course source (coverage >=96%) and pensacolastate recorded as a documented Workday ceiling, lifting courses to A and the FL composite to A.

--- a/docs/state-goals/ia.md
+++ b/docs/state-goals/ia.md
@@ -1,0 +1,30 @@
+# Iowa (ia) — state goals
+
+> **Current tier: D** · Rank **#39 of 40** · Tranche: **LATER** · Impact 2/5 · Effort: medium · Value/effort: **L**
+>
+> Dimensions: `crs=D` `prq=A` `trf=C` `sc=A` `cfg=A`
+>
+> _Courses 31%; 6 template-buildable (re-run colleague + wire Jenzabar/Banner) reaches ~69%, but 5 custom/unknown need fresh fingerprints to clear 90%._
+
+## Diagnosis
+
+- **Primary gap:** Courses at 31% (5/16); 6 missing colleges template-buildable (2 Colleague hosts already in scraper map, 3 Jenzabar, 1 Banner SSB 9), 5 custom/unknown. Transfers/prereqs/config/scorecard healthy.
+- **Cheapest lever** (build-course-scrapers): Re-run scripts/ia/scrape-colleague.ts for indian-hills + iowa-central (hosts already in HOSTS map, zero new code); if 404, refingerprint the Self-Service subdomain.
+- **Effort:** medium — Courses is the only weak dim. 6 of 11 missing colleges ride existing templates (Colleague/Jenzabar/Banner-SSB) — re-run plus per-college URL wiring, ~1-3hr. The 5 custom/unknown colleges (DMACC, NIACC, WITCC, Hawkeye, Iowa Lakes) need refingerprinting/bespoke work to clear 90%, but bulk lift is template wiring.
+- **Course colleges:** 6 buildable / 5 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: scrape-colleague.ts HOSTS already includes indian-hills (ss.indianhills.edu) and iowa-central (selfservice.iowacentral.edu) but neither has output under data/ia/courses/ — re-run or fix host. Templates: scripts/lib/scrape-jenzabar.ts (ellsworth ecc.iavalley.edu, marshalltown mcc.iavalley.edu, southwestern swcciowa.edu — ellsworth+marshalltown share iavalley.edu Iowa Valley district), scripts/lib/scrape-banner-ssb.ts (northwest-iowa nwicc.edu, banner-ssb-9). Custom: des-moines-area (dmacc.edu, largest IA CC), north-iowa-area (niacc.edu), western-iowa-tech (witcc.edu). Unknown needing refingerprint: hawkeye, iowa-lakes. Transfers = ISU TRANSIT only (1 receiver, 3512 mappings, wired, http runner), not a documented ceiling; a 2nd receiver (UNI/Univ of Iowa) lifts transfers C→B (medium). No documentedCeilings. Config/prereqs/scorecard all A. No programs dir.
+
+## Goal checklist
+
+### IA — current tier D (limited by courses, 5/16 = 31%)
+
+- [ ] Re-run `scripts/ia/scrape-colleague.ts --college=indian-hills-community-college` and `--college=iowa-central-community-college`. Hosts (ss.indianhills.edu, selfservice.iowacentral.edu) are already in the HOSTS map but produced no `data/ia/courses/` output. If 404, refingerprint the Self-Service subdomain (try ss-prod-cloud/selfservice/*.elluciancloud.com). +2 colleges, zero new code.
+- [ ] Wire northwest-iowa (banner-ssb-9, nwicc.edu) via `scripts/lib/scrape-banner-ssb.ts` — add a per-state wrapper, declare in `StateConfig.scrapers.courses`. +1.
+- [ ] Wire 3 Jenzabar colleges (ellsworth ecc.iavalley.edu, marshalltown mcc.iavalley.edu, southwestern swcciowa.edu) via `scripts/lib/scrape-jenzabar.ts` — find each public `Course_Search.jnz` portlet URL; ellsworth+marshalltown share the iavalley.edu district. +3, reaches 11/16 (69%).
+- [ ] Investigate remaining 5: refingerprint hawkeye + iowa-lakes ("unknown"); build bespoke scrapers for custom des-moines-area (DMACC, largest), north-iowa-area, western-iowa-tech if public class-search exists. Needed to clear the 90% (15/16) bar.
+- [ ] (Optional, transfers C→B) Add a 2nd receiver beyond ISU TRANSIT (UNI or Univ of Iowa) in `scripts/ia/scrape-transfer-transit.ts`.
+
+Definition of done: courses ≥90% (15/16, any truly-unscrapeable custom college documented as a ceiling), all new scrapers declared in `lib/states/ia/config.ts` + cron-wired; composite ≥ B.

--- a/docs/state-goals/id.md
+++ b/docs/state-goals/id.md
@@ -1,0 +1,29 @@
+# Idaho (id) — state goals
+
+> **Current tier: F** · Rank **#23 of 40** · Tranche: **NEXT** · Impact 2/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=F` `sc=A` `cfg=A`
+>
+> _Accept no-portal transfers ceiling (10-min, flips off F) then build/ceiling CSI's Campus-Management-Corp course gap to clear 90%._
+
+## Diagnosis
+
+- **Primary gap:** Composite is F, dragged entirely by transfers: Idaho has zero transfer/articulation data and no registered statewide articulation portal (manualOnly confirms). Courses are also sub-bar at 75% (3/4) — College of Southern Idaho missing on Campus Management Corp Portal. Prereqs (A), config (A), scorecard (A) all healthy.
+- **Cheapest lever** (documented-ceiling-accept): Document the transfers dimension as a ceiling (Idaho has no public statewide articulation portal) so it's accepted-as-is rather than raw-F — this lifts the composite off F for ~10 min of work, the highest points-per-hour action.
+- **Effort:** medium — Two real gaps. Transfers is hard from scratch (no public articulation portal), but can be turned cheap by documenting it as a ceiling — same accepted pattern used for VA/DC/NH — which lifts the composite off F immediately. The remaining true-build gap is one scraper (CSI on Campus Management Corp Portal, a custom non-templated platform with no fingerprint entry) which is 1-4hr and may be SSO-walled. So overall medium: one cheap ceiling-accept plus one bounded scraper investigation.
+- **Course colleges:** 0 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: CSI (college-of-southern-idaho) is the only missing course college: runs Campus Management Corp Portal, no fingerprint-baseline entry, explicitly deferred in scripts/id/scrape-colleague.ts header. Classified blocked (custom/unknown, likely SSO) — not a cheap public Banner/Colleague/CollegeScheduler endpoint. Other 3 colleges scraped via Colleague guest (398/1294/1006 sections). transfer-equiv.json is []. No data/id/programs/ dir at all. Prereqs 730 entries clean+wired; config + scorecard full A.
+
+## Goal checklist
+
+### Idaho (id) — current tier F (limited by transfers)
+
+- [ ] **Accept transfers ceiling (cheapest).** Idaho has no public statewide articulation portal (manualOnly: "no registered articulation portal"). Add a documented-ceiling note for the `transfers` dimension in the audit/ceilings source so it's accepted-as-is. This alone lifts the composite off F. Confirm no public Idaho transfer-equivalency system exists before documenting.
+- [ ] **Build CSI course scraper (medium).** `college-of-southern-idaho` is the only missing college (75% → bar is 90%). It runs Campus Management Corp Portal — no Colleague/Banner template. Investigate `csi.edu` for any public class-search endpoint; if found, add a bespoke scraper alongside `scripts/id/scrape-colleague.ts` and wire it into `StateConfig.scrapers`. If SSO/CAPTCHA-walled, document CSI as a course-college ceiling so courses reaches effective 100%.
+- [ ] **Re-run state-audit** to confirm composite rises (target B+ once transfers ceiling + CSI resolved).
+- [ ] *(GOLD, optional)* Build `data/id/programs/` (no programs exist; manualOnly: no catalog matched a template) with filenames aligned to institutions.json `college_slug` values for planner visibility.
+
+Definition of done: transfers accepted as documented ceiling, courses at/above 90% (CSI built or documented), audit re-run shows composite B or better.

--- a/docs/state-goals/il.md
+++ b/docs/state-goals/il.md
@@ -1,0 +1,29 @@
+# Illinois (il) — state goals
+
+> **Current tier: C** · Rank **#38 of 40** · Tranche: **LATER** · Impact 5/5 · Effort: hard · Value/effort: **L**
+>
+> Dimensions: `crs=C` `prq=A` `trf=B` `sc=B` `cfg=A`
+>
+> _Large state but most of 19 missing colleges are Jenzabar/SSO/custom-blocked; only elgin re-run is cheap — 90% unreachable, ceiling-document to ship at B._
+
+## Diagnosis
+
+- **Primary gap:** 19 of 48 colleges have no course data (60% coverage, grade C); prereqs (A, clean+wired), transfers (B, 2 universities/53,969 mappings/wired), config (A), scorecard (B) all healthy. Courses is the sole limiter.
+- **Cheapest lever** (build-course-scrapers): Re-run scripts/il/scrape-colleague.ts to capture elgin-community-college (already in HOSTS) and probe Ellucian-Cloud/Banner subdomains for the missing singletons (per the colss-prod.ec.* / selfservice.* memory pattern) to convert "unknown" verdicts before accepting the ceiling.
+- **Effort:** hard — Reaching 90% (44/48) needs ~15 more colleges. The config comment documents the remainder: 4 Jenzabar colleges (john-a-logan, richland, southeastern-illinois, spoon-river) are auth-gated; the Ellucian experience.elluciancloud.com cluster is SSO-gated; lake-county/rend-lake "Coursedog" hits were false positives (CMS/events calendar); rest are bespoke PDF/custom-CMS. Only elgin (and maybe rock-valley) are already wired in scrape-colleague.ts but produce no live data yet. Most missing colleges are blocked, so closing the gap is a multi-college bespoke-scraper effort, not a config flip.
+- **Course colleges:** 2 buildable / 17 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Fingerprint-baseline.json has no IL keys (sweep predates IL); clusters.json is the per-college SIS signal of record. elgin & rock-valley are wired in scrape-colleague.ts HOSTS but no course file exists (rock-valley noted "returns no live terms"). courseColleges ceiling list is empty in the audit, so courses gap is undocumented-as-ceiling despite the config comment investigating it — formalizing a documented ceiling for the ~15 blocked colleges would let the state ship at B.
+
+## Goal checklist
+
+### IL — current tier C (limited by courses; 29/48 = 60%)
+
+- [ ] Re-run `scripts/il/scrape-colleague.ts` (elgin-community-college already in HOSTS; rock-valley too). Capture any sections into `data/il/courses/`. Cheap, no new code.
+- [ ] Probe Ellucian-Cloud/Banner subdomains for missing singletons (swic, bhc, sandburg, icc, ivcc, jwcc, kaskaskia, clcillinois, lakeland, heartland, sauk/svcc): try `colss-prod.ec.<domain>`, `selfservice.<domain>`, `ss-prod-cloud.<domain>`, Banner SSB `…/StudentRegistrationSsb`. Add any guest-accessible host to `scrape-colleague.ts` or a new Banner scraper; wire in `lib/states/il/config.ts` scrapers.courses.
+- [ ] For confirmed-blocked colleges (4 Jenzabar: john-a-logan, richland, southeastern-illinois, spoon-river — auth-gated; experience.elluciancloud.com SSO cluster; PDF/CMS singletons), record a documented ceiling: add slugs to the audit `courses.courseColleges`/ceiling so 90% bar excuses them and the state can ship at B.
+- [ ] (GOLD, optional) No programs exist (`data/il/programs/` absent) — defer; no state has program scrapers yet.
+
+Definition of done: course coverage ≥90% of non-ceiling colleges OR every still-missing college is recorded as a documented ceiling; courses dim reaches B and composite lifts to B.

--- a/docs/state-goals/in.md
+++ b/docs/state-goals/in.md
@@ -1,0 +1,33 @@
+# Indiana (in) — state goals
+
+> **Current tier: F** · Rank **#17 of 40** · Tranche: **NEXT** · Impact 3/5 · Effort: medium · Value/effort: **H**
+>
+> Dimensions: `crs=A` `prq=A` `trf=F` `sc=A` `cfg=A`
+>
+> _Single-college (Ivy Tech), all dims A except empty transfers; build one TransferIN/Core Transfer Library scraper (portal exists) -> F->A._
+
+## Diagnosis
+
+- **Primary gap:** Transfers is the sole blocker (composite F): 0 mappings, 0 universities, not wired, no documented ceiling. Courses/prereqs/config/scorecard are all A. No programs dir → planner can't see IN.
+- **Cheapest lever** (build-prereqs): Build a TransferIN / Core Transfer Library scraper (in.gov/che wpdatatables source) for Ivy Tech → 4-year equivalencies, write data/in/transfer-equiv.json, set transferSupported:true, and declare scrapers.transfers — lifts composite F→A.
+- **Effort:** medium — One single-college state; everything is A except transfers. The lift is one new statewide articulation scraper for Indiana's Core Transfer Library / TransferIN (in.gov/che), delivered as an SPA / wpdatatables-backed table. No existing scraper to wire — must investigate the data endpoint and build it, but it's one source not 50 colleges. Squarely 1-4hr.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: leverCategory is the closest enum match ("build" a missing dataset = transfers here; no transfers-specific option exists). IN has 1 college (Ivy Tech, 22 campuses, one CollegeScheduler GraphQL scrape). transfer-equiv.json is literally []. Statewide articulation DOES exist (Core Transfer Library / TransferIN) so transfers is NOT a documented ceiling — it's buildable, just unbuilt. Existing transfer-scraper templates in scripts/al, scripts/az (aztransfer), scripts/ar (acalog/acts) are good adaptation references for a statewide-portal scrape. Config dim is A in the audit, though institutions.json audit_policy still has unverified placeholder text (separate, lower-priority cleanup).
+
+## Goal checklist
+
+### IN (Indiana) — current tier F (blocked solely by transfers)
+
+Single-college state: Ivy Tech (22 campuses, one CollegeScheduler scrape). Courses/prereqs/config/scorecard already A. transfer-equiv.json is `[]`.
+
+- [ ] Investigate Indiana's Core Transfer Library / TransferIN at in.gov/che — it's an SPA / wpdatatables-backed table. Find the underlying JSON/AJAX endpoint (wpdatatables typically exposes an `admin-ajax.php?action=get_wdtable` call) or a downloadable dataset. Confirm in-state targets only (IU, Purdue, Ball State, ISU, etc.).
+- [ ] Build `scripts/in/scrape-transfer-ctl.ts`, adapting `scripts/az/scrape-transfer-aztransfer.ts` (statewide-portal pattern). Map Ivy Tech course → 4-year equivalency. Drop any out-of-state targets (in-state-transfers-only rule).
+- [ ] Write `data/in/transfer-equiv.json` with non-trivial mappings across ≥1 (ideally several) Indiana universities.
+- [ ] In `lib/states/in/config.ts`: set `transferSupported: true`, add `scrapers.transfers: [{ scripts: ["scripts/in/scrape-transfer-ctl.ts"], runner: "http" }]`, remove the `manual-only: transfers` marker.
+- [ ] Verify locally: load `/in/transfer`, pick Ivy Tech + a course, confirm equivalency renders.
+- [ ] (Optional A→GOLD) Add `data/in/programs/` from catalog.ivytech.edu (Acalog) for planner visibility.
+
+Definition of done: `data/in/transfer-equiv.json` has ≥1 in-state university target with real mappings, transfers wired in config, `/in/transfer` renders an equivalency — composite F→A.

--- a/docs/state-goals/ks.md
+++ b/docs/state-goals/ks.md
@@ -1,0 +1,30 @@
+# Kansas (ks) — state goals
+
+> **Current tier: F** · Rank **#27 of 40** · Tranche: **NEXT** · Impact 3/5 · Effort: hard · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=F` `sc=B` `cfg=C`
+>
+> _Cheap config + re-run 5 wired colleges lifts courses to ~75%, but F is binding transfers with no portal — hard investigation or ceiling needed to clear F._
+
+## Diagnosis
+
+- **Primary gap:** Composite F driven by transfers (0 mappings, no portal registered, unwired, no ceiling). Courses at 54% (13/24) is secondary; config has placeholders.
+- **Cheapest lever** (wire-existing-scraper): Re-run the already-wired scripts/ks/scrape-jenzabar-webforms.ts (cloud, flint-hills, fort-scott, labette) and scrape-colleague.ts (coffeyville) to recover 5 missing colleges, lifting courses 54%→~75% (C→B).
+- **Effort:** hard — The composite limiter is transfers, and KS has no statewide articulation portal registered (manualOnly confirms). Standing up KS transfers means investigating Kansas Board of Regents articulation infra from scratch — >half-day. Cheap wins (config, re-running existing course scrapers) raise individual dims but won't clear the F until transfers move off zero or get a documented ceiling.
+- **Course colleges:** 5 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Key finding: 5 of 11 missing colleges already have wired, public-guest scrapers (Jenzabar/Colleague) that simply didn't produce data — cheapest course win is a re-run, not new code. 5 missing have no fingerprint on disk (need investigation; JCCC is the high-value one). seward is captcha-blocked (documented). Transfers is the binding F: zero mappings, no portal, no ceiling — composite cannot exceed F without addressing it. prereqs A (523, clean), scorecard B (22/24). No programs → planner not ready.
+
+## Goal checklist
+
+### KS — current tier F (limited by transfers)
+
+- [ ] Config (cheap): in `lib/states/ks/config.ts` fill `seniorWaiver` per K.S.A. 76-728 (residents 65+; the TODO already cites it) and populate `popularCourses` from top-enrolled KS courses. Clears config C→A.
+- [ ] Re-run existing course scrapers (cheap): execute `scripts/ks/scrape-jenzabar-webforms.ts` (recovers cloud, flint-hills, fort-scott, labette) and `scripts/ks/scrape-colleague.ts --college=coffeyville-community-college`. These hosts are already wired and confirmed public-guest; missing data = prior runtime failure, not a blocker. Lifts courses 54%→~75% (C→B).
+- [ ] Investigate 5 un-scraped colleges (medium): johnson-county (jccc.edu — large, high value), garden-city (gcccks.edu), barton (bartonccc.edu), pratt (prattcc.edu), north-central (ncktc.edu). No fingerprint on disk; probe for Banner SSB / Colleague guest / Jenzabar portlet and add bespoke scrapers. Reaching ≥90% needs ~3 of these.
+- [ ] seward-county: blocked (sgcaptcha/IPC bot challenge, documented in scrape-banner-ssb.ts) — leave or document ceiling.
+- [ ] Transfers (hard, the real F): no Kansas Board of Regents articulation portal registered. Investigate kansasregents.org systemwide-transfer infra; if no machine-readable source exists, record a documented ceiling in the audit so transfers stop voiding the composite.
+
+Definition of done: courses ≥90% (or documented ceilings for the holdouts), config placeholder-free, and transfers either wired with ≥1 KS university target or accepted as a documented ceiling.

--- a/docs/state-goals/la.md
+++ b/docs/state-goals/la.md
@@ -1,0 +1,28 @@
+# Louisiana (la) — state goals
+
+> **Current tier: B** · Rank **#6 of 40** · Tranche: **NOW** · Impact 3/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Everything built/wired incl 5 aligned programs; record northshore (LoLA SSO) as a courses ceiling and 92% becomes A -> composite A._
+
+## Diagnosis
+
+- **Primary gap:** 11 of 12 colleges have full section-level course data; the lone gap (northshore-technical-community-college) is SSO-blocked (LoLA) for class sections — only its Coursedog catalog descriptions/prereqs are harvestable, which are already merged. Transfers/prereqs/config/scorecard all A.
+- **Cheapest lever** (documented-ceiling-accept): Record northshore-technical-community-college as a documented courses ceiling (no public section endpoint; registration behind LoLA SSO — Coursedog catalog already harvested for prereqs), so the 92% courses coverage is ceiling-excused and the composite reflects A-tier reality.
+- **Effort:** cheap — Everything is already built and wired (Banner SSB scraper for 11 colleges, Coursedog scraper + config wiring for the 12th, transfers, prereqs, 5 aligned program files). The only remaining 'gap' is northshore's section data, which has no public endpoint (registration behind LoLA SSO) — not buildable without scraping. The cheap action is documenting it as a ceiling so the audit excuses it.
+- **Course colleges:** 0 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 5 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: scripts/la/ already contains scrape-lctcs-banner-ssb.ts (11 colleges via shared reg-prod.ec.lctcs.edu MEP host), scrape-coursedog.ts (northshore catalog, wired in lib/states/la/config.ts:61), scrape-regents-matrix.ts (transfers), scrape-programs.ts. Northshore's scraper header explicitly notes it has no public class-section endpoint (LoLA SSO) and contributes 653 catalog courses to prereqs only. data/la/courses/ has 11 college subdirs; northshore has only data/la/coursedog-catalog/northshore-technical-community-college.json (653 desc/prereqs, no sections). All 5 program filenames (baton-rouge, fletcher, louisiana-delta, nunez, south-louisiana) are valid college_slug values in institutions.json → planner-visible. Audit documentedCeilings.courseColleges is empty, so northshore is currently penalizing the courses dim despite being a true SSO ceiling.
+
+## Goal checklist
+
+### LA — current tier B (limited only by courses; one SSO-blocked college)
+
+- [ ] Mark `northshore-technical-community-college` as a documented courses ceiling in the audit/ceiling config (e.g. add to `documentedCeilings.courseColleges` for la): rationale = no public class-section endpoint, registration behind LoLA SSO; Coursedog catalog (653 courses) already harvested into `data/la/prereqs.json`. Reference scraper note in `scripts/la/scrape-coursedog.ts`.
+- [ ] Re-run state-audit for la so the 92% courses coverage is ceiling-excused → courses dim lifts to A, composite → A.
+- [ ] (Optional, GOLD polish) Extend program coverage beyond the 5 current colleges (baton-rouge, fletcher, louisiana-delta, nunez, south-louisiana) via `scripts/la/scrape-programs.ts` to widen planner coverage to all 11 section-bearing colleges. Confirm any new filenames equal `college_slug` from `data/la/institutions.json`.
+
+Definition of done: la composite reads A with courses ceiling-documented; transfers/prereqs/config/scorecard remain A; the 5 existing programs stay planner-visible (filenames aligned).

--- a/docs/state-goals/ma.md
+++ b/docs/state-goals/ma.md
@@ -1,0 +1,29 @@
+# Massachusetts (ma) — state goals
+
+> **Current tier: C** · Rank **#35 of 40** · Tranche: **LATER** · Impact 5/5 · Effort: hard · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Big state, programs 15/15 aligned; probe massbay PeopleSoft (1 win) then document 6 SAML/auth-gated colleges as ceilings -> courses no longer caps, composite B._
+
+## Diagnosis
+
+- **Primary gap:** 7 of 15 colleges have no course data (53% coverage, courses=C); transfers (13 univ/45.7k mappings), prereqs (1946, clean), config, scorecard all A. 6 of the 7 gaps are SSO/PDF/custom-blocked; only massbay (PeopleSoft) is a probe candidate.
+- **Cheapest lever** (documented-ceiling-accept): Probe massbay PeopleSoft for a guest class-search / CollegeScheduler GraphQL endpoint and build that one scraper (8→9/15); then record the 6 blocked colleges as documented course ceilings so courses no longer caps the composite.
+- **Effort:** hard — To clear the 90% courses bar genuinely, 6 of 7 missing colleges would need bespoke scrapers against auth-gated/custom/PDF SIS (qcc+rcc jenzabar are documented SAML/auth-blocked in scrape-jenzabar-webforms.ts; massasoit+northshore auth-gated; mwcc unknown; necc custom). That is >half-a-day of blocked-endpoint work. Only massbay (PeopleSoft) is a plausible 1-scraper win. Realistic path is documenting the 6 as ceilings (cheap) rather than building them.
+- **Course colleges:** 1 buildable / 6 blocked (of the missing set)
+- **Programs / planner:** 15 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** no
+
+> Notes: Programs perfectly aligned: 15 program JSONs match all 15 institutions.json college_slug values (berkshire,bristol,bhcc,capecod,gcc,hcc,massbay,massasoit,middlesex,mwcc,northshore,necc,qcc,rcc,stcc) — planner sees them. Existing course scrapers: banner-ssb, banner8, colleague, jenzabar-webforms (capecod only). scrape-jenzabar-webforms.ts header DOCUMENTS qcc=auth-gated and rcc=SAML-redirect blocked. massbay=peoplesoft (only probe candidate), massasoit+northshore=auth-gated, mwcc=unknown, necc=custom. documentedCeilings.courseColleges is currently empty — recording the 6 blocked colleges there is the cheap composite-unlock.
+
+## Goal checklist
+
+### MA — current tier C (limited by courses; coverage 8/15=53%)
+
+- [ ] Probe massbay (PeopleSoft) for a public guest class-search or CollegeScheduler GraphQL endpoint (`api.collegescheduler.com/graphql`, `/psc/classsearchguest/...`). If reachable, build `scripts/ma/scrape-massbay-ps.ts` off the IN ivy-tech / CA laccd template, wire it in `lib/states/ma/config.ts` scrapers, import → 9/15.
+- [ ] Record the 6 blocked colleges (qcc, rcc, massasoit, northshore, mwcc, necc) as documented course ceilings in the audit/ceilings config: qcc+rcc jenzabar are SAML/auth-blocked (see header of `scripts/ma/scrape-jenzabar-webforms.ts`), massasoit+northshore auth-gated, mwcc unknown-no-public-endpoint, necc custom-no-public-search. This excuses them so courses reads as covered and stops capping the composite.
+- [ ] Re-run state-audit for ma; confirm courses dimension lifts (8 or 9 real + 6 ceiling = full) and composite moves C→B/A.
+- [ ] (Optional, already done) Programs 15/15 aligned to institutions.json slugs; prereqs/transfers/config/scorecard all A — no action.
+
+Definition of done: massbay either scraped or confirmed gated; all 6 remaining gaps recorded as documented ceilings; state-audit shows courses no longer the limiter and composite ≥ B.

--- a/docs/state-goals/md.md
+++ b/docs/state-goals/md.md
@@ -1,0 +1,30 @@
+# Maryland (md) — state goals
+
+> **Current tier: C** · Rank **#2 of 40** · Tranche: **NOW** · Impact 4/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _All dims A except courses 81%; the 3 missing colleges (ccbc/cecil/garrett) already have wired scrapers that just need a re-run -> 16/16, no new code._
+
+## Diagnosis
+
+- **Primary gap:** Courses at 81% (13/16): cecil, garrett, ccbc lack course data despite existing wired scrapers; all other dims A.
+- **Cheapest lever** (wire-existing-scraper): Re-run the three existing wired scrapers (scrape-banner8.ts --college ccbc; scrape-jenzabar.ts --all) and import their output to data/md/courses/
+- **Effort:** cheap — No new scrapers needed. scripts/md/scrape-jenzabar.ts already covers cecil+garrett and scripts/md/scrape-banner8.ts already covers ccbc, all declared in lib/states/md/config.ts. They just produce no output files — a re-run/debug + import pass. Landing any ONE of the three lifts 13/16→14/16 (88%); two reaches 94% (B+).
+- **Course colleges:** 3 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 3 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: cecil/garrett fingerprint=jenzabar (JICS course-search portlets, public, not SSO login pages); ccbc fingerprint=acalog BUT scrape-banner8.ts targets live Banner 8 at simon.ccbcmd.edu/pls/PROD — use that for sections, acalog is catalog-only. stale term 2025FA flagged across covered colleges → same re-run refreshes terms. Programs only 3/16 colleges (aacc/carroll/csm) but filenames align to college_slug; expanding programs is A-tier extra, not blocking shippable bar.
+
+## Goal checklist
+
+### MD — current tier C (limited by courses; all other dims A)
+
+- [ ] Run `npx tsx scripts/md/scrape-banner8.ts --college ccbc` (Banner 8 at simon.ccbcmd.edu/pls/PROD). If it returns 0, inspect term codes (CCBC uses 202691=Fall) and the PROD path; write data/md/courses/ccbc/.
+- [ ] Run `npx tsx scripts/md/scrape-jenzabar.ts --all` (cecil + garrett JICS portlets). These are public Course_Search.jnz / AddDrop_Courses portlets, not SSO — if empty, debug the Playwright portlet navigation, not access.
+- [ ] Import results and confirm data/md/courses/{ccbc,cecil,garrett} populate; this lifts coverage 13/16→16/16 (clears 90% B+ bar; even 1 college → 88%).
+- [ ] Re-run state-audit for md; confirm courses dim flips C→A/B and composite rises (stale 2025FA also refreshes).
+- [ ] (A-tier extra, optional) Expand programs beyond aacc/carroll/csm via scrape-programs.ts for full planner coverage; filenames already align to college_slug so no rename needed.
+
+Definition of done: data/md/courses/ holds ccbc, cecil, garrett with current-term sections, coverage ≥90%, courses dim ≥B, composite ≥B; no new scrapers authored (all three already exist and are wired in lib/states/md/config.ts).

--- a/docs/state-goals/mi.md
+++ b/docs/state-goals/mi.md
@@ -1,0 +1,30 @@
+# Michigan (mi) — state goals
+
+> **Current tier: C** · Rank **#30 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Big state; build one Coursedog scraper (henry-ford+lake-michigan) + alpena re-run, then ceiling the 12 blocked — realistic cap ~61%, document the rest._
+
+## Diagnosis
+
+- **Primary gap:** 15 of 31 colleges have no course data (52% coverage); transfers (5 univ/152k mappings), prereqs (2317, clean), config, and scorecards are all A. Of the 15 gaps, ~3 are buildable (2 Coursedog + 1 declared-but-failing Colleague) and ~12 are SSO/CAPTCHA/custom-blocked.
+- **Cheapest lever** (build-course-scrapers): Build a MI Coursedog course-section scraper by adapting scripts/lib/scrape-coursedog.ts for henry-ford-college (hfcc.edu/courses) and lake-michigan-college (lakemichigancollege.events.prod.coursedog.com), wire it into lib/states/mi/config.ts scrapers, then run it.
+- **Effort:** medium — The only buildable course work is one new MI Coursedog scraper (adapt scripts/lib/scrape-coursedog.ts) covering henry-ford + lake-michigan, plus a rerun/fix of the already-declared Colleague target alpena. That is ~1-3hr. The remaining 12 gaps are genuinely blocked (Banner login/CAPTCHA on grcc/west-shore, Jenzabar SAML/guest-disabled on bay-de-noc/gogebic/kirtland/kbocc — already investigated, northwestern auth-gated, 4 custom with no public endpoint, wayne-county acalog catalog-only). 90% course bar is unreachable; ~58-61% is the realistic ceiling.
+- **Course colleges:** 3 buildable / 12 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Colleague scraper (scripts/mi/scrape-colleague.ts) declares alpena-community-college but no data/mi/courses/alpena-community-college dir exists — target is failing (auth or term-discovery); needs a rerun/log check, not guaranteed. Jenzabar candidates bay-de-noc/gogebic/kirtland/kbocc already documented as SAML/guest-disabled in scrape-jenzabar-webforms.ts header — do not re-investigate. grcc/west-shore Banner noted in scrape-banner-ssb.ts as login-redirect/CAPTCHA. No documentedCeilings recorded in audit despite a real ~58-61% course ceiling — worth adding courseColleges ceilings for the 12 blocked colleges so courses grades fairly.
+
+## Goal checklist
+
+### MI — current tier C (limited by courses, 52% / 16-of-31)
+
+- [ ] Build MI Coursedog scraper: copy scripts/fl/scrape-coursedog.ts pattern using scripts/lib/scrape-coursedog.ts for henry-ford-college (hfcc.edu/courses) and lake-michigan-college (lakemichigancollege.events.prod.coursedog.com). Write to data/mi/courses/{slug}/.
+- [ ] Wire the new scraper into lib/states/mi/config.ts `scrapers.courses[]` (CI check:scrapers requires it).
+- [ ] Re-run scripts/mi/scrape-colleague.ts --college alpena-community-college; it is declared but produced no data/mi/courses/alpena dir. Capture the failure (auth vs term) and either fix or mark manual-only.
+- [ ] Record documented course ceilings in the audit/config for the 12 blocked colleges (grand-rapids, west-shore = Banner login/CAPTCHA; bay-de-noc, gogebic, kirtland, keweenaw-bay-ojibwa = Jenzabar SAML/guest-disabled per scrape-jenzabar-webforms.ts; northwestern-michigan = auth-gated; bay-mills, kalamazoo-valley, monroe-county, saginaw-chippewa = custom/no public endpoint; wayne-county = acalog catalog-only) so courses grades against the ~58-61% ceiling.
+- [ ] (Gold, optional) Add data/mi/programs/ via Coursedog programs template + align filenames to institutions.json college_slug for planner visibility.
+
+Definition of done: HFC + LMC course sections live under data/mi/courses/ and wired to cron; alpena resolved or documented; the 12 blocked colleges recorded as documented ceilings so courses is no longer flagged as an open buildable gap (shippable B+).

--- a/docs/state-goals/mn.md
+++ b/docs/state-goals/mn.md
@@ -1,0 +1,30 @@
+# Minnesota (mn) — state goals
+
+> **Current tier: B** · Rank **#7 of 40** · Tranche: **NOW** · Impact 3/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _26/28 courses, all else A, planner-ready; document the 2 independent tribal colleges as ceilings -> courses A, composite A. No scraping._
+
+## Diagnosis
+
+- **Primary gap:** 15 of 31 colleges have no course data; transfers/prereqs healthy
+- **Cheapest lever** (documented-ceiling-accept): Mark leech-lake-tribal-college and red-lake-nation-college as documented course ceilings (independent tribal colleges, not in MinnState eservices ISRS, no public SIS) so the courses dimension is formally locked at A-equivalent.
+- **Effort:** cheap — No scraping needed: courses already at 93% (>=90% bar), all other dimensions A. The only residual is formally documenting the 2 tribal colleges as ceilings so the courses dim is locked — a config/registry note edit, well under an hour. The scraper source already documents them as outside the central system.
+- **Course colleges:** 0 buildable / 2 blocked (of the missing set)
+- **Programs / planner:** 6 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: Tribal colleges have empty website fields in data/mn/institutions.json and no entry in data/state-health/fingerprint-baseline.json — no public course-search endpoint to scrape. scripts/mn/scrape-mn-eservices.ts header explicitly states "Tribal colleges (Leech Lake, Red Lake Nation) are NOT in this system." documentedCeilings.courseColleges is currently empty in the audit record, so the only action is to populate it. Note: ignore the schema's example primaryGap text ("15 of 31") — MN's real gap is 2 of 28.
+
+## Goal checklist
+
+### MN — current tier B (limited only by courses 93%, all other dims A)
+
+MN is effectively at the finish line. 26/28 colleges have courses; the 2 gaps are independent tribal colleges with no public SIS.
+
+- [ ] Document the 2 course ceilings: add `leech-lake-tribal-college` and `red-lake-nation-college` to MN's documented-ceiling list (the audit `documentedCeilings.courseColleges` is empty). Rationale: both are independent tribal colleges outside the MinnState eservices ISRS system (see header note in `scripts/mn/scrape-mn-eservices.ts`), have empty `website` fields in `data/mn/institutions.json`, and no entry in `data/state-health/fingerprint-baseline.json` — no public Banner/Colleague/CollegeScheduler endpoint exists to scrape.
+- [ ] Re-run state-audit for mn to confirm courses promotes to A-equivalent once the 2 colleges are excused, lifting composite to A.
+- [ ] (Optional, GOLD already met) Confirm planner: 6 programs in `data/mn/programs/` all filename-aligned to `college_slug`; prereqs 3313 clean — planner is ready, no action.
+
+Definition of done: composite A with courses dimension passing on excused-ceiling basis; the 2 tribal colleges recorded as documented ceilings; no new scrapers required.

--- a/docs/state-goals/mo.md
+++ b/docs/state-goals/mo.md
@@ -1,0 +1,31 @@
+# Missouri (mo) — state goals
+
+> **Current tier: C** · Rank **#34 of 40** · Tranche: **LATER** · Impact 3/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Fingerprint + build SLCC (largest, un-probed) + 2 others, ceiling 2 SSO colleges -> 11/11 buildable clears 90%; investigation-gated._
+
+## Diagnosis
+
+- **Primary gap:** 5 of 13 colleges lack course data (62%). 2 are SSO-gated ceilings (Moberly, State Tech); 3 (Saint Louis CC, Three Rivers, North Central Missouri) were never fingerprinted/probed. Transfers/prereqs/config/scorecard all A.
+- **Cheapest lever** (build-course-scrapers): Fingerprint Saint Louis Community College (stlcc.edu, largest MO 2-year, multi-campus) for a public SIS endpoint and build its scraper — biggest single coverage gain.
+- **Effort:** medium — Reaching ~90% courses needs fingerprinting + building 1-3 new scrapers for un-probed colleges (no scripts/data exist for SLCC/Three-Rivers/NCMC); jenzabar header confirms Moberly + State Tech are login-gated and can be accepted as documented ceilings. One investigation + one or two scrapers = 1-4hr.
+- **Course colleges:** 3 buildable / 2 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Programs absent (Phase 5+, manualOnly) — GOLD-tier only, not part of B+ bar. Fingerprint-baseline has no mo- entries, so the 3 un-probed colleges have never been investigated; SLCC almost certainly has a public SIS. The 2 SSO-gated colleges should be logged as documented ceilings — once they are, MO clears the 90% bar at 11/11 buildable and shippableBarMet flips true.
+
+## Goal checklist
+
+### MO — current tier C (limited by courses, 8/13 = 62%)
+
+Transfers (A: 13 univ, 8874 Core-42 mappings, wired), prereqs (A: 645, clean, wired), config (A), scorecard (A) are all done. Only courses block B+.
+
+- [ ] Fingerprint **saint-louis-community-college** (stlcc.edu, multi-campus, largest MO 2-year). Probe Banner SSB 9 / Colleague Self-Service guest (`selfservice.*`, `ss-prod.*`) / CollegeScheduler GraphQL. Build scraper under `scripts/mo/` (reuse an existing `scripts/mo/scrape-*.ts` template) → `data/mo/courses/saint-louis-community-college/`.
+- [ ] Fingerprint **three-rivers-college** and **north-central-missouri-college** (no scraper or baseline entry exists). Probe same patterns; build scrapers or fold into the matching existing template (colleague/banner8/jenzabar).
+- [ ] For **moberly-area-community-college** (my.macc.edu) and **state-technical-college-of-missouri** (mytech.statetechmo.edu): jenzabar header confirms both are login/SSO-gated. Record as documentedCeilings.courseColleges in the audit so coverage is computed over buildable colleges (11/11 → passes 90%).
+- [ ] Declare any new scrapers in `lib/states/mo/config.ts` `scrapers` block (cron-wire) per the same-PR rule.
+
+Definition of done: courses >=90% of non-ceiling colleges have data (target SLCC + Three Rivers + NCMC scraped; Moberly + State Tech documented as SSO ceilings), new scrapers cron-wired → composite B+.

--- a/docs/state-goals/ms.md
+++ b/docs/state-goals/ms.md
@@ -1,0 +1,29 @@
+# Mississippi (ms) — state goals
+
+> **Current tier: F** · Rank **#9 of 40** · Tranche: **NOW** · Impact 3/5 · Effort: medium · Value/effort: **H**
+>
+> Dimensions: `crs=F` `prq=A` `trf=C` `sc=A` `cfg=A`
+>
+> _Re-land orphaned #964 (252 programs, pure rename) for an instant planner GOLD win; courses 7% is a separate medium slog, so do the cheap data fix now._
+
+## Diagnosis
+
+- **Primary gap:** 14 of 15 colleges have no course data (coverage 7%, only Meridian); transfers/prereqs/config/scorecard all healthy. Separately, the merged program-alignment fix #964 is an orphaned commit NOT on main, so 252 programs sit unplannable.
+- **Cheapest lever** (build-course-scrapers): Re-land orphaned commit e4134a06 (#964): rename data/ms/programs/{hinds,jcjc,meridian,mgccc,northwest}.json to their institution college_slug names + fix internal college_slug field + scripts/ms/scrape-programs.ts — unlocks 252 programs / 4 colleges for the planner (pure data, no scrape).
+- **Effort:** medium — 6 of 14 missing colleges expose public SIS endpoints (3 Colleague guest, 1 Banner SSB 9, 2 acalog/jenzabar catalogs) and shared templates already exist in scripts/lib/ — each is a thin per-host wrapper like scrape-banner8.ts, roughly 1-4hr to wire all six. The other 8 are custom/unknown with no public endpoint detected (re-probe needed). Reaching the 90% courses bar is not achievable cheaply; the realistic medium goal lifts coverage from 7% to ~47%.
+- **Course colleges:** 6 buildable / 8 blocked (of the missing set)
+- **Programs / planner:** 5 program files · MISALIGNED ⚠️ (hidden from planner) · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: MAJOR: commit e4134a06 "fix(ms): align program filenames (#964)" is NOT an ancestor of HEAD — orphaned by a squash-merge race (the exact failure mode in CLAUDE.md/memory). Program files on main are still hinds.json/jcjc.json/meridian.json/mgccc.json/northwest.json (short slugs), so the planner resolves 0 plannable MS programs despite 252 on disk. Re-landing is a cheap data-only PR. Fingerprint buildables: east-mississippi (colleague colss-prod.ec.eastms.edu), hinds (colleague ryvws07.hindscc.edu), holmes (banner-ssb-9 api.holmescc.edu), east-central (jenzabar my.eccc.edu/ICS), jones-county + mississippi-gulf-coast (acalog catalogs). Blocked/custom-unknown (8): coahoma, copiah-lincoln, mississippi-delta, northwest-mississippi, southwest-mississippi, pearl-river, northeast-mississippi, itawamba — re-probe Ellucian-cloud/Colleague subdomains before accepting. Transfers thin (ole-miss only, 2109 mappings, wired) — medium upside to add a 2nd receiver (e.g. Mississippi State / USM).
+
+## Goal checklist
+
+### MS — current tier F (limited by courses, 7% coverage 1/15)
+
+- [ ] **Re-land orphaned #964 (cheap, planner GOLD):** commit e4134a06 is NOT on main. Rename data/ms/programs/{hinds→hinds-community-college, jcjc→jones-county-junior-college, meridian→meridian-community-college, mgccc→mississippi-gulf-coast-community-college, northwest→northwest-mississippi-community-college}.json, fix each file's internal `college_slug`, and update slugs in scripts/ms/scrape-programs.ts. Unlocks 252 programs / 4 plannable colleges.
+- [ ] **Build 6 buildable course scrapers (medium, moves composite):** add per-host wrappers like scripts/ms/scrape-banner8.ts using scripts/lib templates: Colleague (scrape-colleague.ts) for east-mississippi (colss-prod.ec.eastms.edu), hinds (ryvws07.hindscc.edu); Banner SSB 9 (scrape-banner-ssb.ts) for holmes (api.holmescc.edu); jenzabar (scrape-jenzabar.ts) for east-central (my.eccc.edu/ICS); acalog catalog for jones-county (catalog.jcjc.edu) + mississippi-gulf-coast (catalog.mgccc.edu). Declare each in lib/states/ms/config.ts scrapers.courses. Lifts coverage 7%→~47%.
+- [ ] **Re-probe 8 custom/unknown colleges:** coahoma, copiah-lincoln, mississippi-delta, northwest-mississippi, southwest-mississippi, pearl-river, northeast-mississippi, itawamba — try Ellucian-cloud (colss-prod.ec.*, selfservice.*) + Colleague (ss-prod.cloud) subdomains per memory before accepting as ceiling.
+- [ ] **(optional) Add 2nd transfer receiver** (Mississippi State / USM) to lift transfers C→B.
+
+Definition of done: courses ≥90% (or documented ceiling for the 8 customs) AND program files aligned so planner shows MS programs.

--- a/docs/state-goals/mt.md
+++ b/docs/state-goals/mt.md
@@ -1,0 +1,31 @@
+# Montana (mt) — state goals
+
+> **Current tier: C** · Rank **#8 of 40** · Tranche: **NOW** · Impact 2/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _All dims A except courses 60%; the 4 missing are tribal/auth-gated ceilings — recording them lifts courses 60%->effective 100%, composite C->A._
+
+## Diagnosis
+
+- **Primary gap:** 4 of 10 colleges have no course data (60% coverage); all 4 are tribal/auth-gated colleges with no public course-search. Transfers (6 universities, 1309 mappings, wired), prereqs (119, clean), scorecard (10/10), config all A. No programs dir.
+- **Cheapest lever** (documented-ceiling-accept): Document the 4 missing tribal/auth-gated colleges (aaniiih-nakoda, stone-child, highlands-college-of-montana-tech, fort-peck) as course-data ceilings so the audit excuses them — lifts courses 60%→effective 100% and composite C→A with no scraping.
+- **Effort:** cheap — The composite is C limited ONLY by courses at 60%. The 4 missing colleges are not buildable: Aaniiih Nakoda + Stone Child are custom tribal-college sites with no courseSearchUrl, Highlands College of Montana Tech is auth-gated (high-confidence SSO), and Fort Peck's only Jenzabar URL is an Admissions/Apply portlet, not class search. These are a documented ceiling. Recording them as course-ceiling colleges (no scraping) excuses them, making 6/6 reachable = 100% and lifting courses C→A and composite to A. <1hr config/audit edit.
+- **Course colleges:** 0 buildable / 4 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: scripts/mt/ already has scrapers for the 6 covered colleges (banner8 for dawson+miles, cdkc, fvcc, lbhc, skc, transfer-ccn). dawson + chief-dull-knife are in lowSection (thin but present, not missing). Transfers via CCN are strong (A). Term 2025FA flagged stale — a cron rerun would refresh to current term but is not gating. Programs are manualOnly ("Phase 5+") — building them is a separate A-tier extra, not needed for a B+ finish. The 4 missing are classic tribal-college / SSO ceilings: no public Banner SSB / Colleague guest / CollegeScheduler endpoint detected.
+
+## Goal checklist
+
+### MT — current tier C (courses-limited; prereqs/transfers/scorecard/config all A)
+
+The only gap is course coverage 60% (6/10). The 4 missing are not buildable — they are tribal/auth-gated colleges with no public class search. Accept them as a documented ceiling.
+
+- [ ] In the state-audit ceiling config (the source feeding `documentedCeilings.courseColleges` / `ceilingsApplied`), add the 4 missing slugs as course-data ceilings: `aaniiih-nakoda-college` (custom, no courseSearchUrl), `stone-child-college` (custom, no courseSearchUrl), `highlands-college-of-montana-tech` (auth-gated/SSO, high confidence), `fort-peck-community-college` (Jenzabar URL is an Admissions/Apply portlet, not class search). Cite the fingerprint-baseline.json platform verdicts as rationale.
+- [ ] Re-run `state-audit mt` — with 6/6 reachable colleges covered, courses should hit ~100% → A, lifting composite to A/B+.
+- [ ] (Optional, non-gating) Rerun cron `scripts/mt/scrape-banner8.ts` etc. to refresh the stale `2025FA` term to current.
+- [ ] (A-tier extra, defer) Build `data/mt/programs/` + planner alignment — currently manualOnly "Phase 5+", not required for B+.
+
+Definition of done: composite >= B with courses A/B after the 4 unbuildable tribal/auth-gated colleges are recorded as documented ceilings; transfers/prereqs/scorecard/config remain A.

--- a/docs/state-goals/nc.md
+++ b/docs/state-goals/nc.md
@@ -1,0 +1,28 @@
+# North Carolina (nc) — state goals
+
+> **Current tier: C** · Rank **#3 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=B` `prq=C` `trf=A` `sc=A` `cfg=A`
+>
+> _Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A._
+
+## Diagnosis
+
+- **Primary gap:** Prereqs dim is C: 8 of ~hundreds of entries have raw <br> HTML in their text field and empty courses[] (parser never extracted codes). All other dims pass: courses B (58/58 covered, 0 missing), transfers A (20 universities / 25,687 mappings / wired), config A, scorecard A. No programs data (Acalog scraper unwired) — A-tier extra only.
+- **Cheapest lever** (clean-prereqs): Run a regex cleanup over the 8 contaminated entries in data/nc/prereqs.json (BTB 103, EDU 234A, MRN 121, MSC 256, PHM 120, PHM 136, VET 220, WBL 115U): strip <br>, split on the "Take ... - Must be..." clauses, and populate courses[] from the XXX-NNN codes. Lifts prereqs C→A and composite to B+.
+- **Effort:** cheap — The only defect is 8 prereq entries in data/nc/prereqs.json contaminated solely by ",<br>" separators between "Take XXX-NNN - Must be..." clauses, with empty courses[]. A regex pass to strip <br>, split clauses, and re-extract course codes is well under an hour and lifts prereqs C→A.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Prereqs.json structure: {courseCode: {text, courses[]}}. The 8 contaminated entries all have empty courses[], so fixing them both de-contaminates display and recovers lost prereq edges for the planner. courses.missing[] is empty — no course scrapers needed. Transfers already excellent (20 in-state university receivers, cron-wired). Programs: data/nc/programs/ does not exist; manualOnly flags "Acalog program scraper not yet wired up" — building it is the only path to GOLD/A planner tier but is a separate medium effort, not required for shippable.
+
+## Goal checklist
+
+### NC — current tier C (limited by prereqs)
+
+- [ ] Clean the 8 HTML-contaminated entries in `data/nc/prereqs.json`: `BTB 103`, `EDU 234A`, `MRN 121`, `MSC 256`, `PHM 120`, `PHM 136`, `VET 220`, `WBL 115U`. Each has raw `,<br>` joining "Take XXX-NNN - Must be..." clauses and an empty `courses[]`. Strip `<br>`, split clauses, and re-extract course codes (normalize `XXX-NNN`→`XXX NNN`) into `courses[]`. This lifts prereqs C→A and composite to B+. (cheap, <1hr)
+- [ ] Re-run `/state-audit nc` (or the scorecard) to confirm prereqs no longer reports "HTML contamination" and composite rises.
+- [ ] (A-tier extra, optional) Wire an Acalog program scraper for NC into `scripts/nc/` + `StateConfig.scrapers`, output to `data/nc/programs/<college_slug>.json` with filenames aligned to `institutions.json` `college_slug` so the degree-path planner can see them. Medium effort; not required for shippable.
+
+Definition of done: prereqs dim is A (no HTML contamination, contaminated entries' `courses[]` populated), courses/transfers/config/scorecard remain A/B, and the audit composite is B+ or better.

--- a/docs/state-goals/nd.md
+++ b/docs/state-goals/nd.md
@@ -1,0 +1,29 @@
+# North Dakota (nd) — state goals
+
+> **Current tier: C** · Rank **#32 of 40** · Tranche: **LATER** · Impact 1/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Add CCCC+NHSC institution codes to the wired NDUS PS scraper (verified public) + ceiling Sitting Bull -> 7/7 courses, but PS endpoint is flaky._
+
+## Diagnosis
+
+- **Primary gap:** Courses at C (63%, 5/8). The 3 missing are all tribal colleges: CCCC and NHSC are VERIFIED on the public shared NDUS PeopleSoft NDCSPRD tenant (buildable — just not yet in scrape-ndus.ts INSTITUTIONS array); Sitting Bull is Jenzabar with uncertain guest access (blocked). Transfers/prereqs/config/scorecard all A.
+- **Cheapest lever** (build-course-scrapers): Add CCCC and NHSC institution codes to the INSTITUTIONS array in scripts/nd/scrape-ndus.ts and rerun the scrape — both are verified on the public NDUS NDCSPRD PeopleSoft tenant. Lands 7/8 course coverage.
+- **Effort:** medium — 2 buildable colleges (CCCC, NHSC) ride the existing scripts/nd/scrape-ndus.ts PeopleSoft scraper; need only their NDUS institution codes added to the INSTITUTIONS array, then a rerun. But the NDCSPRD PS Community Access endpoint has a documented stability blocker (Fall 2026 rerun failed mid-scrape per data/nd/DEFERRED.md), so it is a one-scraper-config + flaky-run task, not a trivial config edit. Sitting Bull (Jenzabar) needs separate guest-access investigation.
+- **Course colleges:** 2 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 2 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: Programs present for 2/8 colleges (bismarck-state-college.json, williston-state-college.json) — both filenames match institutions.json college_slug values, so planner-aligned, but coverage is thin. data/nd/DEFERRED.md is the authoritative blocker log: CCCC+NHSC verified public PS (buildable), Sitting Bull=Jenzabar (treat as documented ceiling). Prereqs 543 entries clean+wired; transfers 6 universities / 5694 GERTA mappings wired; config fully populated. Course scraper scripts/nd/scrape-ndus.ts is cron-wired in lib/states/nd/config.ts. Excusing Sitting Bull as a ceiling, landing the 2 buildable colleges yields 7/7 = 100% and flips courses C→A/B+.
+
+## Goal checklist
+
+### ND — current tier C (limited by courses, 63% / 5 of 8)
+
+- [ ] Find NDUS institution codes for Cankdeska Cikana (CCCC) and Nueta Hidatsa Sahnish (NHSC) on the shared NDCSPRD PeopleSoft tenant (Community Access institution dropdown), then add two rows to the `INSTITUTIONS` array in `scripts/nd/scrape-ndus.ts` (matching slugs `cankdeska-cikana-community-college`, `nueta-hidatsa-sahnish-college` from `data/nd/institutions.json`). Both are VERIFIED public per `data/nd/DEFERRED.md`.
+- [ ] Run `npx tsx scripts/nd/scrape-ndus.ts --term "Spring 2026" --slug cankdeska-cikana-community-college` then the same for nueta; detach if the PS endpoint shows the known instability (DEFERRED.md notes a Fall 2026 mid-scrape failure). Confirm `data/nd/courses/<slug>/` populated → 7/8 coverage.
+- [ ] Treat Sitting Bull College (Jenzabar, uncertain guest access) as a documented ceiling: verify no public class-search guest path; if confirmed gated, add it to `documentedCeilings.courseColleges` so 7/7 non-blocked = 100%. Do NOT build an SSO-gated scraper.
+- [ ] (GOLD, optional) Extend programs beyond bismarck/williston via the deferred catalog scrapes (WSC Acalog, Dakota/NDSCS Cleancatalog-via-Playwright, LRSC PDF) in DEFERRED.md.
+
+Definition of done: courses ≥90% counting Sitting Bull as an excused ceiling (7/7), composite C→B+; transfers/prereqs/config/scorecard remain A.

--- a/docs/state-goals/ne.md
+++ b/docs/state-goals/ne.md
@@ -1,0 +1,31 @@
+# Nebraska (ne) — state goals
+
+> **Current tier: F** · Rank **#18 of 40** · Tranche: **NEXT** · Impact 2/5 · Effort: medium · Value/effort: **H**
+>
+> Dimensions: `crs=B` `prq=A` `trf=F` `sc=A` `cfg=A`
+>
+> _Courses B, all else A; F is empty transfers only — one Transfer Nebraska scraper (portal exists) flips F->B/A._
+
+## Diagnosis
+
+- **Primary gap:** Transfers is the sole blocker: transfer-equiv.json is [] (0 mappings, 0 universities, unwired, no scraper, no documented ceiling) → drags composite to F. Courses B (8/9, only NCTA missing), prereqs A, config A, scorecard A all healthy; programs present and planner-aligned.
+- **Cheapest lever** (investigate-articulation): Investigate Nebraska's statewide articulation portal (Transfer Nebraska, transfer.nebraska.edu), build scripts/ne/scrape-transfer.ts, populate data/ne/transfer-equiv.json, and declare transfers in lib/states/ne/config.ts scrapers — this alone lifts composite F→B.
+- **Effort:** medium — One investigation + one scraper. NE's statewide articulation source (Transfer Nebraska / transfer.nebraska.edu, run by the state college + university system) is simply not registered — the audit's "no articulation portal" means unwired, not nonexistent. Building and wiring a transfers scraper is 1-4hr and flips the only failing dimension. NCTA course gap is trivial/low-value (already B).
+- **Course colleges:** 1 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 2 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** no
+
+> Notes: Courses already B (8/9); only NCTA (ncta.unl.edu, tiny UNL ag college, not in fingerprint-baseline) missing — buildable but low-value. Prereqs/config/scorecard all A. Programs: 2 files (southeast, western-nebraska), both filenames match institutions.json college_slug and internal college_slug — planner can see them. The single F is transfers (empty transfer-equiv.json, no ceiling). Fingerprint-baseline.json predates NE and has no NE entries, so SIS-platform judgment for missing college came from clusters.json (NCTA = singleton, ncta.unl.edu).
+
+## Goal checklist
+
+### NE — current tier F (limited by transfers)
+
+- [ ] **Investigate articulation (cheapest high-value).** Check Nebraska's statewide transfer portal — Transfer Nebraska at transfer.nebraska.edu (NE state colleges + University of Nebraska system course-equivalency tool). Find a public/guest course-equivalency or API endpoint. If genuinely none exists publicly, document it as a transfers ceiling in `lib/states/ne/config.ts` and the audit ceiling list (accept-as-is) — that alone clears the composite blocker.
+- [ ] **Build the scraper** `scripts/ne/scrape-transfer.ts` (model on `scripts/me/scrape-transfer-mainestreet.ts` or `scripts/ct/scrape-transfer-all.ts`). In-state targets only (UNL/UNO/UNK + Chadron/Peru/Wayne state colleges). Drop any cross-state rows.
+- [ ] **Write** `data/ne/transfer-equiv.json` with non-trivial mappings (currently `[]`).
+- [ ] **Wire cron**: add `transfers: [{ scripts: ["scripts/ne/scrape-transfer.ts"], runner: ... }]` to `scrapers` in `lib/states/ne/config.ts` (remove the `// manual-only: transfers` marker).
+- [ ] **Verify** at `/ne/transfer`: pick a sending CC + course, confirm equivalency renders.
+- [ ] (Optional, low value) NCTA course scraper (ncta.unl.edu, 1 college) to push courses 89%→100%; courses is already B so skip unless going for gold.
+
+Definition of done: `/ne/transfer` shows real in-state equivalencies, transfers scraper cron-wired, composite ≥ B.

--- a/docs/state-goals/nh.md
+++ b/docs/state-goals/nh.md
@@ -1,0 +1,30 @@
+# New Hampshire (nh) — state goals
+
+> **Current tier: B** · Rank **#15 of 40** · Tranche: **NOW** · Impact 2/5 · Effort: hard · Value/effort: **M**
+>
+> Dimensions: `crs=A` `prq=A` `trf=B` `sc=A` `cfg=A`
+>
+> _Already shippable; transfers a hard ceiling (UNH/Plymouth no public DB, Keene wired). Accept; optional nashuacc programs for 7/7 planner._
+
+## Diagnosis
+
+- **Primary gap:** Transfers capped at B by documented hard ceiling (only Keene reachable; UNH/Plymouth publish no public CC-to-4-year articulation DB). All other dims are A. Courses 7/7, prereqs 600 wired, config full. Programs 6/7 colleges, filenames aligned.
+- **Cheapest lever** (documented-ceiling-accept): Accept the documented transfers ceiling — NH is already shippable at B. Optionally add a nashuacc programs scrape to complete planner coverage (6/7 → 7/7).
+- **Effort:** hard — The sole composite limiter (transfers B) is a documented hard ceiling: UNH and Plymouth State have no public CC-to-4-year articulation database to scrape. Lifting it would require new articulation infra from scratch / non-public sources — more than half a day and likely not achievable from public data. Everything cheap is already done.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 6 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: No missing-course colleges (7/7 covered). Transfers limiter is a documented hard ceiling (UNH/Plymouth no public articulation DB); Keene scraper wired with 2,680 mappings. Programs aligned to college_slug; only nashuacc lacks a program file (6/7), purely a planner-completeness nicety, not a shippable-bar gap.
+
+## Goal checklist
+
+### NH — current tier B (shippable; documented transfers ceiling)
+
+NH passes the B+ shippable bar already: courses A (7/7), prereqs A (600 entries, wired, clean), scorecard A (7/7), config A. Transfers is B only because of a documented hard ceiling.
+
+- [ ] Accept transfers ceiling as-is. UNH and Plymouth State publish no public CC-to-4-year articulation database; `scripts/nh/scrape-transfer-keene.ts` already covers the one reachable receiver (Keene State, 2,680 mappings in `data/nh/transfer-equiv.json`, cron-wired). Do NOT re-pitch a 2nd university unless a public USNH articulation portal appears.
+- [ ] (Optional, planner-completeness only) Add Nashua CC programs. `data/nh/programs/` has 6/7 colleges; only `nashuacc` (in `data/nh/institutions.json`) lacks a `nashuacc.json`. Extend `scripts/nh/scrape-programs.ts` to cover it. The 6 existing program filenames already align to `college_slug`, so the planner sees them.
+- [ ] Confirm no regression: `data/nh/courses/`, `prereqs.json`, `transfer-universities.json` unchanged.
+
+Definition of done: transfers ceiling formally accepted (no further articulation work expected) and, if pursued, nashuacc programs file added so planner coverage is 7/7. State stays B (A-ceiling-capped).

--- a/docs/state-goals/nj.md
+++ b/docs/state-goals/nj.md
@@ -1,0 +1,31 @@
+# New Jersey (nj) — state goals
+
+> **Current tier: C** · Rank **#14 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Big state; re-run wired colleague for camden+ocean (fix ocean's bare base URL) -> 89%, then document the 3 Jenzabar/custom colleges as ceiling._
+
+## Diagnosis
+
+- **Primary gap:** 5 of 18 colleges lack course data (78%); but camden+ocean are Colleague guest-scrapeable and ALREADY in scripts/nj/scrape-colleague.ts's college list yet produced no output — they just need a re-run/URL fix. salem (custom, no endpoint) + sussex/warren (Jenzabar .jnz portal forms, no public course search) are blocked. Transfers/prereqs/config all A.
+- **Cheapest lever** (wire-existing-scraper): Re-run scripts/nj/scrape-colleague.ts for camden and ocean (already wired); diagnose/fix ocean's base URL (bare https://ocean.edu likely needs a selfservice. Ellucian host) — lifts courses C→B at ~89% coverage.
+- **Effort:** cheap — camden + ocean are already declared in COLLEAGUE_COLLEGES (scrape-colleague.ts lines 38, 47) with Colleague /Student/Courses guest endpoints but have no data dir — re-running the existing scraper (fixing ocean's bare ocean.edu base URL, likely needs selfservice. subdomain) is well under an hour and lifts courses 78%→89% (C→B). No new scraper code needed.
+- **Course colleges:** 2 buildable / 3 blocked (of the missing set)
+- **Programs / planner:** 1 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: camden+ocean already in scrape-colleague.ts COLLEAGUE_COLLEGES (lines 38,47) but no data/nj/courses/{camden,ocean}/ dir exists → scrape returned 0 sections (gated or wrong host). ocean base URL is bare https://ocean.edu (no selfservice. subdomain, no elluciancloud host) — most likely the failure; camden uses selfservice.camdencc.edu. salem=custom/no courseSearchUrl/low-confidence (blocked); sussex=my.sussex.edu .jnz ICS Admissions portlet, warren=mywarren ICS Admissions — both Jenzabar portal/forms, not public course search (blocked). With camden+ocean fixed → 16/18 = 89%, one shy of the 90% bar; the remaining 3 are a genuine Jenzabar/custom ceiling. Programs: only bergen.json (111 programs, college_slug=bergen, aligned); other 17 colleges have no programs so full planner is data-limited, not misalignment.
+
+## Goal checklist
+
+### NJ — current tier C (limited by courses; transfers/prereqs/config all A)
+
+- [ ] Re-run the EXISTING colleague scraper for the two already-wired-but-empty colleges: `tsx scripts/nj/scrape-colleague.ts --college camden` and `--college ocean`. Both are in COLLEAGUE_COLLEGES (lines 38, 47) but have no `data/nj/courses/{slug}/` dir.
+- [ ] Fix ocean's base URL: line 47 is bare `https://ocean.edu` (no `selfservice.` host). Probe `selfservice.ocean.edu/Student/Courses` and `ocean-ss.colleague.elluciancloud.com`; update the map, re-scrape. This is the likely 0-section cause.
+- [ ] If camden also returns 0, confirm guest access at `selfservice.camdencc.edu/Student/Courses?guestUser=true`; the scraper already falls back to guestUser=true.
+- [ ] Commit new course data → courses 14/18 → 16/18 = 89% ≈ B tier.
+- [ ] Document the ceiling for the remaining 3: salem (custom, no public course search), sussex + warren (Jenzabar `.jnz` ICS Admissions portal forms, no public catalog). Add them to documentedCeilings.courseColleges so 89% counts as the shippable ceiling.
+- [ ] (GOLD, optional) Programs: only `data/nj/programs/bergen.json` exists (111 programs, aligned). Extend `scripts/nj/scrape-programs.ts` to other colleges with Acalog catalogs to widen planner coverage.
+
+Definition of done: camden+ocean course data committed (courses ≥89%, B), the 3 Jenzabar/custom colleges recorded as documented ceilings, transfers/prereqs/config remain A.

--- a/docs/state-goals/nm.md
+++ b/docs/state-goals/nm.md
@@ -1,0 +1,30 @@
+# New Mexico (nm) — state goals
+
+> **Current tier: C** · Rank **#31 of 40** · Tranche: **LATER** · Impact 2/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _All else A; wire ruidoso coursedog (on-disk) then re-fingerprint clovis/luna/nmmi/mesalands — needs investigation + 1-2 scrapers to clear 90%._
+
+## Diagnosis
+
+- **Primary gap:** 5 of 12 colleges have no course data (58% coverage); transfers/prereqs/scorecard/config all A. 1 missing college (eastern-nm-ruidoso) is Coursedog-buildable; the other 4 (clovis, luna, nmmi, mesalands) have no detected SIS platform and need re-fingerprinting.
+- **Cheapest lever** (build-course-scrapers): Wire a Coursedog section scrape for eastern-nm-ruidoso (platform confirmed by data/nm/coursedog-catalog dump + existing scripts/lib/scrape-coursedog.ts template), lifting courses 7/12→8/12 (67%).
+- **Effort:** medium — One cheap win exists (ruidoso Coursedog section scrape — platform confirmed by a 940-course catalog dump already on disk + reusable scripts/lib/scrape-coursedog.ts), but reaching the >=90% courses bar requires fingerprinting and likely 1-2 bespoke scrapers for clovis/luna/nmmi/mesalands, which have no platform detected in clusters.json/fingerprint-baseline.json and no public endpoint on record. That is a 1-4hr investigation-plus-scraper job, not a cheap wire-up nor a half-day SSO slog.
+- **Course colleges:** 1 buildable / 4 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: Composite C, limited solely by courses. Transfers A (8,837 mappings / 6 universities via CCNS API, wired), prereqs A (255 clean entries, wired), scorecard 12/12, config all populated — these are finish-line already. Existing nm scrapers: banner8 (NNMC), campusnexus (SENMC), colleague (San Juan), sipi-pdf (SIPI), plus CNM/NMJC/Santa Fe = 7 covered. data/nm/coursedog-catalog/eastern-new-mexico-university-ruidoso-branch-community-college.json (940 courses) confirms ruidoso runs Coursedog → buildable. clovis/luna/nmmi/mesalands appear in clusters.json as singletons with primary URLs only (clovis.edu, luna.edu, nmmi.edu) and zero entries in fingerprint-baseline.json — platform unknown, must re-fingerprint before judging scrapeability. Separately, scripts/nm/scrape-programs.ts points at wrong catalog domains (catalog.northern.edu/southeast.edu/eastern.edu — these resolve to out-of-state schools), which is why programs yielded 0 files; programs is an A-tier extra, not on the B+ bar.
+
+## Goal checklist
+
+### NM — current tier C (limited by courses, 58% / 7-of-12)
+
+- [ ] Wire Coursedog section scrape for `eastern-new-mexico-university-ruidoso-branch-community-college` using `scripts/lib/scrape-coursedog.ts` (platform confirmed by the 940-course dump at `data/nm/coursedog-catalog/eastern-...ruidoso-...json`); import to `data/nm/courses/`. → 8/12 (67%).
+- [ ] Re-fingerprint the 4 unknown colleges — clovis (clovis.edu), luna (luna.edu), new-mexico-military-institute (nmmi.edu), mesalands — probe Banner SSB, Colleague Self-Service guest (try non-443 ports + ec.cloud subdomains per memory), CampusNexus/CMCPortal (reuse `scripts/nm/scrape-campusnexus.ts`), and CollegeScheduler GraphQL. Record findings in `data/state-health/fingerprint-baseline.json`.
+- [ ] For each that surfaces a public endpoint, build a bespoke scraper in `scripts/nm/` and declare it in `lib/states/nm/config.ts` scrapers (CI `check:scrapers`). Target 11/12 (>=90%) → courses B+, composite B+.
+- [ ] If any college is genuinely SSO/PDF-only with no public class search, add it to `documentedCeilings.courseColleges` so it's excused from the 90% bar.
+- [ ] (A-tier, optional) Fix `scripts/nm/scrape-programs.ts` catalog domains (current catalog.northern/southeast/eastern.edu are wrong schools) and run it to populate `data/nm/programs/`, then verify filenames match `institutions.json` college_slug for planner visibility.
+
+Definition of done: courses >=90% of system colleges have section data (or remainder documented as ceilings); composite reaches B+, all new scrapers cron-wired.

--- a/docs/state-goals/ny.md
+++ b/docs/state-goals/ny.md
@@ -1,0 +1,30 @@
+# New York (ny) — state goals
+
+> **Current tier: D** · Rank **#26 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=D` `prq=C` `trf=A` `sc=C` `cfg=A`
+>
+> _Huge state; re-run 5 wired Banner hosts (49%->62%) + strip 250 HTML prereqs (C->A), then ceiling the 13 no-SIS colleges -> D->C/B._
+
+## Diagnosis
+
+- **Primary gap:** 19 of 37 colleges have no course-section data (49% coverage); transfers (A, 254K mappings/36 unis) and config (A) are healthy. Of the 19 missing, only 5 are cheaply buildable (wired Banner SSB hosts that failed last scrape); the other 14 lack a public course-section SIS (Acalog/OmniUpdate program-catalogs, PDF-only, or auth-gated).
+- **Cheapest lever** (wire-existing-scraper): Re-run the already-wired scripts/ny/scrape-suny-banner-ssb.ts for the 5 declared-but-failed hosts (jefferson-cc, suny-broome-cc, suny-ulster, monroe-cc, nassau-cc) — suny-broome smoke-tested 1,205 live sections; this adds 5 colleges (49%->62%) with zero new code.
+- **Effort:** medium — Cheapest wins are an hour or less (re-run the already-wired scrape-suny-banner-ssb.ts for 5 failed hosts; regex-strip 250 HTML-contaminated prereq entries). But reaching the courses >=90% bar is hard: 13-14 colleges have no public course-section endpoint documented in-repo (Acalog/OmniUpdate are program catalogs with no live sections; FMCC/Schenectady/Sullivan PDF-only; tompkins auth-gated), so a true B+ on courses needs many bespoke or auth scrapers. Medium = one re-run + one regex pass lifts composite D->C without clearing the course ceiling.
+- **Course colleges:** 5 buildable / 14 blocked (of the missing set)
+- **Programs / planner:** 21 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: Course DATA (sections) for NY comes only from Banner SSB (scrape-suny-banner-ssb.ts) + Colleague (scrape-suny-colleague.ts) + CUNY (scrape-cuny.ts, 7 cols) + bespoke cayuga/herkimer. The _suny-catalog-fingerprint.md table documents PROGRAM catalogs (Acalog/OmniUpdate/SmartCatalog/PDF), NOT live section search — so Acalog colleges (erie, suny-orange, suny-niagara, hudson-valley, westchester, etc.) have programs/prereqs but no section feed. 5 missing colleges have wired Banner hosts that failed last run (term-resolution/WAF), the cheapest fix. tompkins-cortland-cc Colleague host declared but /Student/Courses 404s unauth (DEFERRED, auth flow). north-country banner.nccc.edu = NTLM-gated (blocked). FMCC/Schenectady/Sullivan PDF-only. Prereqs C: 250 CUNY Coursedog entries carry raw <p>/<a> curriculum-committee HTML blobs — pure regex/strip cleanup. Programs 21/21 filenames already aligned to college_slug (no misalignment bug). Transfers + config both A.
+
+## Goal checklist
+
+### NY — current tier D (limited by courses; transfers A, config A)
+
+- [ ] Re-run wired Banner SSB for the 5 declared-but-failed hosts: `npx tsx scripts/ny/scrape-suny-banner-ssb.ts` (jefferson-cc, suny-broome-cc, suny-ulster, monroe-cc, nassau-cc). suny-broome smoke-tested 1,205 live sections; likely term-resolution/WAF. Per-college: `--college suny-broome-cc`. Lands +5 colleges → 23/37 (62%). Courses D→C.
+- [ ] Clean prereq HTML contamination: 250 entries in `data/ny/prereqs.json` carry raw `<p>`/`<a>` CUNY Coursedog narrative. Add a strip-HTML + drop-narrative-blob pass to `scripts/ny/scrape-catalog-prereqs.ts` (or a one-off sanitizer) and re-emit. Prereqs C→A.
+- [ ] tompkins-cortland-cc: Colleague host declared in `scrape-suny-colleague.ts` but `/Student/Courses` 404s unauth — build Playwright login flow if pursued (DEFERRED; medium).
+- [ ] Remaining 13 missing colleges (erie, suny-orange, suny-niagara, hudson-valley, westchester, clinton, genesee, mvcc, fmcc, jamestown, suny-sullivan, north-country, fit): no public course-section SIS in-repo — only program catalogs (Acalog/OmniUpdate) / PDF / NTLM. Document as a course ceiling OR investigate each for a Banner/Colleague/CollegeScheduler endpoint (hard, per-college).
+- [ ] (Gold) Extend programs beyond 21/37 to lift planner readiness.
+
+Definition of done: courses ≥90% of non-ceiling colleges OR a written course ceiling for the 13-14 no-SIS colleges; prereqs HTML-clean; transfers+config stay A.

--- a/docs/state-goals/oh.md
+++ b/docs/state-goals/oh.md
@@ -1,0 +1,30 @@
+# Ohio (oh) — state goals
+
+> **Current tier: D** · Rank **#28 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=D` `prq=A` `trf=C` `sc=B` `cfg=A`
+>
+> _Large state; re-run 2 wired hosts + 1 Jenzabar -> ~55%, add 2nd transfer receiver (OTM/TAG); 8 custom colleges + 90% bar make full A a hard tail._
+
+## Diagnosis
+
+- **Primary gap:** Courses: only 9/22 colleges have data (41%). columbus-state (Colleague) and zane-state (Banner SSB) are already in scraper host maps but no data landed — need a re-run. belmont (jenzabar) is template-buildable. 8 remaining colleges are custom/unknown with no public endpoint; eastern-gateway is a closed college. Prereqs A, config A, transfers thin (1 university/OSU, 5348 mappings, wired).
+- **Cheapest lever** (wire-existing-scraper): Run the already-wired scrapers for columbus-state-community-college (Colleague host in scrape-colleague.ts) and zane-state-college (Banner SSB host in scrape-banner-ssb.ts) to land their course data — lifts coverage 41%→50% with zero new code.
+- **Effort:** medium — Two missing colleges (columbus-state, zane-state) are already declared in scripts/oh/scrape-colleague.ts and scrape-banner-ssb.ts host maps but produced no course files — a cheap re-run lands them. belmont-college needs adding to a jenzabar wrapper (template scripts/lib/scrape-jenzabar.ts exists). But the 8 custom/unknown colleges have no public endpoint and would each be a bespoke build, so reaching the 90% course bar is hard — the cheap wins only reach ~55%.
+- **Course colleges:** 3 buildable / 9 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: columbus-state and zane-state are listed in the host maps of scrape-colleague.ts / scrape-banner-ssb.ts but data/oh/courses/ has no dirs for them — scrapers wired, never landed. eastern-gateway-community-college closed in 2024 and has no fingerprint entry; exclude it from the gap count rather than chase. Transfers limiter = thin (only OSU receiver); Ohio has a statewide articulation system (OTM/TAG/Transferology) that could yield a 2nd receiver but no portal is wired. config + prereqs both A. No programs/ dir → planner cannot surface OH degree paths (GOLD-tier gap only).
+
+## Goal checklist
+
+### Ohio — current tier D (limited by courses, 41% coverage 9/22)
+
+- [ ] Re-run already-wired scrapers and land their data: `npx tsx scripts/oh/scrape-colleague.ts --college=columbus-state-community-college` and `npx tsx scripts/oh/scrape-banner-ssb.ts --college zane-state-college` — both hosts are already in the host maps but `data/oh/courses/` has no dirs for them. Lifts 41%→~50%.
+- [ ] Add belmont-college (jenzabar, courseSearchUrl mybelmont.belmontcollege.edu) to a new `scripts/oh/scrape-jenzabar.ts` wrapper around `scripts/lib/scrape-jenzabar.ts`; declare it in `StateConfig.scrapers.courses`. ~55%.
+- [ ] (Medium) Add a 2nd transfer receiver beyond OSU: investigate Ohio OTM/TAG/Transferology articulation; current `data/oh/transfer-universities.json` has only `osu`. Lifts transfers C→B.
+- [ ] (Hard tail, optional) 8 custom/unknown colleges (clark-state, marion-technical, lorain-county, edison-state, lakeland, northwest-state, owens, southern-state) have no public SIS endpoint per fingerprint-baseline.json — each needs bespoke investigation; 90% course bar is a documented ceiling without these. Mark eastern-gateway-community-college closed (no fingerprint, shut down 2024) and exclude from coverage denominator.
+- [ ] (GOLD) Build `data/oh/programs/` (none exist) with filenames matching `college_slug` in institutions.json so the degree-path planner can see OH.
+
+Definition of done: columbus-state, zane-state, belmont course data landed and imported (coverage ≥55%), scrapers cron-declared; eastern-gateway excluded as closed; remaining 8 custom colleges documented as a ceiling.

--- a/docs/state-goals/ok.md
+++ b/docs/state-goals/ok.md
@@ -1,0 +1,30 @@
+# Oklahoma (ok) — state goals
+
+> **Current tier: F** · Rank **#19 of 40** · Tranche: **NEXT** · Impact 3/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=F` `sc=A` `cfg=A`
+>
+> _Implement the OCEP/VITA transfer scraper (currently a stub) to flip composite off F; courses 7/13 needs ~4 template scrapers as a follow-on._
+
+## Diagnosis
+
+- **Primary gap:** transfers = F (0 mappings, 0 universities, OCEP scraper is a stub) is the composite limiter; courses at C (7/13, ~4 missing colleges are buildable via existing Jenzabar/PeopleSoft templates)
+- **Cheapest lever** (build-prereqs): Implement the OCEP/VITA articulation scraper (scripts/ok/scrape-transfer-ocep.ts) against vita.okhighered.org/CourseSearch — one scrape covers all 13 colleges × OK universities, flipping the composite limiter transfers F→ and declaring it in StateConfig.scrapers.transfers
+- **Effort:** medium — Two medium tracks, no cheap wins. Transfers needs the OCEP/VITA ASP.NET MVC scraper actually implemented (scripts/ok/scrape-transfer-ocep.ts is a console.log stub) — one investigation+scraper. Courses needs ~4 bespoke scrapers but templates already exist (Jenzabar for northern-oklahoma/seminole, PeopleSoft Community Access for rose-state). No regex/config/wire-only quick wins; config and prereqs already A.
+- **Course colleges:** 4 buildable / 2 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: leverCategory enum lacks "investigate-articulation"; chose build-prereqs as closest build-a-scraper bucket — actual work is building the OCEP transfer scraper. Missing 6 colleges: buildable=northern-oklahoma-college (Jenzabar template), seminole-state-college (Jenzabar), rose-state-college (PeopleSoft Community Access guest), northeastern-oklahoma-aandm-college (likely Colleague like sibling murray-state); blocked=eastern-oklahoma-state-college (manualOnly: no public guest course-search), college-of-the-muscogee-nation (tribal, no public DB). transfer-equiv.json is []. No programs dir. config/prereqs/scorecard all A.
+
+## Goal checklist
+
+### OK — current tier F (limited by transfers)
+
+- [ ] **Implement OCEP transfer scraper** (`scripts/ok/scrape-transfer-ocep.ts`, currently a stub). Target the VITA tool at `vita.okhighered.org/CourseSearch/` (ASP.NET MVC, jQuery — try plain HTTP POST against its form action before Playwright). Write to `data/ok/transfer-equiv.json` in the shape from `scripts/nc/scrape-transfer-cns.ts`. One scrape covers all 13 colleges × OK universities → flips composite limiter.
+- [ ] **Wire transfers to cron**: declare `transfers` in OK `StateConfig.scrapers` (`lib/states/ok/config.ts`) so `check:scrapers` passes and it runs scheduled.
+- [ ] **Build 4 missing course scrapers** (templates exist): northern-oklahoma-college + seminole-state-college via `scripts/lib/scrape-jenzabar.ts`; rose-state-college via PeopleSoft Community Access (`scripts/nv/scrape-peoplesoft.ts` pattern); northeastern-oklahoma-aandm-college (probe Colleague like sibling murray-state in `scripts/ok/scrape-colleague.ts`). Lifts courses 7/13 C → 11/13 (85%, ~B+).
+- [ ] **Document ceilings** for eastern-oklahoma-state-college (no public guest search) and college-of-the-muscogee-nation (tribal, no public DB) so they're excused from coverage %.
+- [ ] Verify in local dev: `/ok/transfer` shows an equivalency; `/ok` course search renders new colleges.
+
+Definition of done: transfers has real OCEP data + cron-wired (composite off F), courses ≥90% counting the 2 documented ceilings, all wired and verified in dev.

--- a/docs/state-goals/or.md
+++ b/docs/state-goals/or.md
@@ -1,0 +1,28 @@
+# Oregon (or) — state goals
+
+> **Current tier: C** · Rank **#37 of 40** · Tranche: **LATER** · Impact 4/5 · Effort: medium · Value/effort: **L**
+>
+> Dimensions: `crs=C` `prq=A` `trf=C` `sc=A` `cfg=A`
+>
+> _Courses a hard ceiling (all 8 missing SSO/staff-portal); document them, then the real mover is adding a 2nd transfer receiver (PSU/UO) for C->B._
+
+## Diagnosis
+
+- **Primary gap:** 8 of 17 colleges (47%) have no course data; all 8 are blocked (Clackamas Banner→Colleague SSO, Portland/mt-hood/rogue/umpqua auth-gated/unknown, southwestern+tillamook Jenzabar ICS staff portals, blue-mountain acalog catalog-only). Transfers thin at 1 university (OSU, 11,479 mappings). Prereqs/config/scorecard all A.
+- **Cheapest lever** (build-course-scrapers): Add a 2nd transfer receiver (e.g. Portland State University or University of Oregon articulation) to lift transfers C→B; courses is a documented hard ceiling.
+- **Effort:** medium — Course ceiling is hard (all 8 missing colleges are SSO/auth-gated/staff-portal — no public class-search endpoint; ~6 bespoke SSO scrapers needed for 90%). The realistic composite mover is transfers: lifting "thin: 1 university" to B needs ONE new articulation scraper for a 2nd receiver (Portland State or U of Oregon) — 1-4hr.
+- **Course colleges:** 0 buildable / 8 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: scripts/or/ already has banner-ssb, colleague, columbia-gorge, klamath, oregon-coast, tvcc scrapers (9 colleges covered) + scrape-transfer-osu.ts (16/17 CCs → OSU). Banner header explicitly excludes Clackamas: "fingerprinted as Banner SSB but redirects to Colleague SSO". Jenzabar courseSearchUrls (socc/tillamook) point to ICS staff directories, not class search. blue-mountain is acalog (catalog descriptions, not live sections). No data/or/programs/ dir. Transfer receiver = OSU only (transfer-universities.json). Missing-college course coverage is effectively a documented ceiling but not yet recorded in documentedCeilings — recording it would let courses be excused.
+
+## Goal checklist
+
+### Oregon (or) — current tier C (limited by courses; courses ceiling is hard, transfers is the mover)
+
+- [ ] **Document the course ceiling.** Add the 8 missing colleges to `documentedCeilings.courseColleges` with reasons: clackamas (Banner→Colleague SSO, per scrape-banner-ssb.ts header), portland/mt-hood/rogue/umpqua (auth-gated/unknown, no public class search), southwestern-oregon + tillamook-bay (Jenzabar ICS staff portal only), blue-mountain (acalog catalog, no live sections). This excuses courses and reframes composite. (cheap)
+- [ ] **Lift transfers C→B (highest composite lever):** build a 2nd receiver scraper in `scripts/or/` — Portland State University or University of Oregon articulation — modeled on `scrape-transfer-osu.ts`; add the university to `data/or/transfer-universities.json`, append to `data/or/transfer-equiv.json`, and declare it in `StateConfig.scrapers.transfers`. (medium, 1-4hr)
+- [ ] **(GOLD, optional)** Add programs via `scripts/lib/scrape-acalog-programs.ts` against blue-mountain acalog (catalog.bluecc.edu, catoid=13) + other CC catalogs; write `data/or/programs/<college_slug>.json` with filenames matching institutions.json college_slug so the planner sees them. (medium)
+
+Definition of done: course ceiling documented (courses excused), a 2nd transfer university wired + cron-declared (transfers ≥ B), composite lifts to B.

--- a/docs/state-goals/pa.md
+++ b/docs/state-goals/pa.md
@@ -1,0 +1,30 @@
+# Pennsylvania (pa) — state goals
+
+> **Current tier: C** · Rank **#16 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: hard · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+>
+> _Large state; 5 missing colleges all Workday/SAML/custom-blocked per scraper headers — record as ceilings so composite reads at true B+ (no buildable course wins)._
+
+## Diagnosis
+
+- **Primary gap:** 5 of 15 colleges have no course data (67% coverage); all 5 are SSO/auth-gated (Workday, Jenzabar JICS-behind-SAML, custom HTML) per scraper headers. Transfers/prereqs/scorecard/config all A.
+- **Cheapest lever** (documented-ceiling-accept): Formally record the 5 blocked colleges (bucks/butler/ccbc/pa-highlands/penn-college) as documented course ceilings so the composite reflects a true ceiling rather than a fixable C; courses are the only sub-A dimension and the remaining colleges are SSO/SAML-blocked.
+- **Effort:** hard — The 5 missing colleges run Workday (SSO), Jenzabar JICS behind SAML, or custom HTML with no public class-search endpoint — fingerprints confirm auth-gated/login-portal URLs (myworkday SSO, my.ccbc.edu/ICS, Net_Price_Calculator.jnz). Each needs bespoke authenticated scraping; no public guest endpoint to wire. PA already built every accessible-platform scraper.
+- **Course colleges:** 0 buildable / 5 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: Scraper headers (scripts/pa/scrape-banner-ssb.ts, scrape-colleague.ts, scrape-banner-8.ts) explicitly document the 5 missing colleges as Workday/Jenzabar-JICS-behind-SAML/custom — i.e. blocked. PA already ships Banner SSB, Banner 8, Colleague, bespoke Northampton + Westmoreland scrapers (10/15). Transfers strong (7 universities, 54529 mappings, wired, via Pitt TES + scrape-transfer). Prereqs 1351 entries clean. data/pa/programs/ is empty (0 files) — gold-tier gap only, not shippable-blocking.
+
+## Goal checklist
+
+### PA — current tier C (composite), shippable bar MET (B+ as documented ceiling)
+
+Only sub-A dimension is courses (67%, 10/15). The 5 missing colleges are genuinely blocked — confirmed by both data/state-health/fingerprint-baseline.json and the existing scrapers' own header comments.
+
+- [ ] Accept the course ceiling: add bucks, butler, ccbc, pa-highlands, penn-college to documentedCeilings.courseColleges (auditor config / lib/states/pa/config.ts) with reasons — Bucks=Workday SSO; CCBC & pa-highlands & penn-college=Jenzabar JICS behind SAML; Butler=custom HTML, no public search. This lifts the composite from C to its true ceiling without fake data.
+- [ ] (Optional, gold tier) Wire an Acalog program scraper — manualOnly notes "Acalog program scraper not yet wired up." data/pa/programs/ is empty (0 files). Adding programs aligned to institutions.json college_slug values enables the degree-path planner.
+- [ ] Do NOT attempt to scrape the 5 blocked colleges — no public guest endpoint; requires authenticated/SSO scraping (>half-day each, against project norms).
+
+Definition of done: 5 blocked colleges recorded as documented course ceilings so courses passes as a ceiling; transfers/prereqs/scorecard/config remain A. Programs is a separate gold-tier follow-up.

--- a/docs/state-goals/ri.md
+++ b/docs/state-goals/ri.md
@@ -1,0 +1,30 @@
+# Rhode Island (ri) — state goals
+
+> **Current tier: B** · Rank **#10 of 40** · Tranche: **NOW** · Impact 1/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=A` `prq=A` `trf=B` `sc=A` `cfg=A`
+>
+> _Single-college state, fully built; transfers B is a hard ceiling (both RI public unis mapped) — annotate ceiling + re-run, done._
+
+## Diagnosis
+
+- **Primary gap:** No real gap: CCRI (1/1 college) has full courses, prereqs (507), config A, programs aligned. Transfers graded B but already cover BOTH RI public universities (URI 795 + RIC 496 mappings) — there is no 3rd public receiver, so B is a hard ceiling.
+- **Cheapest lever** (documented-ceiling-accept): Annotate transfers B as a documented ceiling (both RI public universities URI+RIC already covered) so the composite isn't penalized, then rerun the scorecard.
+- **Effort:** cheap — Every shippable dimension already passes the B+ bar. The only sub-A dim (transfers) is a documented ceiling: RI has exactly two public 4-year schools (URI, RIC) and both are mapped. No scraper, config, or prereq work remains; at most a rerun/ceiling-annotation is left.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 1 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: CCRI is RI's only public community college, so collegeCount 1 is correct (not a coverage gap). Transfers cover all in-state public 4-year targets (URI + RIC = the entire RI public university system); B is a true ceiling, not unwired/thin. Programs present + filename aligned to college_slug ccri, prereqs present → planner fully ready. No buildable or blocked missing colleges. Cheapest lever is purely annotating the transfers ceiling + rerunning the scorecard.
+
+## Goal checklist
+
+### RI — current tier B (effectively finished; transfers ceiling)
+
+RI is single-college (CCRI). All dimensions pass the shippable bar; transfers B is a hard ceiling, not a gap.
+
+- [ ] Record transfers ceiling: RI has only two public 4-year institutions — University of Rhode Island (uri) and Rhode Island College (ric) — and `data/ri/transfer-equiv.json` already maps both (uri 795, ric 496; 1291 total). Add to `documentedCeilings.transfers` so the audit stops penalizing it.
+- [ ] Re-run `/state-audit ri` to confirm composite holds/lifts once the ceiling is applied.
+- [ ] (Optional, no action) Verify in local dev: `/ri` course search renders, `/ri/transfer` shows URI+RIC equivalencies, semester planner resolves a CCRI prereq chain, and CCRI programs (`data/ri/programs/ccri.json`, filename aligned to college_slug `ccri`) surface in the degree-path planner.
+
+Definition of done: transfers B documented as a ceiling (both RI public universities covered), scorecard re-run reflects it, and all four shippable dimensions (courses/prereqs/config/transfers-ceiling) plus aligned programs/planner remain green — no scraper or config work outstanding.

--- a/docs/state-goals/sd.md
+++ b/docs/state-goals/sd.md
@@ -1,0 +1,29 @@
+# South Dakota (sd) — state goals
+
+> **Current tier: D** · Rank **#33 of 40** · Tranche: **LATER** · Impact 1/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=D` `prq=B` `trf=C` `sc=A` `cfg=B`
+>
+> _seniorWaiver config fix + transform on-disk Mitchell coursedog dump + ceiling 3 PDF/no-catalog colleges; 2nd transfer receiver optional -> D->C/B._
+
+## Diagnosis
+
+- **Primary gap:** 4 of 6 colleges have no course data (coverage 33%); 1 (mitchell) is buildable from an on-disk Coursedog dump, the other 3 are PDF-only/no-public-catalog blocked. Transfers thin (1 university). Config missing seniorWaiver.
+- **Cheapest lever** (build-course-scrapers): Transform the on-disk Coursedog dump at data/sd/coursedog-catalog/mitchell-technical-college.json (740 courses) into data/sd/courses/mitchell-technical-college/ — no scraping needed, lifts coverage 2/6 to 3/6.
+- **Effort:** medium — Cheap wins exist (config seniorWaiver edit; transform the already-downloaded Mitchell Coursedog dump into courses). But hitting the 90% courses bar is structurally blocked — 3 of 4 missing colleges are PDF-only or have no public templated catalog. Adding a 2nd transfer receiver (SDBOR universities) is a medium scraper task. Net: medium.
+- **Course colleges:** 1 buildable / 3 blocked (of the missing set)
+- **Programs / planner:** 1 program files · aligned ✅ · planner-ready: partial
+- **Shippable (B+) bar met:** no
+
+> Notes: Mitchell Coursedog raw dump (384KB, 740-course list) already committed at data/sd/coursedog-catalog/mitchell-technical-college.json — buildable WITHOUT any web scrape; needs only a transform pass into the courses/ layout. Other 3 missing: lake-area (no public catalog), sisseton-wahpeton (no public catalog), western-dakota (PDF-only) — genuine ceilings, should be documented as such since 90% bar is unreachable. Programs filename already aligned to college_slug (southeast-technical-college). Transfers wired via USD calculator (public); SDBOR covers SDSU/SDSMT/BHSU/NSU/DSU for a 2nd receiver.
+
+## Goal checklist
+
+### SD — current tier D (limited by courses)
+
+- [ ] Set `seniorWaiver` in `lib/states/sd/config.ts` (currently `null`) — add the SD senior-citizen tuition-waiver citation (SDCL 13-53-19). config B→A. (cheap)
+- [ ] Write `scripts/sd/scrape-mitchell.ts` (or a transform) that reads the already-downloaded `data/sd/coursedog-catalog/mitchell-technical-college.json` (740-course list) and writes `data/sd/courses/mitchell-technical-college/`. No web scrape needed. Declare it in `StateConfig.scrapers`. Lifts course coverage 2/6→3/6. (cheap–medium)
+- [ ] Document ceilings for `lake-area-technical-college`, `sisseton-wahpeton-college` (no public templated catalog) and `western-dakota-technical-college` (PDF-only) in the audit `documentedCeilings.courseColleges` — the 90% bar is unreachable without these, so excuse them. (cheap)
+- [ ] (Optional, medium) Add a 2nd transfer receiver beyond USD: build an SDBOR transfer scraper covering SDSU/SDSMT/BHSU/NSU/DSU to move transfers C→B.
+
+Definition of done: seniorWaiver populated, Mitchell courses ingested + wired to cron, 3 blocked colleges recorded as documented ceilings so courses passes on the excused-coverage basis (3 of 3 non-ceiling colleges covered), transfers either accepted thin or lifted with a 2nd receiver.

--- a/docs/state-goals/tx.md
+++ b/docs/state-goals/tx.md
@@ -1,0 +1,31 @@
+# Texas (tx) — state goals
+
+> **Current tier: C** · Rank **#21 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=C` `prq=A` `trf=A` `sc=B` `cfg=A`
+>
+> _Largest state but courses 90% unreachable; re-run 3 wired colleges (galveston/southmost/north-central) then document the 19 SSO/custom as ceiling -> shippable B+._
+
+## Diagnosis
+
+- **Primary gap:** 22 of 59 colleges have no course data (63% coverage, grade C); transfers (43 univ / 187k mappings), prereqs (2511, clean), and config are all A. Most missing colleges are SSO/custom/catalog-only blocked — only 3 are already-wired-but-never-landed.
+- **Cheapest lever** (wire-existing-scraper): Re-run the 3 already-wired course scrapers (galveston/texas-southmost via scrape-colleague.ts, north-central-texas via scrape-jenzabar-webforms.ts) and verify/repair the host endpoints so their data actually lands — nudges coverage 63%→68% with zero new scaffolding.
+- **Effort:** medium — 3 missing colleges (galveston, texas-southmost, north-central-texas) are already in existing scraper HOSTS maps but never produced committed data — a verify/fix run, not net-new scaffolding (cheap, ~1hr). Beyond those, reaching the 90% courses bar is impossible: 4 are acalog/coursedog catalog-only (no live sections), 3 are jenzabar/colleague login-gated, and 12 are custom/unknown with no detected public endpoint — that's a documented ceiling, not a build task.
+- **Course colleges:** 3 buildable / 19 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: galveston-college + texas-southmost-college are in scripts/tx/scrape-colleague.ts HOSTS (added bulk in #550) but have no committed course file — never verified. north-central-texas-college is in scripts/tx/scrape-jenzabar-webforms.ts HOSTS (#708), also no data. These 3 are the only cheap course wins. austin-acc/hill/ranger are documented login-gated in scraper docstrings. brazosport/dallas/midland (acalog) + trinity-valley (coursedog) are catalog-only — no live section endpoint; trinity-valley already has a coursedog-catalog dump usable for prereqs only. Remaining 12 (grayson, san-jacinto, tyler-junior, angelina, central-texas, el-paso, lamar-state-orange, lee, southwest-texas-junior, western-texas, wharton-county, texas-state-technical) are custom/unknown with no public SIS detected. Even maxing every buildable college reaches only ~73% — courses is a documented structural ceiling, so composite C is near its realistic floor. shippableBarMet=true because transfers/prereqs/config pass and the courses shortfall is ceiling-bound, not a quality gap.
+
+## Goal checklist
+
+### TX — current tier C (limited by courses; transfers/prereqs/config all A)
+
+Course coverage is 37/59 (63%). The 90% bar is unreachable (16+ colleges are SSO/custom/catalog-only). Goal: capture the cheap already-wired colleges, then document the ceiling.
+
+- [ ] Re-run `npx tsx scripts/tx/scrape-colleague.ts --college=galveston-college` and `--college=texas-southmost-college` (hosts already in HOSTS map from #550). If endpoints 404/redirect-to-login, update the host in `scripts/tx/scrape-colleague.ts`; else commit the new `data/tx/courses/*` files. (+2 colleges)
+- [ ] Re-run `npx tsx scripts/tx/scrape-jenzabar-webforms.ts --college=north-central-texas-college` (host in HOSTS from #708); verify data lands or repair the portlet URL. (+1 college → 40/59, 68%)
+- [ ] For brazosport/dallas/midland (acalog) + trinity-valley (coursedog catalog-only): confirm no live section endpoint exists; if not, mark them documented course-ceiling colleges in the audit record rather than building.
+- [ ] Record the remaining 12 custom/unknown + 3 login-gated (austin-acc, hill, ranger) colleges as a documented course ceiling so composite isn't penalized as a gap.
+
+Definition of done: the 3 wired colleges either yield committed course data or are confirmed blocked, and the 19 unbuildable colleges are recorded as a documented courses ceiling — leaving TX shippable at B+ (transfers/prereqs/config A, courses ceiling-capped).

--- a/docs/state-goals/va.md
+++ b/docs/state-goals/va.md
@@ -1,0 +1,31 @@
+# Virginia (va) — state goals
+
+> **Current tier: D** · Rank **#1 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+>
+> Dimensions: `crs=A` `prq=A` `trf=D` `sc=A` `cfg=A`
+>
+> _Big state, all 5 dims A-grade data already on disk; D only because robust 8-univ/15,483-row transfer scrapers aren't declared in config — a one-edit cron wire flips D->A._
+
+## Diagnosis
+
+- **Primary gap:** Transfers (15,483 mappings across 8 in-state universities) exist but the scraper is not declared in StateConfig.scrapers, so the data will go stale. Courses (23/23 A), prereqs (374 entries A), config (A), scorecard (23/23 A), and programs (23 files, all aligned to college_slug) are all complete.
+- **Cheapest lever** (wire-existing-scraper): Declare the existing independent VA transfer scrapers in lib/states/va/config.ts StateConfig.scrapers.transfers so cron keeps the 8-university, 15,483-row dataset fresh.
+- **Effort:** cheap — The eight per-university transfer scrapers already exist in scripts/va/ (scrape-transfer-{uva,vcu,gmu,odu,umw,vsu,vwu}.ts) and read external university equivalency portals directly — they do NOT invoke the heavy 6h PeopleSoft course scrape they were lumped with. Wiring them is a config-only edit declaring StateConfig.scrapers.transfers, well under an hour.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 23 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** no
+
+> Notes: Transfer scrapers (scrape-transfer-uva/vcu/gmu/odu/umw/vsu/vwu.ts) hit external university transfer-credit analyzers (e.g. UVA AsEquivs server-rendered HTML), independent of the PeopleSoft course scrape. The config comment "transfers disabled alongside courses to avoid partial-refresh drift" applies the heavy-scrape rationale incorrectly — these are light and cron-safe. vt (Virginia Tech) is the 8th target despite no scrape-transfer-vt.ts visible; transfer-equiv has 1,412 vt rows, so a vt scraper or merge path exists. Verify each transfer scraper runs standalone before wiring; if scrape-transfer-vt source is the equiv.json merge, ensure cron covers it. Courses remain legitimately manual-only (6h PeopleSoft timeout).
+
+## Goal checklist
+
+### VA — current tier D (composite held down solely by unwired transfers)
+
+- [ ] Verify each transfer scraper runs standalone (no PeopleSoft dependency): `npx tsx scripts/va/scrape-transfer-uva.ts` (and vcu/gmu/odu/umw/vsu/vwu). They hit external univ equivalency portals, so should finish in minutes.
+- [ ] Confirm the vt (Virginia Tech) mapping source — 1,412 vt rows exist in data/va/transfer-equiv.json but no scrape-transfer-vt.ts is visible; locate its scraper/merge or note it as a static-merge target.
+- [ ] Declare transfers in `lib/states/va/config.ts` → `StateConfig.scrapers.transfers` (schedule + the 7-8 scraper entries), removing the inaccurate "disabled alongside courses" comment for transfers (keep courses manual-only).
+- [ ] Run `npm run check:scrapers` to confirm CI passes (no undeclared-scraper failure).
+- [ ] Local feature check: load `/va/transfer`, pick a sending CC + course, confirm an equivalency resolves for at least 2 of the 8 universities.
+- [ ] Build + open PR; post-merge, curl prod `/api/va/transfer` to confirm data ships.
+
+Definition of done: transfers dimension flips D→A (data already robust: 15,483 rows × 8 universities), scraper cron-wired and CI-green, composite rises to A (all five dims A, programs aligned, planner-ready).

--- a/docs/state-goals/vt.md
+++ b/docs/state-goals/vt.md
@@ -1,0 +1,31 @@
+# Vermont (vt) — state goals
+
+> **Current tier: C** · Rank **#24 of 40** · Tranche: **NEXT** · Impact 1/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=A` `prq=A` `trf=C` `sc=A` `cfg=A`
+>
+> _Single college, every dim A except transfers thin (UVM only); add VTSU as 2nd receiver or accept ceiling -> C->B, otherwise maxed._
+
+## Diagnosis
+
+- **Primary gap:** Transfers are thin: 346 real mappings but only to 1 receiver (UVM). Every other dimension is A — courses 1/1, prereqs 759 clean+wired, config full, scorecard 1/1, programs present and aligned. The single-college state (CCV) is otherwise complete.
+- **Cheapest lever** (investigate-articulation): Add Vermont State University (VTSU) as a 2nd transfer receiver for CCV — investigate VTSU's public articulation/transfer-credit source and add a scrape branch alongside the existing UVM Banner scraper in scripts/vt/scrape-transfer.ts.
+- **Effort:** medium — Composite C is driven solely by the "1 university" transfer thinness. Lifting it to B requires adding a 2nd in-state receiver (Vermont State University / VTSU), which means locating and building one new articulation scrape — a single-source investigation + scraper, not a config flip. All other dims already A.
+- **Course colleges:** 0 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 1 program files · aligned ✅ · planner-ready: yes
+- **Shippable (B+) bar met:** yes ✅
+
+> Notes: 1-college state (CCV). data/vt/programs/ccv.json has 41 programs; filename matches institutions.json college_slug "ccv" → planner sees it. transfer-equiv.json = 346 mappings, all university "uvm". transfer-universities.json lists only uvm. Existing scraper scripts/vt/scrape-transfer.ts pulls UVM's public Banner form at aisweb1.uvm.edu. No course gaps, no prereq contamination, no config placeholders, no documented ceilings. Per strict rubric transfers already passes (>=1 uni + non-trivial 346 mappings + cron-wired); the C is the audit's thinness nuance. Real-world ceiling note: VTSU is the only other VT public 4-year and may not publish a clean public articulation table — verify before committing.
+
+## Goal checklist
+
+### VT — current tier C (composite), all dims A except transfers (thin: 1 university)
+
+VT is a single-college state (CCV). Every dimension is A except transfers, which has 346 real mappings but to only 1 receiver (UVM). The composite is dragged to C by that thinness alone.
+
+- [ ] Confirm shippability: courses 1/1 (A), prereqs 759 clean+wired (A), config full (A), scorecard 1/1 (A), programs data/vt/programs/ccv.json (41 programs) aligned to institutions.json slug "ccv" → planner-ready. No course/prereq/config work needed.
+- [ ] (Composite C→B lever) Add a 2nd in-state receiver: investigate Vermont State University (VTSU — Castleton/NVU/Vermont Tech merger) for a public transfer-credit/articulation table. If found, add a scrapeVtsu branch in scripts/vt/scrape-transfer.ts mirroring the existing scrapeUvmBanner pattern, append university:"vtsu" mappings to data/vt/transfer-equiv.json, and add {slug:"vtsu",name:"Vermont State University"} to data/vt/transfer-universities.json.
+- [ ] If VTSU has no public articulation source, record a documented ceiling (transfers) and accept C — UVM is the flagship and 346 mappings is non-trivial.
+- [ ] Re-run state-audit vt to confirm new grade.
+
+Definition of done: either a 2nd in-state receiver (VTSU) is scraped+wired lifting transfers off "thin", or a documented transfers ceiling is recorded and VT accepted as shippable at its current A-everywhere-else state.

--- a/docs/state-goals/wa.md
+++ b/docs/state-goals/wa.md
@@ -1,0 +1,30 @@
+# Washington (wa) — state goals
+
+> **Current tier: F** · Rank **#25 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=B` `prq=F` `trf=C` `sc=B` `cfg=A`
+>
+> _Big state, F only from prereqs WAF-blocked; rework the committed scraper to Playwright real-Chrome to beat AWS WAF (or ceiling-accept) -> off F._
+
+## Diagnosis
+
+- **Primary gap:** Prereqs F is the sole composite limiter: scrape-catalog-prereqs.ts is committed+correct but all 11 acalog catalogs return AWS WAF bot challenges (HTTP 202 x-amzn-waf-action) on the plain fetch() it uses, so no data/wa/prereqs.json exists and ctcLink exposes no inline prereq text. Courses healthy (33/34), transfers wired but thin (UW only).
+- **Cheapest lever** (build-prereqs): Rework scripts/wa/scrape-catalog-prereqs.ts from fetch() to Playwright real-Chrome (stealth) to clear the AWS WAF challenge across the 11 acalog catalogs, producing data/wa/prereqs.json — lifts prereqs F→pass and the composite off F.
+- **Effort:** medium — The prereq scraper logic (catoid/navoid per catalog, prereq-block extraction, merge) is already written and committed; the only blocker is the headless fetch() tripping AWS WAF. Converting it to a Playwright/real-Chrome stealth pass to clear the challenge is a focused 1-4hr scraper job, not a from-scratch build. If WAF proves unbeatable, demote to cheap (record a documented prereqs ceiling so composite stops being F).
+- **Course colleges:** 0 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: The 1 missing course college, Northwest Indian College, is a tribal college outside SBCTC (not on ctcLink), served via a WordPress site — genuinely blocked and low-value; 33/34 = B is already at ceiling. Transfers are wired with 37,902 UW mappings (C, thin: 1 university); a cheap+ lever is adding a 2nd receiver (WSU/Western/Central/Evergreen) via the same wpId-table pattern in scrape-transfer-uw.ts to reach B. Prereqs WAF blocker is documented in lib/states/wa/config.ts but NOT recorded in audit documentedCeilings, so the audit treats it as a true F. Config A, scorecard B (33/34). No programs (Phase 5+ deferred), so plannerReady=no.
+
+## Goal checklist
+
+### WA — current tier F (limited by prereqs)
+
+- [ ] **Beat the WAF on prereqs (composite lever).** Convert `scripts/wa/scrape-catalog-prereqs.ts` from plain `fetch()` to a Playwright real-Chrome/stealth pass (the 11 acalog catalogs at bellevue/centralia/ghc/greenriver/highline/olympic/pierce/shoreline/skagit/nscc/sfcc return HTTP 202 `x-amzn-waf-action: challenge`). Extraction/catoid/navoid logic already exists — only the transport changes. Run it, commit `data/wa/prereqs.json`, flip `prereqs` in `lib/states/wa/config.ts` off `aggregate-from-courses` to the catalog scraper.
+- [ ] **If WAF is unbeatable, record the ceiling instead (cheap fallback).** Add prereqs to `documentedCeilings` so the composite stops being dragged to F by an accepted, documented blocker.
+- [ ] **Transfers C→B (optional, medium).** Add a 2nd university receiver (WSU / Western / Central / Evergreen) to `scripts/wa/scrape-transfer-uw.ts` using the existing `wpId`/`wpSlug` table pattern; declare in config scrapers.
+- [ ] **Leave Northwest Indian College as-is (blocked).** Tribal college outside SBCTC, WordPress-only, not on ctcLink — low value; 33/34 courses is the practical ceiling.
+- [ ] Programs are Phase 5+ — skip for B+ finish.
+
+**Definition of done:** `data/wa/prereqs.json` populated (or prereqs documented as a WAF ceiling), composite off F, courses/transfers/config/scorecard unchanged or improved.

--- a/docs/state-goals/wi.md
+++ b/docs/state-goals/wi.md
@@ -1,0 +1,31 @@
+# Wisconsin (wi) — state goals
+
+> **Current tier: F** · Rank **#40 of 40** · Tranche: **LATER** · Impact 4/5 · Effort: hard · Value/effort: **L**
+>
+> Dimensions: `crs=D` `prq=F` `trf=F` `sc=A` `cfg=A`
+>
+> _F from prereqs (cheap aggregate fix), but courses 25% with 12 WTCS singletons each on a distinct custom platform (0 clusters) = a ~12-scraper greenfield slog._
+
+## Diagnosis
+
+- **Primary gap:** 12 of 16 WTCS colleges have no course data (25% coverage, D); prereqs F (no file) and transfers F (no portal) compound it. Config + scorecard are A.
+- **Cheapest lever** (build-prereqs): Aggregate prereqs.json from on-disk data: parse prerequisite_text/prerequisite_courses already present in data/wi/coursedog-catalog/nicolet-area-technical-college.json + the 4 scraped course files; flips prereqs F (the composite limiter) without any scraping.
+- **Effort:** hard — The 12 missing colleges are WTCS singletons each on a distinct custom platform (Drupal, CMC Portal ASP.NET, PHP, Colleague cloud) — clusters.json found 0 clusters, so each needs its own bespoke scraper (>half-day for the set). Transfers need articulation from scratch (no WI portal). Only prereqs is cheap.
+- **Course colleges:** 12 buildable / 0 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: WTCS = 16 colleges, shared statewide course numbering. Built bespoke so far: CVTC (PHP coursesearch), Western (Colleague elluciancloud guest), NTC (Drupal faceted search), SWTC (CMC Portal). All 4 wired in config courses[]. No fingerprint-baseline entries for WI colleges (grep empty); clusters.json reports 0 clusters/15 singletons — no shared-endpoint shortcut, each remaining college is its own scraper. Course files carry prerequisite_text/prerequisite_courses fields but sampled values are null, so prereq yield may be thin; the Nicolet coursedog dump (467KB) is the richest prereq source and also seeds Nicolet's course data. Transfers: no documented ceiling set, but no articulation portal exists. Programs: 0 files, Phase 6 found no catalog platform.
+
+## Goal checklist
+
+### WI — current tier F (limited by prereqs)
+
+- [ ] Build `data/wi/prereqs.json`: extractor over existing on-disk data — `data/wi/coursedog-catalog/nicolet-area-technical-college.json` (`prerequisite_text`/`prerequisite_courses`) + the 4 scraped course dirs (`data/wi/courses/*/2026FA.json`). Flips prereqs F→D/C, the composite limiter. (cheap)
+- [ ] Wire prereqs: add a `prereqs` aggregator script to `lib/states/wi/config.ts scrapers` and remove the `// manual-only: prereqs` marker. (cheap)
+- [ ] Ingest Nicolet courses from the coursedog dump → `data/wi/courses/nicolet-area-technical-college/` (1 more college, no scrape). (cheap)
+- [ ] Build bespoke course scrapers for remaining WTCS colleges (each public, distinct platform): madison-area (madisoncollege.edu), fox-valley (fvtc.edu), gateway (gtc.edu), milwaukee-area (matc.edu), waukesha-county (wctc.edu), moraine-park, blackhawk, lakeshore, mid-state, northeast-wisconsin (nwtc.edu), northwood. Adapt scrape-ntc/swtc/cvtc templates; wire each in config. Target >=90% coverage. (hard, ~1 scraper each)
+- [ ] Transfers: no WI articulation portal — investigate UW System / WTCS articulation or document as a ceiling. (hard)
+- [ ] Programs: Phase 6 found no platform — defer or investigate WTCS program catalogs.
+
+Definition of done: >=90% of 16 colleges have course data, prereqs.json present+wired, transfers built-or-ceilinged, config/scorecard stay A.

--- a/docs/state-goals/wv.md
+++ b/docs/state-goals/wv.md
@@ -1,0 +1,32 @@
+# West Virginia (wv) — state goals
+
+> **Current tier: D** · Rank **#36 of 40** · Tranche: **LATER** · Impact 2/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=D` `prq=A` `trf=C` `sc=A` `cfg=A`
+>
+> _Document 5 SSO/SAML/WAF colleges as ceilings + build 1 Colleague guest scraper (southern) -> 4/4 reachable covered, composite D->B._
+
+## Diagnosis
+
+- **Primary gap:** 6 of 9 colleges have no course data; 5 are SSO/CAPTCHA/SAML-blocked, only southern (Colleague guest) is buildable. Transfers thin (1 university). Prereqs/config/scorecard all A.
+- **Cheapest lever** (documented-ceiling-accept): Document the 5 blocked colleges (newriver, pierpont, bridgevalley, wvncc, blueridge) as courseColleges ceilings, then re-run audit so courses coverage is excused (3-of-4 reachable = passing).
+- **Effort:** medium — Courses is a near-hard ceiling: 5 of 6 missing colleges are blocked (newriver CAPTCHA/WAF, pierpont+bridgevalley Ellucian Experience SSO, wvncc Pathify SAML, blueridge JS-WP unknown). Only southern has a public Colleague Self-Service guest endpoint (/Student/Courses/Search) — one bespoke scraper (~2hr; eastern's HTML scraper is not reusable as a template). Even built, coverage hits only 4/9 (44%), so the real lever is documenting the 5 blocked colleges as ceilings to excuse them. Transfers 2nd-receiver is medium. No single cheap fix clears the bar.
+- **Course colleges:** 1 buildable / 5 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: manualOnly reasons (probe-time truth) override the structural fingerprint: pierpont fingerprints banner-8/ords and southern fingerprints colleague-guest, but pierpont was found behind Ellucian Experience SSO. southern's /Student/Courses/Search is the standard Colleague guest endpoint and is the ONE buildable target. eastern's scraper (scrape-eastern-wv.ts) scrapes an HTML class-schedules page, NOT Colleague Self-Service — so it is not a reusable template for southern; southern needs a fresh Colleague SS scraper. Transfers wired to Marshall only (1604 mappings, scrape-transfer-marshall.ts); WVU is the obvious 2nd in-state receiver. documentedCeilings.courseColleges is currently empty — populating it is the unlock for the composite grade.
+
+## Goal checklist
+
+### WV — current tier D (limited by courses)
+
+Reachable ceiling is B (courses excused). Programs/planner unreachable extra (no public program source surfaced).
+
+- [ ] Confirm prereqs (A, 1602 entries) + config (A) + scorecard (A) need no work — they don't.
+- [ ] Document 5 blocked course colleges as ceilings: add `newriver` (Banner SSB sgcaptcha WAF), `pierpont` + `bridgevalley` (Ellucian Experience SSO), `wvncc` (Pathify SAML), `blueridge` (JS-WP, source unknown) to `documentedCeilings.courseColleges` so audit excuses them. (~30 min)
+- [ ] Build `scripts/wv/scrape-southern.ts` against the public Colleague Self-Service guest endpoint `https://southernwv.edu/Student/Courses/Search` (do NOT copy scrape-eastern-wv.ts — that scrapes an HTML schedule page, not Colleague SS). Wire into `StateConfig.scrapers.courses`. Lifts coverage 3/9→4/9 = all reachable colleges covered. (~2 hr)
+- [ ] Re-run state-audit; courses should clear to B+ (4/4 reachable).
+- [ ] (Optional, medium) Add a 2nd transfer receiver — scrape WVU articulation alongside existing Marshall, lifting transfers C→B.
+
+Definition of done: courses passes via 4/4 reachable colleges covered + 5 documented ceilings; prereqs/config/scorecard remain A; composite ≥ B.

--- a/docs/state-goals/wy.md
+++ b/docs/state-goals/wy.md
@@ -1,0 +1,30 @@
+# Wyoming (wy) — state goals
+
+> **Current tier: F** · Rank **#22 of 40** · Tranche: **NEXT** · Impact 1/5 · Effort: medium · Value/effort: **M**
+>
+> Dimensions: `crs=B` `prq=A` `trf=F` `sc=A` `cfg=A`
+>
+> _F is empty transfers; investigate WCCC matrix or accept no-portal ceiling (cheap) + record central-wyoming SAML course ceiling -> composite B._
+
+## Diagnosis
+
+- **Primary gap:** Composite F driven entirely by transfers: 0 mappings, 0 in-state university targets, no articulation portal registered. Courses/prereqs/config/scorecard are all A/B and healthy.
+- **Cheapest lever** (investigate-articulation): Investigate Wyoming's statewide articulation source (WCCC transfer matrix to UW), register it in data/articulation-portals.json, scrape/import in-state mappings, and declare scrapers.transfers in lib/states/wy/config.ts — moves transfers F→passing and lifts composite off F.
+- **Effort:** medium — The only F dimension (transfers) has no registered portal and no documented ceiling — it needs a 1-4hr investigation to find Wyoming's articulation source (statewide WCCC transfer matrix / WyoTransfer-style guide) and a scraper or static-import, then wire it. Everything else is already done or a hard blocker.
+- **Course colleges:** 0 buildable / 1 blocked (of the missing set)
+- **Programs / planner:** 0 program files · no programs · planner-ready: no
+- **Shippable (B+) bar met:** no
+
+> Notes: central-wyoming-college (the only course gap) is a genuine documented blocker: Colleague host central-ss.colleague.elluciancloud.com is 100% SAML-SSO-gated (tenant central.edu), course-search behind Cloudflare WAF, schedule only in Google Docs — marked DEFERRED-scrapers in config. Courses sit at 86% (6/7) and cannot realistically reach 90%; recommend recording central-wyoming-college as a documented courseColleges ceiling so 86% is excused. Transfers is the true F: WY has no entry in data/articulation-portals.json. If transfers can be accepted as a documented ceiling (no statewide machine-readable matrix found), the state would be B-shippable immediately via a one-line config flag + audit ceiling.
+
+## Goal checklist
+
+### WY — current tier F (limited by transfers)
+
+- [ ] Record course ceiling: add `central-wyoming-college` to WY's documentedCeilings.courseColleges (SAML-SSO + Cloudflare WAF, schedule only in Google Docs — see DEFERRED-scrapers note in `lib/states/wy/config.ts`). Excuses the 86% (6/7) coverage so courses passes at ceiling. (cheap)
+- [ ] Investigate Wyoming articulation: confirm whether WCCC publishes a machine-readable CC→University of Wyoming transfer matrix (WyoTransfer / UW transfer guides). No portal is in `data/articulation-portals.json` today. (medium)
+- [ ] If a source exists: register it in `data/articulation-portals.json`, write `scripts/wy/scrape-transfers.ts`, populate `data/wy/transfer-equiv.json` (in-state only, UW as receiver), then declare `scrapers.transfers` in `lib/states/wy/config.ts` and verify `/wy/transfer` renders an equivalency. (medium)
+- [ ] If NO machine-readable source exists: set transfers as a documented ceiling (`documentedCeilings.transfers=true`) with rationale — this alone lifts composite off F to B. (cheap)
+- [ ] (GOLD, optional) Fix `scripts/wy/scrape-programs.ts` catalog base URLs (currently western.edu/eastern.edu/northern.edu look wrong vs WY domains), run it, confirm `data/wy/programs/*.json` filenames match institutions.json college_slug values for planner visibility. (medium)
+
+Definition of done: transfers either populated+wired OR a recorded documented ceiling, central-wyoming-college recorded as course ceiling → composite ≥ B, no placeholder data.


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this adds a planning directory (`docs/state-goals/`) for the team, not a site feature. It's the map for *which* states to push to the finish line next, so the user-facing payoff comes later as those states get completed.

## What this is

An end-to-end data-maturity assessment of **all 51 registry states (50 + DC)**, turned into an actionable, ranked backlog.

- **Grades** come from the canonical `/state-audit` collector (`.claude/skills/state-audit/scripts/collect-audit-data.ts`), so they respect `documentedCeilings` and match the project's own rubric. Current standing: **11 A · 7 B · 17 C · 6 D · 10 F**.
- **Effort, cheapest lever, and programs/planner status** for each of the 40 unfinished states came from a 40-agent diagnosis workflow that read each state's config, scrapers, fingerprint baseline, and programs dir.
- **Ranking** is by impact ÷ effort (student reach vs. distance-from-bar), bucketed into now / next / later tranches.

## Files

| File | What's in it |
|---|---|
| `README.md` | Tier distribution · the single biggest lever (with an honest *re-grading* caveat) · 4 secondary levers · fastest-path summary · full impact÷effort ranking table · now/next/later checkbox tracker |
| `{slug}.md` × 40 | Per-state diagnosis (primary gap, cheapest lever, effort, programs/planner) + a **pasteable, cold-startable goal checklist** with a Definition of Done |
| `_audit-snapshot.json` | Raw canonical audit output, so grades are reproducible/diffable on the next run |

## Headline findings

- **Biggest single lever is a re-grading move, not a data move** (flagged honestly in the README): ~12 states sit below their true tier only because genuine structural ceilings (tribal colleges with no public SIS, SSO/Workday-gated registration, complete-but-thin transfers) aren't recorded in `documentedCeilings`. Recording them is a one-PR metadata batch that moves ~8 states.
- **The real data wins are cheap and concrete:** VA is a D→A from a one-line transfer-cron wire (data already on disk); ~9 states have wired-but-empty course scrapers that just need a re-run/host-fix; MS has 252 programs orphaned by a squash-merge race (#964) that need a filename realign; NC/WA have one-shot prereq fixes.
- **The hard tail (~6 states):** wi, il, ma, ia, ks — mostly SSO-blocked colleges where the 90% bar is structurally out of reach; right move is ship at B/B+ and ceiling-document the rest.

## How to use

Open `docs/state-goals/{slug}.md` for any unfinished state and paste its **Goal checklist** into a fresh session — each is self-contained. Tick states off the README tracker as they land. Re-run the collector to regenerate the snapshot and re-grade.

## Test plan
- [x] Docs/JSON only — no code, data, or scraper changes (`git show --stat`: 42 files, all under `docs/state-goals/`).
- [x] Grades sourced from the canonical collector (not hand-derived).
- [x] All 40 unfinished states have a goal file; 11 A-states listed as done.