### PR TITLE
fl: record fscj + pensacolastate as documented course ceilings

### DIFF
--- a/lib/states/fl/config.ts
+++ b/lib/states/fl/config.ts
@@ -208,6 +208,27 @@ const flConfig: StateConfig = {
       },
     ],
   },
+  // Two FCS colleges have no public section data and cannot be scraped — both
+  // investigated 2026-06 (see the not-scrapable notes in scrapers.courses).
+  // They are excused from the course-coverage denominator so the audit reflects
+  // the reachable system, not an unreachable one. FSCJ's Coursedog catalog still
+  // contributes course-level prereqs via the aggregator; it just never yields
+  // sections, so it is not surfaced as course coverage (no fake/section-less
+  // listings — invariant #4).
+  documentedCeilings: {
+    courses: [
+      {
+        collegeSlug: "fscj",
+        reason:
+          "FSCJ runs PeopleSoft Campus Solutions at csprd.fscj.edu with no guest realm provisioned (csprdguest/FSCJGUEST both return a 'Site name is not valid' body; COMMUNITY_ACCESS.CLASS_SEARCH.GBL on the main realm redirects to login). No Banner or alternate SIS subdomain and no PDF schedule exist. The public Coursedog catalog (scripts/fl/scrape-coursedog.ts) yields course descriptions + prereqs but never sections. Verified 2026-06.",
+      },
+      {
+        collegeSlug: "pensacolastate",
+        reason:
+          "Pensacola State migrated to Workday Student (wd501.myworkday.com/pensacolastate); Workday Student has no public guest class-search by design. The pensacolastate.edu/course-search/ WordPress form POSTs to a JS widget that calls Workday client-side and returns nothing without auth. No Banner/Colleague endpoint exists anywhere on pensacolastate.edu. Verified 2026-06.",
+      },
+    ],
+  },
 };
 
 export default flConfig;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible. This is a data-accuracy fix to internal config: it records that two Florida colleges (FSCJ and Pensacola State) genuinely have no public class schedule we can show, so the project's audit stops treating them as "missing work" when they're actually "can't be reached." Students still see no FSCJ/Pensacola sections — that hasn't changed — but the catalog descriptions we *do* have for FSCJ keep feeding the prerequisite data.

## What changes on the technical front

FSCJ and Pensacola State were already documented as `not-scrapable` in **prose comments** inside `lib/states/fl/config.ts` (`scrapers.courses`), with full investigation notes:
- **FSCJ** — PeopleSoft Campus Solutions at `csprd.fscj.edu`, no guest realm provisioned (`csprdguest`/`FSCJGUEST` both 404; `COMMUNITY_ACCESS.CLASS_SEARCH.GBL` redirects to login). Only the public Coursedog catalog is reachable — course descriptions + prereqs, never sections.
- **Pensacola State** — migrated to Workday Student (`wd501.myworkday.com/pensacolastate`), which has no public guest class-search by design.

This PR promotes those prose notes into the **structured `documentedCeilings.courses` field** the audit collector actually reads. FSCJ's Coursedog catalog continues to contribute course-level prereqs via the aggregator; it is deliberately **not** surfaced as course coverage, because it has no sections and fabricating section-less listings would violate invariant #4 (no fake student data).

### ⚠️ This does NOT flip FL's grade yet — and it exposes a collector bug
I expected this to take FL courses C/B→A. It doesn't, because `gradeCourses()` in `.claude/skills/state-audit/scripts/collect-audit-data.ts` has a bug: for a ceiling college that's in `missingColleges` (the normal case), it subtracts that college from **both** the numerator and denominator:

```js
adjustedCovered = coveredColleges - missingColleges.filter(isExempt).length  // wrongly drops a college that was never in `covered`
adjustedTotal   = collegeCount - ceilingColleges.length
```

So documenting a genuine ceiling **lowers** coverage instead of excusing it:
- **fl**: 26/28 = 93% → 24/26 = 92% (still B, slightly worse)
- **ar** (already has 2 documented ceilings): graded **C** at 10/12 = 83%, when its data warrants **A** at 12/12 = 100%

The correct formula removes ceiling colleges entirely (denominator only): `covered / (total − exempt)` → fl 26/26 = 100% = A. **That fix is a separate PR** (it's a shared-tool change touching ar/az/fl grades + the snapshot test). Once it lands, FL reads A with no further change here. This config PR is the prerequisite.

## Test plan
- [x] Registry parses `fl.documentedCeilings.courses` → `fscj, pensacolastate`
- [x] No data files touched; FSCJ catalog still feeds prereqs aggregator
- [x] Honest about the grade: stays B pending the separate collector-formula fix