### PR TITLE
ak: document Ilisagvik Elder Tuition Waiver (NSB 62+)

### DIFF
--- a/lib/states/ak/config.ts
+++ b/lib/states/ak/config.ts
@@ -8,13 +8,23 @@ const akConfig: StateConfig = {
   systemUrl: "https://www.ilisagvik.edu/",
   collegeCount: 1,
 
-  // Alaska has no community-college *system* and no statutory senior-tuition
-  // waiver that reaches Ilisagvik (the state's only IPEDS-listed CC, a
-  // tribally-controlled college in Utqiagvik). The University of Alaska
-  // system has its own 60+ tuition reduction under AS 14.40.130, but that
-  // statute does not bind Ilisagvik. Leave null until a registrar contact
-  // confirms any tribal-college-specific policy.
-  seniorWaiver: null,
+  // Ilisagvik offers a North Slope Borough Elder Tuition Waiver: NSB
+  // residents aged 62+ get tuition waived (fees, registration, textbooks
+  // not covered). Statewide there is no Alaska CC senior statute reaching
+  // Ilisagvik — AS 14.40.130's 60+ UA-system waiver doesn't bind this
+  // tribally-controlled college. The Elder Waiver is the policy that
+  // applies here. Source: ilisagvik.edu/become-a-student/tuition-waiver/
+  seniorWaiver: {
+    ageThreshold: 62,
+    legalCitation: "Ilisagvik College — North Slope Borough Elder Tuition Waiver",
+    description:
+      "North Slope Borough residents aged 62+ qualify for a full tuition waiver at Ilisagvik College. Course fees, registration fees, textbooks, and lab kits are not covered. The waiver form must be submitted every semester before the withdrawal deadline.",
+    bannerTitle: "Ilisagvik Elder Tuition Waiver (NSB Residents 62+)",
+    bannerSummary:
+      "62+ and a North Slope Borough resident? Ilisagvik waives tuition — re-apply each semester.",
+    bannerDetail:
+      "Ilisagvik College's North Slope Borough Elder Tuition Waiver covers tuition for NSB residents aged 62 or older. Students remain responsible for course fees, registration fees, textbooks, and lab kits. The waiver form must be completed and submitted before each semester's withdrawal deadline; contact Financial Aid at 907-852-1708 or fin.aid@ilisagvik.edu. Alaska has no statewide CC senior-tuition statute — the University of Alaska 60+ reduction under AS 14.40.130 applies to UA campuses, not to Ilisagvik.",
+  },
 
   transferSupported: false,
   popularCourses: ["ENGL 101", "MATH 105", "BIOL 100", "PSY 101", "HIST 131"],


### PR DESCRIPTION
## What changes for someone using the site

The Alaska state page (`/ak`) now shows a senior-discount banner: \"62+ and a North Slope Borough resident? Ilisagvik waives tuition — re-apply each semester.\" The expanded detail spells out what's covered (tuition only) and what isn't (fees, textbooks, lab kits), plus the financial-aid contact info.

## What changes on the technical front

Resolves the \"seniorWaiver: null\" config gap surfaced by `/state-audit`. Previous comment correctly flagged that AS 14.40.130 (UA system's 60+ waiver) doesn't bind Ilisagvik, but stopped there. Verified the institution-specific policy directly:

- Source: [Ilisagvik tuition waiver page](https://www.ilisagvik.edu/become-a-student/tuition-waiver/) — North Slope Borough Elder Tuition Waiver, residents 62+, tuition only, semester re-application required.
- Configured with `ageThreshold: 62`, citation listing the institutional policy (no statute exists at state level), and banner copy that makes the NSB residency restriction explicit upfront.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] `/ak` renders the new senior-discount banner
- [ ] Banner copy mentions NSB residency requirement (not generic statewide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)