### PR TITLE
la: document Northshore Technical CC course ceiling → B to A

### DIFF
--- a/docs/state-goals/README.md
+++ b/docs/state-goals/README.md
@@ -97,7 +97,7 @@ The fastest realistic path is to front-load two near-zero-cost batches before an
 - [x] **nc** (C→**B**) — North Carolina: Huge state one regex pass from B+: 8 prereq entries have raw <br> + empty courses[]; strip and re-extract -> prereqs C->A, courses/transfers already A.
 - [ ] **az** (C) — Arizona: Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A.
 - [ ] **ak** (F) — Alaska: Single tribal college; F only because no-portal transfers isn't recorded as a ceiling — a metadata edit flips F->B+/A with everything else already A/B.
-- [ ] **la** (B) — Louisiana: Everything built/wired incl 5 aligned programs; record northshore (LoLA SSO) as a courses ceiling and 92% becomes A -> composite A.
+- [x] **la** (B→**A**) — Louisiana: ✅ documented Northshore Technical CC course ceiling (LoLA SSO, no public sections) → courses 11/11, composite A
 - [ ] **mn** (B) — Minnesota: 26/28 courses, all else A, planner-ready; document the 2 independent tribal colleges as ceilings -> courses A, composite A. No scraping.
 - [ ] **mt** (C) — Montana: All dims A except courses 60%; the 4 missing are tribal/auth-gated ceilings — recording them lifts courses 60%->effective 100%, composite C->A.
 - [ ] **ms** (F) — Mississippi: Re-land orphaned #964 (252 programs, pure rename) for an instant planner GOLD win; courses 7% is a separate medium slog, so do the cheap data fix now.

--- a/lib/states/la/config.ts
+++ b/lib/states/la/config.ts
@@ -80,6 +80,21 @@ const laConfig: StateConfig = {
       { scripts: ["scripts/la/scrape-programs.ts"], runner: "http" },
     ],
   },
+  // Northshore Technical CC (12th LCTCS college) has no public section data:
+  // it's the one LCTCS member not on the shared Banner SSB host, and its
+  // sections sit behind LoLA SSO. The Coursedog catalog (already scraped) gives
+  // course metadata + prereqs via the aggregator, but never sections — so it's
+  // not surfaced as course coverage (no fake/section-less listings — invariant
+  // #4). Recorded as a ceiling so the audit excuses it from the denominator.
+  documentedCeilings: {
+    courses: [
+      {
+        collegeSlug: "northshore-technical-community-college",
+        reason:
+          "Northshore Technical CC is the only LCTCS college not on the shared Banner SSB host (reg-prod.ec.lctcs.edu); its sections sit behind LoLA SSO with no public guest class search. Only the Coursedog catalog is reachable (course metadata + 23 prereqs, fed to the aggregator) — never sections. Verified 2026-06.",
+      },
+    ],
+  },
 };
 
 export default laConfig;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible. Northshore Technical Community College (one of Louisiana's 12 LCTCS colleges) doesn't publish its class schedule publicly — registration is behind the LoLA single sign-on. So its sections aren't on the site and can't be. This change just stops the audit from counting Northshore as "missing work" when it's actually unreachable; the other 11 LCTCS colleges are unaffected.

## What changes on the technical front

LA courses graded **B** (11/12 = 92%). The gap is Northshore Technical CC — the only LCTCS member not on the shared Banner SSB host (`reg-prod.ec.lctcs.edu`). Its sections sit behind LoLA SSO with no public guest class search; only its **Coursedog catalog** is reachable (course metadata + 23 prereqs, already scraped and fed to the prereqs aggregator), and that has **no sections**. This was already documented in prose in `scrapers.courses`.

This PR promotes it to the structured `documentedCeilings.courses` field, so the audit excuses Northshore from the coverage denominator. The catalog keeps feeding prereqs; it is **not** surfaced as course coverage, because fabricating section-less listings would violate invariant #4 (no fake student data).

**Re-graded:** courses 11/12 (B) → **11/11 (A)**, composite **B→A**.

## Test plan
- [x] Re-ran the audit collector: courses A (11/11), composite A (ceilingsApplied: ["courses"])
- [x] Config parses; Coursedog catalog still feeds the prereqs aggregator
- [x] No data files touched; ticked on the state-goals tracker