### PR TITLE
fix(build): batch term-count RPC to unblock Vercel deploys

### DIFF
--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -57,70 +57,71 @@ export async function getAvailableTermsForDisplay(state: string): Promise<{
     .sort((a, b) => termSortKey(b.code) - termSortKey(a.code));
 }
 
+// ---------------------------------------------------------------------------
+// Batch current-term resolver
+//
+// During Next.js static generation, dozens of pages call getCurrentTerm() for
+// different states concurrently. The old per-state RPC accumulated enough
+// connection pressure to time out the 2-minute Supabase statement_timeout once
+// the courses table passed ~1M rows. This version fetches ALL states' term
+// counts in a single RPC (get_all_term_college_counts, ~400ms) and caches the
+// result map so every subsequent getCurrentTerm(state) is a synchronous lookup.
+// ---------------------------------------------------------------------------
+
+interface TermCountRow {
+  state: string;
+  term: string;
+  college_count: number;
+}
+
+function pickBestTerm(rows: TermCountRow[]): string {
+  if (rows.length === 0) return "2026SP";
+  let bestTerm = rows[0].term;
+  let bestCount = Number(rows[0].college_count);
+  for (const row of rows) {
+    const count = Number(row.college_count);
+    if (
+      count > bestCount ||
+      (count === bestCount && termSortKey(row.term) > termSortKey(bestTerm))
+    ) {
+      bestTerm = row.term;
+      bestCount = count;
+    }
+  }
+  return bestTerm;
+}
+
+async function loadAllCurrentTerms(): Promise<Map<string, string>> {
+  const { data, error } = await supabase.rpc("get_all_term_college_counts");
+
+  if (error || !data) {
+    console.warn("get_all_term_college_counts RPC error:", error?.message ?? error);
+    return new Map();
+  }
+
+  const byState = new Map<string, TermCountRow[]>();
+  for (const row of data as TermCountRow[]) {
+    if (!byState.has(row.state)) byState.set(row.state, []);
+    byState.get(row.state)!.push(row);
+  }
+
+  const result = new Map<string, string>();
+  for (const [st, rows] of byState) {
+    result.set(st, pickBestTerm(rows));
+  }
+  return result;
+}
+
 /**
  * Get the current term code by querying Supabase.
- * Uses a single RPC call to get term→college counts instead of N separate queries.
- * Returns the term with the most college data, breaking ties by recency.
+ * Batch-fetches all states' term→college counts in one RPC call, then caches
+ * the map. Returns the term with the most college data, breaking ties by recency.
  * Falls back to "2026SP" if no data is found.
  */
 export async function getCurrentTerm(state: string): Promise<string> {
   return cached(`currentTerm:${state}`, async () => {
-    // Try RPC first (single query instead of N+1)
-    const { data: rpcData, error: rpcErr } = await supabase.rpc(
-      "get_term_college_counts",
-      { p_state: state }
-    );
-
-    if (!rpcErr && rpcData) {
-      if (rpcData.length === 0) return "2026SP";
-
-      let bestTerm = rpcData[0].term;
-      let bestCount = Number(rpcData[0].college_count);
-
-      for (const row of rpcData) {
-        const count = Number(row.college_count);
-        if (
-          count > bestCount ||
-          (count === bestCount && termSortKey(row.term) > termSortKey(bestTerm))
-        ) {
-          bestTerm = row.term;
-          bestCount = count;
-        }
-      }
-
-      return bestTerm;
-    }
-
-    // Fallback: use getAvailableTerms + individual queries (old slow path)
-    console.warn("get_term_college_counts RPC error, using fallback:", rpcErr?.message ?? rpcErr);
-    const terms = await getAvailableTerms(state);
-    if (terms.length === 0) return "2026SP";
-
-    let bestTerm = terms[0];
-    let bestCount = 0;
-
-    for (const term of terms) {
-      const { count, error: countErr } = await supabase
-        .from("courses")
-        .select("id", { count: "exact", head: true })
-        .eq("state", state)
-        .eq("term", term);
-
-      if (countErr) {
-        console.error(`Term count error for ${term}:`, countErr.message);
-        continue;
-      }
-      const c = count || 0;
-      if (
-        c > bestCount ||
-        (c === bestCount && termSortKey(term) > termSortKey(bestTerm))
-      ) {
-        bestTerm = term;
-        bestCount = c;
-      }
-    }
-
-    return bestTerm;
+    const allTerms = await cached("currentTermMap:all", loadAllCurrentTerms);
+    return allTerms.get(state) ?? "2026SP";
   });
 }
 

--- a/supabase/migrations/020_batch_term_college_counts.sql
+++ b/supabase/migrations/020_batch_term_college_counts.sql
@@ -1,0 +1,35 @@
+-- ---------------------------------------------------------------------------
+-- 020_batch_term_college_counts.sql
+--
+-- Adds get_all_term_college_counts() — a batch version of
+-- get_term_college_counts(p_state) that returns (state, term, college_count)
+-- for ALL states in one call.
+--
+-- During Next.js static generation, dozens of pages call getCurrentTerm() for
+-- different states concurrently. With the courses table at 1M+ rows, N
+-- per-state RPCs accumulated enough Supabase connection-pool pressure to
+-- exceed the 2-minute statement_timeout, failing the Vercel production build.
+--
+-- This function replaces those N calls with a single Index Only Scan on
+-- idx_courses_state_term_college (~400ms total). The app-side cache in
+-- lib/terms.ts fetches this once and serves all states from the result map.
+--
+-- Idempotent (CREATE OR REPLACE). Safe to run in the SQL Editor or via
+-- scripts/lib/run-migration.ts.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION get_all_term_college_counts()
+RETURNS TABLE(state text, term text, college_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT c.state, c.term, COUNT(DISTINCT c.college_code) AS college_count
+  FROM courses c
+  GROUP BY c.state, c.term
+  ORDER BY c.state, c.term;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_all_term_college_counts() TO anon, authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changes for site users

Nothing visible — the site shows the same data. This unblocks production deploys that have been failing since the courses table crossed 1M rows.

## What changed technically

The `getCurrentTerm(state)` function used to call `get_term_college_counts(state)` once per state during Next.js static generation. With 51 states and 7 build workers, that's up to 357 concurrent Supabase RPCs — enough to saturate the connection pool and time out every query past the 2-minute `statement_timeout`. The N+1 fallback (individual `SELECT count(*)` per term) made it worse.

Now a single `get_all_term_college_counts()` RPC fetches all states' term×college counts in one Index Only Scan (~400ms on the 1.07M-row table). The result map is cached in-process, so all subsequent `getCurrentTerm(state)` calls are synchronous lookups. If the batch RPC fails, every state gracefully falls back to `"2026SP"` instead of hammering the DB.

**Migration 020** creates the RPC and grants access to `anon`/`authenticated`. Already applied to prod Supabase.

## Test plan

- [x] `get_all_term_college_counts()` returns correct data (verified via SQL Editor)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit` — no errors in `lib/terms.ts`)
- [ ] Vercel build succeeds after merge (the actual validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)