### PR TITLE
transfers: shared preserve-merge helper (future-proof multi-source states)

### DIFF
--- a/scripts/id/scrape-transfer.ts
+++ b/scripts/id/scrape-transfer.ts
@@ -29,6 +29,7 @@ import fs from "fs";
 import path from "path";
 import * as cheerio from "cheerio";
 import { importTransfersToSupabase } from "../lib/supabase-import.js";
+import { mergeTransferRows } from "../lib/transfer-merge.js";
 
 interface TransferMapping {
   state: string;
@@ -246,8 +247,9 @@ async function main() {
 
   const outPath = path.join(process.cwd(), "data", "id", "transfer-equiv.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
-  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+  const merged = mergeTransferRows("id", all, { log: (m) => console.log(`  ${m}`) });
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`\nSaved ${merged.length} mappings → ${outPath}`);
 
   if (!skipImport) {
     try {

--- a/scripts/ks/scrape-transfer.ts
+++ b/scripts/ks/scrape-transfer.ts
@@ -32,6 +32,7 @@ import fs from "fs";
 import path from "path";
 import * as cheerio from "cheerio";
 import { importTransfersToSupabase } from "../lib/supabase-import.js";
+import { mergeTransferRows } from "../lib/transfer-merge.js";
 
 interface TransferMapping {
   state: string;
@@ -275,8 +276,9 @@ async function main() {
 
   const outPath = path.join(process.cwd(), "data", "ks", "transfer-equiv.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
-  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+  const merged = mergeTransferRows("ks", all, { log: (m) => console.log(`  ${m}`) });
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`\nSaved ${merged.length} mappings → ${outPath}`);
 
   if (!skipImport) {
     try {

--- a/scripts/lib/scrape-ctnet-multisource.ts
+++ b/scripts/lib/scrape-ctnet-multisource.ts
@@ -31,6 +31,7 @@ import fs from "fs";
 import path from "path";
 import { importTransfersToSupabase } from "./supabase-import.js";
 import { fetchInStateInstitutions } from "./in-state-institutions.js";
+import { mergeTransferRows } from "./transfer-merge.js";
 
 export interface CtnetCollege {
   /** Our internal college slug (matches data/{slug}/institutions.json). */
@@ -323,29 +324,12 @@ export async function scrapeCtnetState(
     return;
   }
 
+  // Preserve rows this run didn't produce (other scrapers in the same state,
+  // or colleges this run failed to reach), keyed by sending-college slug +
+  // receiving university. Shared with the per-state portal scrapers.
+  const merged = mergeTransferRows(slug, all, { log: (m) => console.log(`\n  ${m}`) });
+
   const outPath = path.join(process.cwd(), "data", slug, "transfer-equiv.json");
-  let preserved: TransferMapping[] = [];
-  // Drop only rows we just refreshed: same sending CC slug AND same receiving
-  // university. Mirrors scripts/nh/scrape-transfer.ts merge semantics so a
-  // partial run preserves colleges that weren't re-scraped this time.
-  const ourUniversities = new Set(all.map((m) => m.university));
-  try {
-    const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
-    if (Array.isArray(existing)) {
-      preserved = (existing as TransferMapping[]).filter((m) => {
-        const sl = m.notes.match(/^\[([\w-]+)\]/)?.[1];
-        const ownedByThisRun =
-          sl !== undefined && successfulSlugs.has(sl) && ourUniversities.has(m.university);
-        return !ownedByThisRun;
-      });
-    }
-  } catch {
-    // No existing file — fresh start.
-  }
-
-  const merged = [...preserved, ...all];
-  console.log(`\n  Merged: ${preserved.length} preserved + ${all.length} new = ${merged.length} total`);
-
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
   console.log(`Saved ${merged.length} mappings → ${outPath}`);

--- a/scripts/lib/transfer-merge.ts
+++ b/scripts/lib/transfer-merge.ts
@@ -1,0 +1,77 @@
+/**
+ * transfer-merge.ts
+ *
+ * Shared preserve-merge for transfer-equivalency scrapers. Lets multiple
+ * scrapers write the same data/{state}/transfer-equiv.json without clobbering
+ * each other, and makes a partial run (some colleges/receivers failed)
+ * non-destructive instead of wiping the file.
+ *
+ * Ownership of a row is keyed by:
+ *   (sending-college slug from the notes `[slug]` prefix, receiving `university` slug)
+ *
+ * A run "owns" exactly the (sender, receiver) pairs present in the rows it just
+ * produced. mergeTransferRows() keeps every existing row whose pair this run did
+ * NOT produce — rows from a different scraper (e.g. CT.Net + a per-university
+ * scraper in the same state), or rows for a college this run failed to reach —
+ * and replaces the rest with the fresh rows.
+ *
+ * This generalizes the logic that previously lived inline in
+ * scrape-ctnet-multisource.ts (and the NH/ME scrapers it was copied from), so a
+ * future "add another receiving university" scraper for a state is additive and
+ * conflict-free by construction.
+ *
+ * Note: the importer (scripts/import-transfers.ts) still enforces the global
+ * >50%-row-drop guard, so a broken scrape can't silently shrink prod even
+ * through this merge.
+ */
+
+import fs from "fs";
+import path from "path";
+
+export interface TransferRowLike {
+  university: string;
+  notes: string;
+}
+
+/** Extract the sending-college slug from a row's `[slug] …` notes prefix. */
+export function senderSlugFromNotes(notes: string): string {
+  return notes.match(/^\[([\w-]+)\]/)?.[1] ?? "";
+}
+
+function ownershipKey(row: TransferRowLike): string {
+  return `${senderSlugFromNotes(row.notes)}|${row.university}`;
+}
+
+/**
+ * Merge freshly-scraped rows into the state's existing transfer-equiv.json,
+ * preserving rows this run did not produce. Returns the merged array; the
+ * caller is responsible for writing it to disk.
+ *
+ * @param state      state slug (e.g. "wi") — used to locate the data file
+ * @param newRows    rows produced by the current run
+ * @param opts.log   optional logger for the preserved/new/total counts
+ */
+export function mergeTransferRows<T extends TransferRowLike>(
+  state: string,
+  newRows: T[],
+  opts: { log?: (msg: string) => void } = {},
+): T[] {
+  const owned = new Set(newRows.map(ownershipKey));
+  const outPath = path.join(process.cwd(), "data", state, "transfer-equiv.json");
+
+  let preserved: T[] = [];
+  try {
+    const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    if (Array.isArray(existing)) {
+      preserved = (existing as T[]).filter((row) => !owned.has(ownershipKey(row)));
+    }
+  } catch {
+    // No existing file (or unreadable) — fresh start.
+  }
+
+  const merged = [...preserved, ...newRows];
+  opts.log?.(
+    `Merged: ${preserved.length} preserved + ${newRows.length} new = ${merged.length} total`,
+  );
+  return merged;
+}

--- a/scripts/ne/scrape-transfer.ts
+++ b/scripts/ne/scrape-transfer.ts
@@ -27,6 +27,7 @@ import fs from "fs";
 import path from "path";
 import * as cheerio from "cheerio";
 import { importTransfersToSupabase } from "../lib/supabase-import.js";
+import { mergeTransferRows } from "../lib/transfer-merge.js";
 
 interface TransferMapping {
   state: string;
@@ -214,8 +215,9 @@ async function main() {
 
   const outPath = path.join(process.cwd(), "data", "ne", "transfer-equiv.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
-  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+  const merged = mergeTransferRows("ne", all, { log: (m) => console.log(`  ${m}`) });
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`\nSaved ${merged.length} mappings → ${outPath}`);
 
   if (!skipImport) {
     try {

--- a/scripts/ok/scrape-transfer.ts
+++ b/scripts/ok/scrape-transfer.ts
@@ -35,6 +35,7 @@
 import fs from "fs";
 import path from "path";
 import { importTransfersToSupabase } from "../lib/supabase-import.js";
+import { mergeTransferRows } from "../lib/transfer-merge.js";
 
 interface TransferMapping {
   state: string;
@@ -267,8 +268,9 @@ async function main() {
 
   const outPath = path.join(process.cwd(), "data", "ok", "transfer-equiv.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(deduped, null, 2) + "\n");
-  console.log(`\nSaved ${deduped.length} mappings → ${outPath}`);
+  const merged = mergeTransferRows("ok", deduped, { log: (m) => console.log(`  ${m}`) });
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`\nSaved ${merged.length} mappings → ${outPath}`);
 
   if (!skipImport) {
     try {

--- a/scripts/wi/scrape-transfer-uwm.ts
+++ b/scripts/wi/scrape-transfer-uwm.ts
@@ -35,6 +35,7 @@
 import fs from "fs";
 import path from "path";
 import { importTransfersToSupabase } from "../lib/supabase-import.js";
+import { mergeTransferRows } from "../lib/transfer-merge.js";
 
 interface TransferMapping {
   state: string;
@@ -232,8 +233,9 @@ async function main() {
 
   const outPath = path.join(process.cwd(), "data", "wi", "transfer-equiv.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
-  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+  const merged = mergeTransferRows("wi", all, { log: (m) => console.log(`  ${m}`) });
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`\nSaved ${merged.length} mappings → ${outPath}`);
 
   if (!skipImport) {
     try {


### PR DESCRIPTION
## What changes for site users

Nothing visible today — this is a safety/maintainability refactor with zero data change (re-running a scraper produces byte-identical output). It's the groundwork that makes the *next* round of transfer work safe: adding a second receiving university to a state (e.g. Ivy Tech → IU/Purdue for Indiana, KU/K-State for Kansas) without the existing scraper wiping it out.

## The problem it fixes

The five portal scrapers (ID, WI, NE, KS, OK) **overwrote** `data/{state}/transfer-equiv.json` wholesale on every run. That's fine while each state has one source — but the moment a state gets a second scraper (the documented receiver-expansion follow-ups), the first scraper's next cron run would clobber the second's rows. Only the CollegeTransfer.Net engine had preserve-merge logic, inline.

## What changed technically

- New `scripts/lib/transfer-merge.ts` → `mergeTransferRows(state, newRows)`. It keys row ownership on **(sending-college slug from the `[slug]` notes prefix, receiving `university` slug)** and preserves every existing row this run did **not** produce — rows from a different scraper, or rows for a college this run failed to reach.
- `scrape-ctnet-multisource.ts` now calls the helper (its inline copy removed — single implementation).
- The five portal scrapers now merge instead of overwrite.

Two bonus benefits beyond multi-source: a **partial run** (some colleges' endpoints down) is now non-destructive instead of shrinking the file, and there's now **one** merge implementation to reason about. The global >50%-row-drop guard in `import-transfers.ts` still applies on top.

## Test plan
- [x] `npx tsc --noEmit` clean across all six touched files
- [x] **Idempotency:** re-ran WI scraper → `0 preserved + 7,555 new`, byte-identical to committed data (no data file churn)
- [x] **Preserve path:** synthetic test — a foreign-receiver (KU) row is preserved while the same scraper's stale (WSU) row is replaced and the fresh one added; no duplication
- [x] No data files modified by this PR (code-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)