### PR TITLE
nc: strip <br> HTML from 8 prereq entries (prereqs C→A)

### DIFF
--- a/data/nc/prereqs.json
+++ b/data/nc/prereqs.json
@@ -2616,7 +2616,7 @@
     "courses": []
   },
   "BTB 103": {
-    "text": "Take BTB-102 - Must be taken either prior to or at the same time as this course.,<br>Take BTB-101 - Must be completed prior to taking this course.",
+    "text": "Take BTB-102 - Must be taken either prior to or at the same time as this course. Take BTB-101 - Must be completed prior to taking this course.",
     "courses": []
   },
   "BTB 106": {
@@ -6435,7 +6435,7 @@
     ]
   },
   "EDU 234A": {
-    "text": "Take EDU-119 - Must be completed prior to taking this course.,<br>Take EDU-234 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take EDU-119 - Must be completed prior to taking this course. Take EDU-234 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "EDU 235": {
@@ -11643,7 +11643,7 @@
     ]
   },
   "MRN 121": {
-    "text": "Take TRN-110 - Must be completed prior to taking this course.,<br>Take HET-110 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take TRN-110 - Must be completed prior to taking this course. Take HET-110 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "MRN 121BB": {
@@ -11690,7 +11690,7 @@
     "courses": []
   },
   "MSC 256": {
-    "text": "Take NET-125 MSC-152 - Must be completed prior to taking this course.,<br>Take MSC-254 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take NET-125 MSC-152 - Must be completed prior to taking this course. Take MSC-254 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "MSP 115": {
@@ -14019,7 +14019,7 @@
     ]
   },
   "PHM 120": {
-    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course.,<br>Take PHM-118 PHM-136 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course. Take PHM-118 PHM-136 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "PHM 125": {
@@ -14054,7 +14054,7 @@
     ]
   },
   "PHM 136": {
-    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course.,<br>Take PHM-118 PHM-120 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course. Take PHM-118 PHM-120 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "PHM 140": {
@@ -17318,7 +17318,7 @@
     ]
   },
   "VET 220": {
-    "text": "Take VET-132 - Must be completed prior to taking this course.,<br>Take VET-213 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take VET-132 - Must be completed prior to taking this course. Take VET-213 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "VET 237": {
@@ -17786,7 +17786,7 @@
     ]
   },
   "WBL 115U": {
-    "text": "Take HSE-110 SAB-110 HSE-112 HSE-123 HSE-125 SAB-120 - Must be completed prior to taking this course.,<br>Take WBL-111U SAB-135 SAB-240 - Must be taken either prior to or at the same time as this course.,<br>Take One: WBL-111, WBL-112, WBL-113 or WBL-114 - Must be taken either prior to or at the same time as this course.",
+    "text": "Take HSE-110 SAB-110 HSE-112 HSE-123 HSE-125 SAB-120 - Must be completed prior to taking this course. Take WBL-111U SAB-135 SAB-240 - Must be taken either prior to or at the same time as this course. Take One: WBL-111, WBL-112, WBL-113 or WBL-114 - Must be taken either prior to or at the same time as this course.",
     "courses": []
   },
   "WBL 115V": {

--- a/docs/state-goals/README.md
+++ b/docs/state-goals/README.md
@@ -94,7 +94,7 @@ The fastest realistic path is to front-load two near-zero-cost batches before an
 ### NOW — cheap, high-impact (do first)
 - [ ] **va** (D) — Virginia: Big state, all 5 dims A-grade data already on disk; D only because robust 8-univ/15,483-row transfer scrapers aren't declared in config — a one-edit cron wire flips D->A.
 - [ ] **md** (C) — Maryland: All dims A except courses 81%; the 3 missing colleges (ccbc/cecil/garrett) already have wired scrapers that just need a re-run -> 16/16, no new code.
-- [ ] **nc** (C) — North Carolina: Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A.
+- [x] **nc** (C→**B**) — North Carolina: Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A.
 - [ ] **az** (C) — Arizona: Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A.
 - [ ] **ak** (F) — Alaska: Single tribal college; F only because no-portal transfers isn't recorded as a ceiling — a metadata edit flips F->B+/A with everything else already A/B.
 - [ ] **la** (B) — Louisiana: Everything built/wired incl 5 aligned programs; record northshore (LoLA SSO) as a courses ceiling and 92% becomes A -> composite A.


### PR DESCRIPTION
## What changes for someone using the site

On North Carolina course pages and the semester planner, eight courses' prerequisite notes had a raw HTML `<br>` tag showing up as literal text in the middle of the sentence. After this, those notes read as clean prose — e.g. BTB 103 now shows *"Take BTB-102 - Must be taken either prior to or at the same time as this course. Take BTB-101 - Must be completed prior to taking this course."* instead of the same text with a stray `,<br>` wedged in. Eight courses affected: BTB 103, EDU 234A, MRN 121, MSC 256, PHM 120, PHM 136, VET 220, WBL 115U.

## What changes on the technical front

The `/state-audit` collector graded NC prereqs **C** ("8 entries have HTML contamination") — the only thing holding NC's composite at C while every other dimension was already strong. The contamination was a literal `<br>` tag in the `text` field of 8 entries in `data/nc/prereqs.json`. Those 8 are otherwise identical in shape to the *hundreds* of clean verbose `"Take XXX-### - Must be completed..."` entries that already pass the audit — the `<br>` was the sole difference.

Fix: replace the `,<br>` clause-joiner with a space and collapse whitespace. Minimal and surgical — **exactly 8 entries change (8 insertions / 8 deletions)**, no whole-file reformat, and zero HTML tags remain anywhere in the file afterward. `courses: []` is left as-is on these entries to match the existing convention for the verbose `"Take..."` format (those entries project-wide carry empty `courses[]`; re-extracting codes for that format is a separate, broader improvement, intentionally not bundled here).

**Result:** prereqs **C→A** ("2367 entries, wired, clean"), composite **C→B**.

### Why B and not A (known, separate)
NC's composite is now capped by courses=B: one "suspicious term", `2026U1`. That's a **false positive** — it's Wilson Community College's legitimate summer-session-1 term with **157 real sections** (Wilson runs `2026FA` + `2026U1`, no `2026SU`). The audit's `isSuspicious` regex `^\d{4}(FA|SP|SU)$` simply doesn't allow U-series summer sub-sessions. Fixing that is a change to the shared audit collector (impacts other states' grading + requires updating `grade-snapshot.test.ts`), so it's tracked as a separate follow-up rather than smuggled into this NC data PR.

## Test plan
- [x] Exactly 8 entries changed (diff: 8 ins / 8 del, one file)
- [x] Zero HTML tags remain in `data/nc/prereqs.json` after the pass
- [x] Re-ran the audit collector: prereqs C→A, composite C→B
- [x] No `courses[]` values altered (text-only change)