### PR TITLE
va: wire 8 transfer scrapers to cron (transfers D→A)

### DIFF
--- a/docs/state-goals/README.md
+++ b/docs/state-goals/README.md
@@ -92,7 +92,7 @@ The fastest realistic path is to front-load two near-zero-cost batches before an
 ## Progress tracker
 
 ### NOW — cheap, high-impact (do first)
-- [ ] **va** (D) — Virginia: Big state, all 5 dims A-grade data already on disk; D only because robust 8-univ/15,483-row transfer scrapers aren't declared in config — a one-edit cron wire flips D->A.
+- [x] **va** (D→**A**) — Virginia: ✅ DONE — wired the 8 external-portal transfer scrapers into `StateConfig.scrapers.transfers`; transfers D→A, composite **A**.
 - [ ] **md** (C) — Maryland: All dims A except courses 81%; the 3 missing colleges (ccbc/cecil/garrett) already have wired scrapers that just need a re-run -> 16/16, no new code.
 - [ ] **nc** (C) — North Carolina: Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A.
 - [ ] **az** (C) — Arizona: Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A.

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -62,7 +62,28 @@ const vaConfig: StateConfig = {
   ],
   scrapers: {
     // manual-only: courses — VA PeopleSoft scraper consistently exceeds the 6h GitHub Actions timeout; run manually when needed.
-    // manual-only: transfers — disabled alongside courses to avoid partial-refresh drift.
+    // Transfers are SAFE on cron despite courses being manual-only. The eight
+    // scrapers below hit external university transfer-equivalency portals
+    // (GMU/ODU/UMW/UVA/VCU/VSU/VWU public HTML/JSON endpoints + Virginia Tech's
+    // published VCCS-equivalency page) — none invoke the heavy PeopleSoft course
+    // scrape they were previously (incorrectly) disabled alongside. They run
+    // sequentially in one job because each loads data/va/transfer-equiv.json,
+    // merges its own university's rows, and writes the file back.
+    transfers: [
+      {
+        scripts: [
+          "scripts/va/scrape-transfer-equiv.ts", // Virginia Tech (vt)
+          "scripts/va/scrape-transfer-gmu.ts",
+          "scripts/va/scrape-transfer-odu.ts",
+          "scripts/va/scrape-transfer-umw.ts",
+          "scripts/va/scrape-transfer-uva.ts",
+          "scripts/va/scrape-transfer-vcu.ts",
+          "scripts/va/scrape-transfer-vsu.ts",
+          "scripts/va/scrape-transfer-vwu.ts",
+        ],
+        runner: "http",
+      },
+    ],
     // Prereqs aggregate from committed course-section prerequisite_text
     // (data/va/prereqs.json, 302 parsed chains; 4,227 sections carry prereq
     // text). This reads already-committed data — it does NOT run the heavy


### PR DESCRIPTION
## What changes for someone using the site

No immediate visible change — Virginia's transfer page already shows this data. What changes is that VA's **8-university transfer dataset stops going stale**: until now nothing kept it fresh, so over time the equivalencies on `/va/transfer` would drift out of date as the universities updated their catalogs. After this, the scheduled scraper refreshes all 8 on cron, so a student comparing a VCCS course against UVA/GMU/ODU/VCU/Virginia Tech/UMW/VSU/VWU keeps seeing current mappings.

## What changes on the technical front

VA had 15,483 transfer mappings across 8 in-state universities already committed to `data/va/transfer-equiv.json`, but `lib/states/va/config.ts` never declared the scrapers in `StateConfig.scrapers.transfers`. The scheduled-scrape workflow builds its matrix from that field (architectural invariant #5), so the data was frozen — and the `/state-audit` collector correctly graded transfers **D** ("data exists but scraper not wired — will go stale"), holding VA's composite at D despite every other dimension being A.

The fix is a **config-only edit**: declare the 8 existing scrapers as one sequential `http` job.

- The previous `// manual-only: transfers — disabled alongside courses` comment was **inaccurate**. Those 8 scrapers hit external university portals (GMU/ODU/UMW/UVA/VCU/VSU/VWU public HTML/JSON endpoints + Virginia Tech's published VCCS-equivalency page) — they do **not** invoke the heavy 6h PeopleSoft course scrape that genuinely is manual-only. They were wrongly lumped with it.
- One job, run sequentially, because each scraper loads → merges its university's rows → writes `data/va/transfer-equiv.json`.
- Virginia Tech's 1,412 rows come from `scrape-transfer-equiv.ts` (confirmed).

**Verification:**
- Smoke-tested `scrape-transfer-vcu.ts` and `scrape-transfer-vsu.ts` standalone → exit 0, correct merges, zero PeopleSoft dependency. (Data file restored afterward so this PR stays config-only; the first cron run does the full coordinated 8-scraper refresh.)
- `npm run check:scrapers` → passes (51 states × 4 datatypes accounted for).
- Registry reads the block: 8 scripts, `runner: http`, no `termSystem` (correct — transfers have no term semantics).
- Re-ran the audit collector on this branch: **transfers D→A** ("8 universities, 15483 mappings, wired"), **composite D→A** — VA now all five dimensions A.

Courses and programs stay `manual-only` (PeopleSoft 6h timeout is unchanged and unrelated).

## Test plan
- [x] `check:scrapers` passes
- [x] Registry parses transfers block (8 http scripts, no termSystem)
- [x] Two scrapers smoke-tested standalone (no PeopleSoft dependency)
- [x] Audit re-grade: transfers D→A, composite D→A
- [x] No data-file changes (config + tracker only)