### PR TITLE
fix(import): raise --all backfill timeouts so recovery runs complete

### DIFF
--- a/.github/workflows/import-on-merge.yml
+++ b/.github/workflows/import-on-merge.yml
@@ -140,7 +140,11 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.courses_states != '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 90 # backstop for the `all` backfill; per-state is seconds
+    # Per-state pushes (the steady state) finish in seconds; this cap only
+    # matters for the manual `--all` backfill path. The 2026-06-01 backfill
+    # (run 26781597798) cancelled at 90 min after importing 24/50 states —
+    # NC alone took 37 min, MD 6, GA 7. Budget enough for the full 50.
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -165,7 +169,11 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.transfers_states != '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Same rationale as courses. The 2026-06-01 backfill cancelled at 45 min
+    # mid-NY — MD alone took 22 min (122,925 mappings), NY 254,448 mappings
+    # is even larger. 180 min gives the full 50-state `--all` headroom; the
+    # per-state-per-merge steady state is seconds.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible immediately — this is the follow-up that lets us **finish the data recovery** from the 2026-06-01 incident. The first backfill (after [#1041](https://github.com/rohan-c0de/cc-coursemap/pull/1041) merged) successfully landed 24 states' courses, 7 states' transfers, and full programs — but ran out of clock and cancelled mid-import, so OK's 50k transfer mappings (#997), CA / FL / TX courses, and ~25 other states' data are still not in production. After this merges I'll dispatch another `--all` backfill which now has enough budget to finish — students will then see the freshly-scraped data on those states.

## What was wrong

The timeouts I set in [#1041](https://github.com/rohan-c0de/cc-coursemap/pull/1041) (courses 90 min, transfers 45 min) were calibrated for the steady state (per-state-per-merge, seconds) but not for the manual `--all` recovery path. Evidence from [run 26781597798](https://github.com/rohan-c0de/cc-coursemap/actions/runs/26781597798):
- **courses**: cancelled at 90 min after 24/50 states. NC alone took 37 min, MD 6 min, GA 7 min.
- **transfers**: cancelled at 45 min after 7/50 states. MD alone took 22 min (122,925 mappings); NY (254,448 mappings) didn't finish.
- **programs**: completed in ~28 min — its 45-min cap is fine, leaving it alone.

## The change

```yaml
courses:   timeout-minutes: 90  -> 240
transfers: timeout-minutes: 45  -> 180
programs:  timeout-minutes: 45  (unchanged)
```

`timeout-minutes` is a **cap**, not a fixed runtime — per-state pushes (the common case after [#1041](https://github.com/rohan-c0de/cc-coursemap/pull/1041)) still finish in seconds. The cap only bites on the manual `--all` backfill / recovery path. Raising it doesn't slow anything down; it just lets the recovery run finish before GitHub kills it.

## Test plan

- YAML validates via `js-yaml`; all 5 jobs still parse.
- Diff is exclusively the two `timeout-minutes` values + explanatory code-comments. No logic changes.

## After merge

I'll trigger one `workflow_dispatch` with `state=all, datatype=both` to finish the recovery. Re-imports of already-landed states are idempotent upserts (NC ~37 min repeats, MD ~22 min repeats, etc.), and the larger budget covers the full sweep. Then I'll re-probe prod for OK transfers and a handful of previously-missing course states to confirm.

## Known follow-ups (not in this PR)

- **MD transfer schema rejects** (556 / 122,925 = 0.5%) — bad `cc_prefix`/`cc_number` rows. Real but small; separate fix.
- **SC course term ABORTs** (3 college/term combos at 100% invalid-row ratio). Scraper bug; separate fix.
- **ND programs envelope mismatch** (expected object, got array). Scraper output format; separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)