### PR TITLE
ks: fill seniorWaiver + popularCourses (config gaps)

### DIFF
--- a/lib/states/ks/config.ts
+++ b/lib/states/ks/config.ts
@@ -8,12 +8,37 @@ const ksConfig: StateConfig = {
   systemUrl: "https://www.kansasregents.org/",
   collegeCount: 24,
 
-  // TODO: verify senior-waiver statute for Kansas (K.S.A. 76-728 may apply for residents 65+).
-  // Set to null if no waiver exists, or fill in per the SeniorWaiverConfig shape.
-  seniorWaiver: null,
+  // Kansas has no statewide senior tuition-waiver statute for community/technical
+  // colleges. K.S.A. 76-731a covers Board of Regents (state university) institutions,
+  // not community colleges (governed under K.S.A. Chapter 71). Each college sets its
+  // own policy; common threshold is 60–65. Populated as "varies by college" per the
+  // NE/AZ/CA pattern.
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation: "No statewide statute for community/technical colleges; set by each college",
+    description:
+      "Kansas has no statewide senior-tuition statute for its community and technical colleges. Each college sets its own policy — many offer a reduced senior rate or waived tuition for residents aged 60+ on credit courses, often on a space-available basis. Terms vary by college; confirm with the registrar.",
+    bannerTitle: "Kansas Senior Discounts (by college)",
+    bannerSummary:
+      "60+ in Kansas? Many community and technical colleges offer a reduced senior tuition rate — terms vary by college.",
+    bannerDetail:
+      "Kansas has no statewide senior-tuition statute for community and technical colleges. K.S.A. 76-731a covers state universities under the Board of Regents but does not extend to the 24-college community/technical system. Each college sets its own policy — commonly a reduced or waived senior rate for residents 60 or 65+ on a space-available basis, sometimes excluding lab fees and non-credit classes. Contact your college's registrar for the specific rate and eligibility.",
+  },
 
   transferSupported: false,
-  popularCourses: [],
+  // Top 8 by section count across all wired KS colleges. Different colleges use
+  // different prefixes (EG/EN/ENG for English Composition); list reflects the
+  // raw rank in scraped data.
+  popularCourses: [
+    "EG 101",
+    "EN 101",
+    "PS 100",
+    "MA 106",
+    "EN 102",
+    "SH 101",
+    "ENG 101",
+    "PSY 101",
+  ],
   defaultZip: "67202",
   defaultZipCity: "Wichita",
 


### PR DESCRIPTION
## What changes for someone using the site

The Kansas state page (`/ks`) now shows a senior-discount banner ("60+ in Kansas? Many community and technical colleges offer a reduced senior tuition rate — terms vary by college") with a fuller explanation in the detail expansion. The course-search autocomplete on `/ks` now suggests 8 popular intro courses (English Comp, intro psych, college algebra, public speaking) instead of an empty list.

## What changes on the technical front

Closes the two config gaps surfaced by `/state-audit` (which had KS at composite F, limited by transfers — config was a separate cross-cutting issue).

- **seniorWaiver** was `null` with a TODO pointing at K.S.A. 76-728. After research: that statute doesn't exist; the relevant one is K.S.A. 76-731a, but it covers Board of Regents *universities*, not the 24-college community/technical system (which lives under Chapter 71). There is no statewide CC senior-waiver statute. Documented as a "varies by college" entry following the existing NE/AZ/CA pattern — threshold 60+, space-available, registrar confirmation required.
- **popularCourses** was `[]`. Computed top 8 by section count across all wired KS colleges (12 colleges, scraped). EG/EN/ENG variants of English Composition all appear separately because KS has no statewide common course numbering — colleges use their own prefixes. Raw rank preserved rather than collapsing.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] `/ks` page renders the senior-discount banner with the new copy
- [ ] `/ks` course-search autocomplete shows the 8 popular courses
- [ ] No regression on the homepage state map (KS still grey — courses dimension limits composite)

## Not in scope

- KS still has zero transfer data (no registered articulation portal) — that's the actual composite-F blocker and needs a separate transfers investigation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)