### PR TITLE
docs(concepts): Plan-to-Outcome design explorations + navigable journey set

### DIFF
--- a/docs/prototypes/plan-to-outcome/concepts/README.md
+++ b/docs/prototypes/plan-to-outcome/concepts/README.md
@@ -1,0 +1,39 @@
+# Design concepts — Plan-to-Outcome
+
+A scratchpad of **exploratory visual-design concepts** for the Plan-to-Outcome experience
+(and the site's look & feel generally). These are **references to react to**, not shipping
+code and **not wired into the app**. The working prototype lives one level up
+(`../journey.html`); this folder is where we collect "what could it look like" ideas while
+the design direction is still being explored.
+
+Each concept is a self-contained HTML file — **just open it in a browser** (no server, no build).
+
+## Concepts
+
+### `welcome-inspired.html` — welcome-screen visual direction
+A more polished, modern take on the welcome/landing screen, in our brand (teal + slate +
+Geist). Inspired by a set of ed-tech / community references the owner liked:
+[Circle](https://circle-website.webflow.io) · [Teachable](https://www.teachable.com) ·
+[CAPSLOCK](https://capslock.ac) · an EduPress e-learning Figma template.
+
+What it borrows:
+- **Floating "product as hero"** — instead of a generic illustration, the hero shows our
+  real UI floating in depth (a live course card, an earnings stat, a transfer chip) over soft
+  teal/amber blobs + a dashed ring. (Capslock's floating graphic elements, applied to our data.)
+- **"How it works" 3-step flow** (Circle's syllabus flow): Plan → Schedule → Transfer → Outcomes.
+- **Social-proof strip + structured sections + soft-shadow cards + pill buttons** (Teachable).
+- **Big airy hero, confident type, generous whitespace**, a teal highlight underline on the
+  emphasis word, primary + soft-secondary CTAs.
+
+⚠️ **Honesty placeholders — do NOT ship as-is.** The student **quote** is illustrative (written
+to represent the north-star user, not a real testimonial), and the **partner logos / "50+
+colleges"** are text stand-ins. Real social proof needs real students/sources, per the
+project's no-fabrication principle. The course/earnings/transfer values shown are real GA /
+Atlanta Tech / Accounting figures.
+
+Status: **partial keep** — the owner liked *some* of it; not yet adopted into the live
+prototype. Still gathering additional ideas before committing to a direction.
+
+## How to add a new concept here
+Drop a self-contained `*.html` in this folder and add a short blurb above: what it explores,
+what it borrows/changes, and any honesty caveats (no fabricated data/quotes presented as real).

--- a/docs/prototypes/plan-to-outcome/concepts/README.md
+++ b/docs/prototypes/plan-to-outcome/concepts/README.md
@@ -34,6 +34,58 @@ Atlanta Tech / Accounting figures.
 Status: **partial keep** — the owner liked *some* of it; not yet adopted into the live
 prototype. Still gathering additional ideas before committing to a direction.
 
+---
+
+### `home-search.html` — search-first home
+A landing where the **search interaction is the hero** (not a static illustration): a pill
+search bar — "I want to study ___ near ___ transfer to ___" — over category pills, then a
+**map + list split** of nearby colleges. Each result card carries a letter-grade transfer
+badge, a confident single cost **estimate**, an open-seats indicator, and a personal **fit
+meter**.
+
+Borrows from:
+- **Airbnb** — search-as-hero, the pill search bar, category browsing.
+- **Zillow** — the map+list split, the one confident "estimate" number (à la Zestimate), filter chips.
+- **Niche** — letter-grade report-card badges.
+- **CollegeVine** — the personalized "fit" gauge.
+
+⚠️ **Honesty:** **Atlanta Technical College** figures are real (Accounting A.S.). The other four
+are **real Georgia institutions**, but their cost / earnings / grade / fit numbers are
+**illustrative placeholders** (tagged inline). The map is **stylized**, not geographic.
+
+### `compare-outcomes.html` — outcomes & compare *(almost entirely real data)*
+A College-Scorecard-style outcomes surface for one program: an **earnings distribution**
+(25th / median / 75th percentile), **cost-by-income** bars (showing that for families under
+$48k, aid *exceeds* tuition — a genuinely non-obvious, honest insight), the **transfer
+breakdown** per university (direct equivalent vs. elective vs. no-credit), and an
+**earnings-vs-nearby-colleges** comparison.
+
+Borrows from:
+- **College Scorecard** — earnings distribution, cost-by-income, comparison framing.
+- **NerdWallet** — money made plain-English + trustworthy, with the caveats surfaced not hidden.
+- **Niche** — compare layout.
+
+✅ **Honesty: every number on this page is real** — College Scorecard outcomes & net-price-by-income
+for Atlanta Tech, real GA statewide articulation counts, real per-college earnings for 22 GA
+colleges. The honesty *caveats* themselves are part of the design (college-wide vs. major-specific
+earnings; "reviewed ≠ transfers"). This is the strongest demonstration that our real data already
+supports a premium outcomes view.
+
+### `journey-dashboard.html` — personal dashboard (premium dark)
+A signed-in "your path" dashboard: a **progress ring** (credits done), stat tiles (semesters
+left, projected earnings, universities that accept your credits, open seats in your next class),
+a **semester timeline** (done / now / planned), an earnings **trajectory** curve, and a "best
+next class" recommendation. Defaults to a **premium dark** theme with a working light toggle.
+
+Borrows from:
+- **Flighty** — personal data made *beautiful*, the timeline/recap feel, premium dark aesthetic.
+- **Apple** — restraint, one focal number per tile.
+
+⚠️ **Honesty:** course codes, credits (67 total), earnings ($30,350 median; $14.5k–$48.4k range),
+seats (18), and the West Georgia transfer count (25) are **real** Atlanta Tech / Accounting data.
+The **completed-credits state and semester layout are an illustrative example** of an in-progress
+student — the real version is driven by what the student checks off.
+
 ## How to add a new concept here
 Drop a self-contained `*.html` in this folder and add a short blurb above: what it explores,
 what it borrows/changes, and any honesty caveats (no fabricated data/quotes presented as real).

--- a/docs/prototypes/plan-to-outcome/concepts/compare-outcomes.html
+++ b/docs/prototypes/plan-to-outcome/concepts/compare-outcomes.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Outcomes &amp; compare — concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#f7faf9; --panel:#fff; --ink:#0f172a; --muted:#5b6573; --line:#e6ebf0; --line2:#d3dbe2;
+  --brand:#0d9488; --brand-strong:#0f766e; --brand-soft:#effbf8; --brand-tint:#cdeee8; --bright:#2dd4bf;
+  --warm:#f59e0b; --warm-soft:#fef3c7; --warm-strong:#b45309;
+  --good:#15803d; --good-bg:#dcfce7;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:"Geist",system-ui,sans-serif;font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1040px;margin:0 auto;padding:0 26px}
+h1,h2,h3{margin:0;letter-spacing:-.025em;font-weight:700}
+.ic{stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round;display:inline-block;vertical-align:middle}
+a{color:var(--brand);text-decoration:none}
+.nav{display:flex;align-items:center;justify-content:space-between;padding:18px 0}
+.brandmark{display:flex;align-items:center;gap:10px;font-weight:700;font-size:16px}
+.logo{width:30px;height:30px;border-radius:9px;background:var(--brand);color:#fff;display:flex;align-items:center;justify-content:center}
+.crumb{color:var(--muted);font-size:13px}
+.btn{font-family:inherit;font-weight:600;border-radius:999px;cursor:pointer;border:none;display:inline-flex;align-items:center;gap:8px;background:var(--brand);color:#fff;padding:10px 16px;font-size:13.5px}
+/* page head */
+.phead{padding:14px 0 8px}
+.phead .kick{color:var(--brand-strong);font-weight:600;font-size:12.5px;letter-spacing:.04em;text-transform:uppercase}
+.phead h1{font-size:32px;letter-spacing:-.03em;margin:6px 0 4px}
+.phead .who{color:var(--muted);font-size:14.5px}
+/* grid of panels */
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:18px;padding:22px 24px;box-shadow:0 1px 2px rgba(15,23,42,.04);margin-top:18px}
+.panel h2{font-size:18px;display:flex;align-items:center;gap:9px}
+.panel h2 .ic{color:var(--brand)}
+.panel .desc{color:var(--muted);font-size:13.5px;margin:4px 0 0}
+.cols2{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+/* earnings hero number */
+.bignum{display:flex;align-items:baseline;gap:12px;margin:16px 0 6px}
+.bignum .n{font-size:44px;font-weight:800;letter-spacing:-.03em;color:var(--brand)}
+.bignum .u{font-size:14px;color:var(--muted);max-width:180px}
+/* distribution bar */
+.dist{margin:18px 0 6px}
+.distbar{position:relative;height:14px;border-radius:999px;background:linear-gradient(90deg,#e2e8f0,var(--brand-tint));margin:26px 0 8px}
+.distbar .fill{position:absolute;top:0;bottom:0;border-radius:999px;background:linear-gradient(90deg,var(--bright),var(--brand))}
+.distbar .mk{position:absolute;top:-22px;transform:translateX(-50%);font-size:11px;color:var(--muted);white-space:nowrap}
+.distbar .mk b{display:block;color:var(--ink);font-size:12.5px;font-weight:800;text-align:center}
+.distbar .tick{position:absolute;top:-6px;width:2px;height:26px;background:var(--ink);opacity:.55;transform:translateX(-50%)}
+.distbar .tick.med{background:var(--brand-strong);opacity:1;width:3px;height:30px;top:-8px}
+.scale{display:flex;justify-content:space-between;color:var(--muted);font-size:11px;margin-top:2px}
+/* callout */
+.callout{display:flex;gap:11px;background:var(--brand-soft);border:1px solid var(--brand-tint);border-radius:13px;padding:13px 15px;margin-top:16px}
+.callout .ic{color:var(--brand);flex:0 0 auto;margin-top:1px}
+.callout b{color:var(--brand-strong)}
+.callout p{margin:0;font-size:13px;color:#334155;line-height:1.5}
+.callout.warm{background:var(--warm-soft);border-color:#fcd34d}
+.callout.warm .ic{color:var(--warm-strong)}
+.callout.warm b{color:var(--warm-strong)}
+/* net price by income bars */
+.npr{display:flex;flex-direction:column;gap:9px;margin-top:14px}
+.nprow{display:grid;grid-template-columns:120px 1fr 64px;align-items:center;gap:10px;font-size:12.5px}
+.nprow .inc{color:var(--muted)}
+.npr .track{position:relative;height:22px;background:#f1f5f9;border-radius:7px;overflow:hidden}
+.npr .zero{position:absolute;top:-3px;bottom:-3px;width:2px;background:var(--line2)}
+.npr .bar{position:absolute;top:3px;bottom:3px;border-radius:5px}
+.npr .bar.neg{background:linear-gradient(90deg,var(--brand),var(--bright))}
+.npr .bar.pos{background:linear-gradient(90deg,#fbbf24,var(--warm))}
+.nprow .amt{text-align:right;font-weight:700;font-variant-numeric:tabular-nums}
+.nprow .amt.neg{color:var(--brand-strong)}.nprow .amt.pos{color:var(--warm-strong)}
+/* transfer comparison */
+.txrow{display:grid;grid-template-columns:190px 1fr;gap:14px;align-items:center;padding:13px 0;border-top:1px solid var(--line)}
+.txrow:first-of-type{border-top:none}
+.txrow .uni{font-weight:700;font-size:14.5px}
+.txrow .uni small{display:block;color:var(--muted);font-weight:500;font-size:12px}
+.stack{display:flex;height:24px;border-radius:7px;overflow:hidden;background:#f1f5f9;font-size:10.5px;font-weight:700;color:#fff}
+.stack span{display:flex;align-items:center;justify-content:center;min-width:0}
+.s-dir{background:var(--brand)}.s-ele{background:var(--bright);color:#0f3d38}.s-no{background:#cbd5e1;color:#475569}
+.txlegend{display:flex;gap:16px;flex-wrap:wrap;margin-top:12px;font-size:12px;color:var(--muted)}
+.txlegend i{display:inline-block;width:11px;height:11px;border-radius:3px;margin-right:5px;vertical-align:middle}
+/* peer earnings chart */
+.peer{display:flex;flex-direction:column;gap:8px;margin-top:14px}
+.peerrow{display:grid;grid-template-columns:150px 1fr 86px;align-items:center;gap:10px;font-size:12.5px}
+.peerrow .pn{color:var(--ink);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.peerrow.me .pn{color:var(--brand-strong);font-weight:800}
+.peertrack{height:20px;background:#f1f5f9;border-radius:6px;overflow:hidden}
+.peertrack i{display:block;height:100%;border-radius:6px;background:linear-gradient(90deg,#a7f3d0,#5eead4)}
+.peerrow.me .peertrack i{background:linear-gradient(90deg,var(--bright),var(--brand))}
+.peerrow .pv{text-align:right;font-weight:700;font-variant-numeric:tabular-nums}
+.peerrow .pv small{color:var(--muted);font-weight:500;display:block;font-size:10.5px}
+.foot{color:var(--muted);font-size:12.5px;padding:24px 0 50px;border-top:1px solid var(--line);margin-top:22px}
+.tag{display:inline-block;background:var(--brand-soft);color:var(--brand-strong);border:1px solid var(--brand-tint);font-size:11px;font-weight:600;padding:3px 9px;border-radius:6px}
+.src{font-size:11px;color:#94a3b8;margin-top:8px}
+@media(max-width:820px){.cols2{grid-template-columns:1fr}.txrow{grid-template-columns:1fr}.peerrow{grid-template-columns:110px 1fr 74px}.nprow{grid-template-columns:96px 1fr 58px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="nav">
+    <div class="brandmark"><div class="logo"><svg class="ic" style="width:17px;height:17px;stroke:#fff" viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2 2 5 2s5-1 5-2v-5"/></svg></div>Community College Path</div>
+    <div class="crumb">Atlanta Technical College · Accounting, A.S.</div>
+    <button class="btn">Start this plan <svg class="ic" style="width:15px;height:15px;stroke:#fff" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></button>
+  </div>
+
+  <div class="phead">
+    <div class="kick">What it leads to</div>
+    <h1>Accounting, A.S. — costs, transfer &amp; earnings</h1>
+    <div class="who">Atlanta Technical College · 67 credits · honest numbers, gaps named</div>
+  </div>
+
+  <!-- OUTCOMES + COST -->
+  <div class="cols2">
+    <div class="panel">
+      <h2><svg class="ic" style="width:18px;height:18px" viewBox="0 0 24 24"><path d="M3 17l6-6 4 4 7-8"/><path d="M21 7v5M21 7h-5"/></svg> What graduates earn</h2>
+      <p class="desc">Median earnings 10 years after starting at this college.</p>
+      <div class="bignum"><div class="n">$30,350</div><div class="u">median · 10&nbsp;yrs after entry</div></div>
+
+      <div class="dist">
+        <div class="distbar">
+          <div class="fill" style="left:26%;right:12%"></div>
+          <div class="tick" style="left:26%"></div>
+          <div class="tick med" style="left:55%"></div>
+          <div class="tick" style="left:88%"></div>
+          <div class="mk" style="left:26%"><b>$14.5k</b>lower 25%</div>
+          <div class="mk" style="left:55%"><b>$30.4k</b>median</div>
+          <div class="mk" style="left:88%"><b>$48.4k</b>upper 25%</div>
+        </div>
+        <div class="scale"><span>$0</span><span>$55k</span></div>
+      </div>
+
+      <div class="callout">
+        <svg class="ic" style="width:17px;height:17px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+        <p><b>37% earn more than a typical high-school graduate</b> in Georgia ($33k). Earnings reflect everyone who started — including those who didn't finish — so completing the degree usually lands you higher in this range.</p>
+      </div>
+      <div class="src">Source: U.S. Dept. of Education College Scorecard. Earnings are college-wide (this measure isn't broken out by major).</div>
+    </div>
+
+    <div class="panel">
+      <h2><svg class="ic" style="width:18px;height:18px" viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M3 10h18M7 15h4"/></svg> What it actually costs</h2>
+      <p class="desc">Sticker tuition is <b>$3,382/yr</b> — but most students pay far less after aid. Net price by family income:</p>
+      <div class="npr">
+        <div class="nprow"><span class="inc">Under $30k</span><div class="track"><span class="zero" style="left:46%"></span><span class="bar neg" style="right:54%;width:24%"></span></div><span class="amt neg">−$1,731</span></div>
+        <div class="nprow"><span class="inc">$30k–$48k</span><div class="track"><span class="zero" style="left:46%"></span><span class="bar neg" style="right:54%;width:18%"></span></div><span class="amt neg">−$1,264</span></div>
+        <div class="nprow"><span class="inc">$48k–$75k</span><div class="track"><span class="zero" style="left:46%"></span><span class="bar pos" style="left:46%;width:6%"></span></div><span class="amt pos">$462</span></div>
+        <div class="nprow"><span class="inc">$75k–$110k</span><div class="track"><span class="zero" style="left:46%"></span><span class="bar pos" style="left:46%;width:40%"></span></div><span class="amt pos">$5,413</span></div>
+        <div class="nprow"><span class="inc">$110k+</span><div class="track"><span class="zero" style="left:46%"></span><span class="bar pos" style="left:46%;width:52%"></span></div><span class="amt pos">$7,293</span></div>
+      </div>
+      <div class="callout">
+        <svg class="ic" style="width:17px;height:17px" viewBox="0 0 24 24"><path d="M12 2l2.4 7.4H22l-6 4.5 2.3 7.1L12 16.9 5.7 21l2.3-7.1-6-4.5h7.6z"/></svg>
+        <p><b>If your family earns under $48k, aid covers tuition and then some</b> — net price is negative (a refund toward living costs). Sticker price is rarely what you pay.</p>
+      </div>
+      <div class="src">Source: College Scorecard average net price by income band (full-year, all programs).</div>
+    </div>
+  </div>
+
+  <!-- TRANSFER COMPARISON -->
+  <div class="panel">
+    <h2><svg class="ic" style="width:18px;height:18px" viewBox="0 0 24 24"><path d="M4 7h12M12 3l4 4-4 4"/><path d="M20 17H8M12 21l-4-4 4-4"/></svg> Where your credits go (transfer)</h2>
+    <p class="desc">Of the Accounting courses each university has reviewed, how many actually count toward a degree there.</p>
+
+    <div style="margin-top:14px">
+      <div class="txrow">
+        <div class="uni">University of West Georgia <small>38 courses reviewed</small></div>
+        <div>
+          <div class="stack"><span class="s-dir" style="width:8%">3</span><span class="s-ele" style="width:58%">22 elective</span><span class="s-no" style="width:34%">13 no credit</span></div>
+        </div>
+      </div>
+      <div class="txrow">
+        <div class="uni">Georgia State University <small>27 courses reviewed</small></div>
+        <div>
+          <div class="stack"><span class="s-dir" style="width:19%">5</span><span class="s-ele" style="width:18%">5</span><span class="s-no" style="width:63%">17 no credit</span></div>
+        </div>
+      </div>
+      <div class="txrow">
+        <div class="uni">University of Georgia <small>19 courses reviewed</small></div>
+        <div>
+          <div class="stack"><span class="s-dir" style="width:5%">1</span><span class="s-ele" style="width:21%">4</span><span class="s-no" style="width:74%">14 no credit</span></div>
+        </div>
+      </div>
+      <div class="txrow">
+        <div class="uni">Georgia Tech <small>9 courses reviewed</small></div>
+        <div>
+          <div class="stack"><span class="s-dir" style="width:78%">7 direct match</span><span class="s-ele" style="width:22%">2</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="txlegend">
+      <span><i style="background:var(--brand)"></i>Direct equivalent (counts as the same course)</span>
+      <span><i style="background:var(--bright)"></i>Elective credit (counts, but not toward a requirement)</span>
+      <span><i style="background:#cbd5e1"></i>No credit</span>
+    </div>
+    <div class="callout warm">
+      <svg class="ic" style="width:17px;height:17px" viewBox="0 0 24 24"><path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>
+      <p><b>More courses reviewed isn't the same as more that transfer.</b> Georgia Tech reviewed only 9 but every one counts; West Georgia counts the most overall (25 of 38). Pick your target university <em>before</em> you register so you don't pay for a class that won't carry.</p>
+    </div>
+    <div class="src">Source: Georgia statewide articulation (live transfer-equivalency data for this program).</div>
+  </div>
+
+  <!-- PEER EARNINGS -->
+  <div class="panel">
+    <h2><svg class="ic" style="width:18px;height:18px" viewBox="0 0 24 24"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg> How nearby colleges compare</h2>
+    <p class="desc">Median earnings 10 years after entry, across nearby Georgia colleges. Atlanta Tech highlighted.</p>
+    <div class="peer">
+      <div class="peerrow"><span class="pn">Gwinnett Tech</span><div class="peertrack"><i style="width:100%"></i></div><span class="pv">$45,025<small>61% above HS</small></span></div>
+      <div class="peerrow"><span class="pn">Chattahoochee Tech</span><div class="peertrack"><i style="width:82%"></i></div><span class="pv">$37,138<small>51% above HS</small></span></div>
+      <div class="peerrow"><span class="pn">West Georgia Tech</span><div class="peertrack"><i style="width:79%"></i></div><span class="pv">$35,479<small>51% above HS</small></span></div>
+      <div class="peerrow"><span class="pn">Georgia Piedmont</span><div class="peertrack"><i style="width:77%"></i></div><span class="pv">$34,619<small>46% above HS</small></span></div>
+      <div class="peerrow"><span class="pn">Savannah Tech</span><div class="peertrack"><i style="width:73%"></i></div><span class="pv">$33,018<small>45% above HS</small></span></div>
+      <div class="peerrow me"><span class="pn">Atlanta Tech</span><div class="peertrack"><i style="width:67%"></i></div><span class="pv">$30,350<small>37% above HS</small></span></div>
+      <div class="peerrow"><span class="pn">Coastal Pines Tech</span><div class="peertrack"><i style="width:67%"></i></div><span class="pv">$30,214<small>41% above HS</small></span></div>
+    </div>
+    <div class="callout">
+      <svg class="ic" style="width:17px;height:17px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+      <p>These are <b>college-wide</b> earnings (every program combined), not Accounting specifically — useful for comparing colleges, but a high-paying program at a lower-ranked college can beat the average. Use it as a signal, not a verdict.</p>
+    </div>
+    <div class="src">Source: College Scorecard, median earnings 10 yrs after entry. 22 GA colleges in dataset; 7 shown.</div>
+  </div>
+
+  <div class="foot">
+    <span class="tag">Concept · outcomes &amp; compare</span> &nbsp; Inspired by College Scorecard (earnings distribution, cost-by-income, comparison), NerdWallet (money made plain-English + trustworthy framing), Niche (compare layout). <b>All figures on this page are real</b> — College Scorecard outcomes for Atlanta Technical College, real net-price-by-income bands, real GA statewide articulation counts, and real per-college earnings for 22 GA colleges. Honesty caveats (college-wide vs. major-specific earnings; "reviewed ≠ transfers") are surfaced inline rather than hidden.
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/prototypes/plan-to-outcome/concepts/home-search.html
+++ b/docs/prototypes/plan-to-outcome/concepts/home-search.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Search-first home — concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#f7faf9; --panel:#fff; --ink:#0f172a; --muted:#5b6573; --line:#e6ebf0; --line2:#d3dbe2;
+  --brand:#0d9488; --brand-strong:#0f766e; --brand-soft:#effbf8; --brand-tint:#cdeee8; --bright:#2dd4bf;
+  --warm:#f59e0b; --warm-soft:#fef3c7;
+  --good:#15803d; --good-bg:#dcfce7; --mid:#b45309; --mid-bg:#fef3c7;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:"Geist",system-ui,sans-serif;font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1120px;margin:0 auto;padding:0 26px}
+h1,h2,h3{margin:0;letter-spacing:-.025em;font-weight:700}
+.ic{stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round;display:inline-block;vertical-align:middle}
+a{color:var(--brand);text-decoration:none}
+/* nav */
+.nav{display:flex;align-items:center;justify-content:space-between;padding:18px 0}
+.brandmark{display:flex;align-items:center;gap:10px;font-weight:700;font-size:16px}
+.logo{width:30px;height:30px;border-radius:9px;background:var(--brand);color:#fff;display:flex;align-items:center;justify-content:center}
+.navlinks{display:flex;gap:22px;align-items:center;color:var(--muted);font-size:14px}
+.navlinks a:hover{color:var(--ink)}
+.btn{font-family:inherit;font-weight:600;border-radius:999px;cursor:pointer;border:none;display:inline-flex;align-items:center;gap:8px;transition:transform .12s,box-shadow .12s,background .12s}
+.btn.primary{background:var(--brand);color:#fff;padding:11px 18px;font-size:14px;box-shadow:0 10px 24px -12px rgba(13,148,136,.6)}
+.btn.primary:hover{background:var(--brand-strong);transform:translateY(-1px)}
+.btn.soft{background:#fff;color:var(--ink);border:1px solid var(--line2);padding:10px 16px;font-size:14px}
+.btn.soft:hover{border-color:var(--brand);color:var(--brand-strong)}
+/* hero with search-as-hero */
+.hero{text-align:center;padding:40px 0 18px}
+.eyebrow{display:inline-flex;align-items:center;gap:8px;color:var(--brand-strong);font-weight:600;font-size:13px;background:var(--brand-soft);border:1px solid var(--brand-tint);padding:6px 13px;border-radius:999px;margin-bottom:18px}
+.hero h1{font-size:46px;line-height:1.05;letter-spacing:-.035em;font-weight:800;max-width:760px;margin:0 auto}
+.hero h1 em{font-style:normal;color:var(--brand);position:relative}
+.hero h1 em::after{content:"";position:absolute;left:0;right:0;bottom:3px;height:9px;background:var(--brand-tint);border-radius:6px;z-index:-1;opacity:.7}
+.hero .sub{font-size:17px;color:var(--muted);max-width:560px;margin:16px auto 26px}
+/* the search bar (airbnb pill) */
+.searchbar{display:flex;align-items:stretch;background:#fff;border:1px solid var(--line2);border-radius:999px;box-shadow:0 18px 44px -26px rgba(15,23,42,.4);max-width:760px;margin:0 auto;padding:6px 6px 6px 8px}
+.sfield{flex:1;display:flex;flex-direction:column;justify-content:center;padding:9px 18px;text-align:left;cursor:pointer;border-radius:999px}
+.sfield:hover{background:var(--brand-soft)}
+.sfield+.sfield{border-left:1px solid var(--line)}
+.sfield .lab{font-size:11px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--muted)}
+.sfield .val{font-size:15px;font-weight:600;color:var(--ink);display:flex;align-items:center;gap:7px;margin-top:1px}
+.sfield .val .ph{color:var(--muted);font-weight:500}
+.searchbar .go{align-self:center;margin-left:6px;width:48px;height:48px;border-radius:50%;background:var(--brand);color:#fff;border:none;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:0 0 auto;box-shadow:0 8px 18px -8px rgba(13,148,136,.7)}
+.searchbar .go:hover{background:var(--brand-strong)}
+/* category pills */
+.cats{display:flex;gap:9px;justify-content:center;flex-wrap:wrap;margin:20px auto 4px;max-width:720px}
+.cat{display:inline-flex;align-items:center;gap:7px;background:#fff;border:1px solid var(--line2);color:var(--ink);font-size:13px;font-weight:600;padding:8px 14px;border-radius:999px;cursor:pointer}
+.cat:hover{border-color:var(--brand);color:var(--brand-strong)}
+.cat.on{background:var(--brand);border-color:var(--brand);color:#fff}
+.cat .d{width:7px;height:7px;border-radius:50%;background:var(--bright)}
+/* results split (zillow map+list) */
+.results{display:grid;grid-template-columns:1.15fr .85fr;gap:18px;margin:34px 0 20px;align-items:start}
+.resbar{grid-column:1/-1;display:flex;align-items:center;justify-content:space-between;margin-bottom:2px}
+.resbar h2{font-size:19px}
+.resbar .filters{display:flex;gap:8px;flex-wrap:wrap}
+.fchip{display:inline-flex;align-items:center;gap:6px;background:#fff;border:1px solid var(--line2);font-size:12.5px;font-weight:600;padding:6px 12px;border-radius:999px;color:var(--muted);cursor:pointer}
+.fchip:hover{border-color:var(--brand);color:var(--brand-strong)}
+.fchip.on{background:var(--brand-soft);border-color:var(--brand-tint);color:var(--brand-strong)}
+.list{display:flex;flex-direction:column;gap:12px}
+.ccard{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:16px 16px 14px;box-shadow:0 1px 2px rgba(15,23,42,.04);transition:transform .15s,box-shadow .15s,border-color .15s;cursor:pointer}
+.ccard:hover{transform:translateY(-2px);box-shadow:0 18px 38px -26px rgba(15,118,110,.5);border-color:var(--brand-tint)}
+.ccard.real{border-color:var(--brand-tint);background:linear-gradient(180deg,#fff,var(--brand-soft))}
+.cc-top{display:flex;justify-content:space-between;align-items:flex-start;gap:10px}
+.cc-name{font-size:16px;font-weight:700;line-height:1.2}
+.cc-meta{color:var(--muted);font-size:12.5px;margin-top:2px;display:flex;align-items:center;gap:8px}
+.grade{flex:0 0 auto;text-align:center;border-radius:12px;padding:6px 10px;min-width:54px;background:var(--good-bg);color:var(--good)}
+.grade .g{font-size:20px;font-weight:800;line-height:1;letter-spacing:-.02em}
+.grade .gl{font-size:9.5px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;opacity:.8}
+.grade.b{background:#e0f2fe;color:#0369a1}.grade.c{background:var(--mid-bg);color:var(--mid)}
+.cc-stats{display:flex;gap:18px;margin-top:13px;flex-wrap:wrap}
+.cc-stat .n{font-size:16px;font-weight:800;letter-spacing:-.02em}
+.cc-stat .n.est{color:var(--brand)}
+.cc-stat .l{font-size:11px;color:var(--muted)}
+.illus{font-style:italic}
+.tagi{font-size:9px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:#94a3b8;border:1px solid var(--line2);border-radius:5px;padding:1px 4px;vertical-align:middle;margin-left:5px}
+.seat{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;color:var(--good);background:var(--good-bg);padding:3px 9px;border-radius:999px}
+.seat .d{width:7px;height:7px;border-radius:50%;background:#16a34a}
+/* fit meter (collegevine) */
+.fit{display:flex;align-items:center;gap:9px;margin-top:12px;padding-top:11px;border-top:1px solid var(--line)}
+.fitbar{flex:1;height:7px;border-radius:999px;background:var(--line);overflow:hidden}
+.fitbar i{display:block;height:100%;border-radius:999px;background:linear-gradient(90deg,var(--bright),var(--brand))}
+.fit .pct{font-size:12.5px;font-weight:700;color:var(--brand-strong)}
+.fit .fl{font-size:11.5px;color:var(--muted)}
+/* map panel (stylized, not a real map) */
+.mapwrap{position:sticky;top:14px;background:var(--panel);border:1px solid var(--line);border-radius:18px;overflow:hidden;box-shadow:0 1px 2px rgba(15,23,42,.04)}
+.maphead{display:flex;align-items:center;justify-content:space-between;padding:11px 14px;border-bottom:1px solid var(--line);font-size:12.5px;color:var(--muted);font-weight:600}
+.mapcanvas{position:relative;height:430px;background:
+  linear-gradient(0deg,rgba(13,148,136,.05),rgba(13,148,136,.05)),
+  repeating-linear-gradient(0deg,transparent 0 38px,rgba(15,23,42,.05) 38px 39px),
+  repeating-linear-gradient(90deg,transparent 0 38px,rgba(15,23,42,.05) 38px 39px),#f1f6f5}
+.road{position:absolute;background:#fff;opacity:.9}
+.pin{position:absolute;transform:translate(-50%,-100%);cursor:pointer}
+.pin .dot{width:26px;height:26px;border-radius:50% 50% 50% 2px;transform:rotate(45deg);background:var(--brand);box-shadow:0 6px 14px -6px rgba(13,148,136,.8);display:flex;align-items:center;justify-content:center}
+.pin .dot b{transform:rotate(-45deg);color:#fff;font-size:12px;font-weight:800}
+.pin.alt .dot{background:#fff;border:2px solid var(--brand)}
+.pin.alt .dot b{color:var(--brand)}
+.pin .lab{position:absolute;left:50%;top:30px;transform:translateX(-50%);white-space:nowrap;background:#fff;border:1px solid var(--line2);border-radius:7px;font-size:10.5px;font-weight:700;padding:2px 7px;box-shadow:0 4px 10px -6px rgba(15,23,42,.4)}
+.mapnote{position:absolute;left:10px;bottom:10px;background:rgba(255,255,255,.92);border:1px solid var(--line2);border-radius:8px;font-size:10px;color:var(--muted);padding:4px 8px;font-style:italic}
+.foot{color:var(--muted);font-size:12.5px;padding:26px 0 50px;border-top:1px solid var(--line);margin-top:8px}
+.tag{display:inline-block;background:var(--brand-soft);color:var(--brand-strong);border:1px solid var(--brand-tint);font-size:11px;font-weight:600;padding:3px 9px;border-radius:6px}
+@media(max-width:880px){.results{grid-template-columns:1fr}.mapwrap{display:none}.hero h1{font-size:34px}.searchbar{flex-wrap:wrap;border-radius:20px}.sfield+.sfield{border-left:none;border-top:1px solid var(--line)}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="nav">
+    <div class="brandmark"><div class="logo"><svg class="ic" style="width:17px;height:17px;stroke:#fff" viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2 2 5 2s5-1 5-2v-5"/></svg></div>Community College Path</div>
+    <div class="navlinks"><a href="#">Browse</a><a href="#">Transfer</a><a href="#">Outcomes</a><button class="btn soft">Sign in</button></div>
+  </div>
+
+  <!-- HERO: search is the hero -->
+  <div class="hero">
+    <span class="eyebrow"><svg class="ic" style="width:14px;height:14px" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg> Free · start by searching</span>
+    <h1>Find a class that <em>fits your life</em> and pays off.</h1>
+    <p class="sub">Tell us what you want to study and where. We'll show real colleges near you — with open seats, transfer paths, and what graduates earn.</p>
+
+    <div class="searchbar">
+      <div class="sfield">
+        <div class="lab">I want to study</div>
+        <div class="val"><svg class="ic" style="width:16px;height:16px;color:var(--brand)" viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2 2 5 2s5-1 5-2v-5"/></svg> Accounting</div>
+      </div>
+      <div class="sfield">
+        <div class="lab">Near</div>
+        <div class="val"><svg class="ic" style="width:16px;height:16px;color:var(--brand)" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> Atlanta, GA <span class="ph">· 30310</span></div>
+      </div>
+      <div class="sfield" style="flex:.7">
+        <div class="lab">Transfer to</div>
+        <div class="val"><span class="ph">Any university</span></div>
+      </div>
+      <button class="go" aria-label="Search"><svg class="ic" style="width:20px;height:20px;stroke:#fff" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg></button>
+    </div>
+
+    <div class="cats">
+      <span class="cat on"><span class="d"></span>Accounting</span>
+      <span class="cat">Nursing</span>
+      <span class="cat">IT &amp; Cybersecurity</span>
+      <span class="cat">Welding</span>
+      <span class="cat">Business</span>
+      <span class="cat">Early Childhood</span>
+      <span class="cat">Not sure yet →</span>
+    </div>
+  </div>
+
+  <!-- RESULTS: zillow map + list -->
+  <div class="results">
+    <div class="resbar">
+      <h2>5 colleges teach Accounting near 30310</h2>
+      <div class="filters">
+        <span class="fchip on"><svg class="ic" style="width:13px;height:13px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l3 2"/></svg> Seats open this term</span>
+        <span class="fchip">Evening / weekend</span>
+        <span class="fchip">Under $8k total</span>
+        <span class="fchip">Transfers to UWG</span>
+      </div>
+    </div>
+
+    <div class="list">
+      <!-- REAL college: Atlanta Technical College -->
+      <div class="ccard real">
+        <div class="cc-top">
+          <div>
+            <div class="cc-name">Atlanta Technical College <span class="seat" style="margin-left:6px"><span class="d"></span>18 seats open</span></div>
+            <div class="cc-meta"><svg class="ic" style="width:13px;height:13px" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> 3.1 mi · Accounting, A.S. · 60 credits</div>
+          </div>
+          <div class="grade"><div class="g">A−</div><div class="gl">Transfer</div></div>
+        </div>
+        <div class="cc-stats">
+          <div class="cc-stat"><div class="n est">$7,400</div><div class="l">Est. total cost <span class="tagi">2 yr</span></div></div>
+          <div class="cc-stat"><div class="n">$30k</div><div class="l">Median earnings, 10y</div></div>
+          <div class="cc-stat"><div class="n">4</div><div class="l">Universities accept credits</div></div>
+        </div>
+        <div class="fit">
+          <span class="fl">Fit for you</span>
+          <div class="fitbar"><i style="width:88%"></i></div>
+          <span class="pct">88% · strong match</span>
+        </div>
+      </div>
+
+      <!-- Illustrative comparators (real GA institutions, figures illustrative) -->
+      <div class="ccard">
+        <div class="cc-top">
+          <div>
+            <div class="cc-name">Georgia Piedmont Technical College <span class="seat" style="margin-left:6px"><span class="d"></span>seats open</span></div>
+            <div class="cc-meta"><svg class="ic" style="width:13px;height:13px" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> 9.4 mi · Accounting, A.S. · 60 credits</div>
+          </div>
+          <div class="grade b"><div class="g">B+</div><div class="gl">Transfer</div></div>
+        </div>
+        <div class="cc-stats">
+          <div class="cc-stat"><div class="n est illus">$7,900</div><div class="l illus">Est. total cost <span class="tagi">illustrative</span></div></div>
+          <div class="cc-stat"><div class="n illus">$29k</div><div class="l illus">Median earnings, 10y</div></div>
+          <div class="cc-stat"><div class="n illus">3</div><div class="l illus">Universities accept credits</div></div>
+        </div>
+        <div class="fit">
+          <span class="fl">Fit for you</span>
+          <div class="fitbar"><i style="width:74%"></i></div>
+          <span class="pct">74% · good match</span>
+        </div>
+      </div>
+
+      <div class="ccard">
+        <div class="cc-top">
+          <div>
+            <div class="cc-name">Atlanta Metropolitan State College</div>
+            <div class="cc-meta"><svg class="ic" style="width:13px;height:13px" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> 4.7 mi · Business / Accounting track</div>
+          </div>
+          <div class="grade b"><div class="g">B</div><div class="gl">Transfer</div></div>
+        </div>
+        <div class="cc-stats">
+          <div class="cc-stat"><div class="n est illus">$6,800</div><div class="l illus">Est. total cost <span class="tagi">illustrative</span></div></div>
+          <div class="cc-stat"><div class="n illus">$28k</div><div class="l illus">Median earnings, 10y</div></div>
+          <div class="cc-stat"><div class="n illus">3</div><div class="l illus">Universities accept credits</div></div>
+        </div>
+        <div class="fit">
+          <span class="fl">Fit for you</span>
+          <div class="fitbar"><i style="width:69%"></i></div>
+          <span class="pct">69% · good match</span>
+        </div>
+      </div>
+
+      <div class="ccard">
+        <div class="cc-top">
+          <div>
+            <div class="cc-name">Chattahoochee Technical College</div>
+            <div class="cc-meta"><svg class="ic" style="width:13px;height:13px" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> 18.2 mi · Accounting, A.S.</div>
+          </div>
+          <div class="grade c"><div class="g">B−</div><div class="gl">Transfer</div></div>
+        </div>
+        <div class="cc-stats">
+          <div class="cc-stat"><div class="n est illus">$7,600</div><div class="l illus">Est. total cost <span class="tagi">illustrative</span></div></div>
+          <div class="cc-stat"><div class="n illus">$31k</div><div class="l illus">Median earnings, 10y</div></div>
+          <div class="cc-stat"><div class="n illus">4</div><div class="l illus">Universities accept credits</div></div>
+        </div>
+        <div class="fit">
+          <span class="fl">Fit for you</span>
+          <div class="fitbar"><i style="width:62%"></i></div>
+          <span class="pct">62% · farther away</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- stylized map -->
+    <div class="mapwrap">
+      <div class="maphead"><span>Map view</span><span><svg class="ic" style="width:13px;height:13px;color:var(--brand)" viewBox="0 0 24 24"><path d="M12 21s-7-6-7-11a7 7 0 0114 0c0 5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg> 5 colleges</span></div>
+      <div class="mapcanvas">
+        <div class="road" style="left:0;right:0;top:46%;height:6px"></div>
+        <div class="road" style="left:0;right:0;top:72%;height:4px"></div>
+        <div class="road" style="top:0;bottom:0;left:38%;width:5px"></div>
+        <div class="road" style="top:0;bottom:0;left:67%;width:4px"></div>
+        <div class="road" style="left:10%;top:10%;width:55%;height:4px;transform:rotate(22deg);transform-origin:left"></div>
+        <div class="pin" style="left:40%;top:50%"><div class="dot"><b>1</b></div><div class="lab">Atlanta Tech · A−</div></div>
+        <div class="pin alt" style="left:67%;top:33%"><div class="dot"><b>2</b></div></div>
+        <div class="pin alt" style="left:50%;top:64%"><div class="dot"><b>3</b></div></div>
+        <div class="pin alt" style="left:79%;top:76%"><div class="dot"><b>4</b></div></div>
+        <div class="pin alt" style="left:22%;top:24%"><div class="dot"><b>5</b></div></div>
+        <div class="mapnote">Stylized map — geometry is illustrative, not to scale</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="foot">
+    <span class="tag">Concept · search-first home</span> &nbsp; Inspired by Airbnb (search-as-hero, category pills), Zillow (map+list split, the confident cost "estimate", filter chips), Niche (letter-grade badges), CollegeVine (fit meter). <b>Atlanta Technical College</b> figures are real GA / Accounting A.S. data; other colleges are real GA institutions but their cost / earnings / grade / fit figures are <span class="illus">illustrative</span> placeholders (flagged inline). The map is stylized, not geographic.
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/prototypes/plan-to-outcome/concepts/journey-dashboard.html
+++ b/docs/prototypes/plan-to-outcome/concepts/journey-dashboard.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Your path — dashboard concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#f7faf9; --panel:#fff; --panel2:#f8fafc; --ink:#0f172a; --muted:#5b6573; --line:#e6ebf0; --line2:#d3dbe2;
+  --brand:#0d9488; --brand-strong:#0f766e; --brand-soft:#effbf8; --brand-tint:#cdeee8; --bright:#2dd4bf;
+  --warm:#f59e0b; --warm-soft:#fef3c7; --good:#15803d; --good-bg:#dcfce7;
+  --glow:rgba(13,148,136,.18); --shadow:0 1px 2px rgba(15,23,42,.05);
+}
+:root[data-theme="dark"]{
+  --bg:#0a1413; --panel:#0f1f1d; --panel2:#13262300; --ink:#ecfdf8; --muted:#8aa39d; --line:#1c302d; --line2:#26423d;
+  --brand:#2dd4bf; --brand-strong:#5eead4; --brand-soft:#102826; --brand-tint:#1c403b; --bright:#5eead4;
+  --warm:#fbbf24; --warm-soft:#2a230f; --good:#4ade80; --good-bg:#10241a;
+  --glow:rgba(45,212,191,.22); --shadow:0 1px 2px rgba(0,0,0,.4);
+}
+*{box-sizing:border-box}
+body{margin:0;background:
+  radial-gradient(900px 380px at 80% -8%,var(--glow),transparent 60%),var(--bg);
+  color:var(--ink);font-family:"Geist",system-ui,sans-serif;font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased;min-height:100vh}
+.wrap{max-width:1020px;margin:0 auto;padding:0 26px}
+h1,h2,h3{margin:0;letter-spacing:-.025em;font-weight:700}
+.ic{stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round;display:inline-block;vertical-align:middle}
+.nav{display:flex;align-items:center;justify-content:space-between;padding:18px 0}
+.brandmark{display:flex;align-items:center;gap:10px;font-weight:700;font-size:16px}
+.logo{width:30px;height:30px;border-radius:9px;background:var(--brand);color:#04201c;display:flex;align-items:center;justify-content:center}
+.toggle{display:inline-flex;align-items:center;gap:7px;background:var(--panel);border:1px solid var(--line2);color:var(--muted);font-size:12.5px;font-weight:600;padding:8px 13px;border-radius:999px;cursor:pointer;font-family:inherit}
+.toggle:hover{color:var(--ink);border-color:var(--brand)}
+/* header */
+.dhead{padding:10px 0 6px}
+.dhead .kick{color:var(--brand-strong);font-weight:600;font-size:12.5px;letter-spacing:.04em;text-transform:uppercase}
+.dhead h1{font-size:34px;letter-spacing:-.03em;margin:6px 0 4px}
+.dhead .who{color:var(--muted);font-size:14.5px}
+/* hero row: ring + stat tiles */
+.hero{display:grid;grid-template-columns:300px 1fr;gap:18px;margin-top:18px}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:20px;box-shadow:var(--shadow)}
+.ringcard{padding:24px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;position:relative;overflow:hidden}
+.ringcard::after{content:"";position:absolute;width:240px;height:240px;border-radius:50%;background:radial-gradient(circle,var(--glow),transparent 70%);top:-60px;right:-80px}
+.ringwrap{position:relative;width:170px;height:170px}
+.ringwrap .ctr{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center}
+.ringwrap .ctr .big{font-size:38px;font-weight:800;letter-spacing:-.03em;line-height:1}
+.ringwrap .ctr .sm{font-size:12px;color:var(--muted);margin-top:3px}
+.ringcard .cap{margin-top:14px;font-size:13px;color:var(--muted)}
+.ringcard .cap b{color:var(--ink)}
+/* tiles */
+.tiles{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+.tile{padding:18px 20px;display:flex;flex-direction:column;gap:6px;position:relative;overflow:hidden}
+.tile .ti{width:36px;height:36px;border-radius:11px;background:var(--brand-soft);color:var(--brand);display:flex;align-items:center;justify-content:center}
+.tile .n{font-size:27px;font-weight:800;letter-spacing:-.03em;margin-top:6px}
+.tile .l{font-size:12.5px;color:var(--muted);line-height:1.4}
+.tile .spark{position:absolute;right:14px;bottom:12px;opacity:.85}
+.pill{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:700;padding:3px 9px;border-radius:999px;background:var(--good-bg);color:var(--good);align-self:flex-start}
+/* section title */
+.stitle{display:flex;align-items:center;gap:9px;font-size:16px;font-weight:700;margin:26px 0 12px}
+.stitle .ic{color:var(--brand)}
+.stitle .note{margin-left:auto;font-size:11.5px;color:var(--muted);font-weight:500;font-style:italic}
+/* timeline */
+.timeline{display:flex;gap:12px;overflow-x:auto;padding:2px 2px 8px}
+.term{flex:0 0 188px;background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:14px;box-shadow:var(--shadow)}
+.term.cur{border-color:var(--brand);box-shadow:0 0 0 1px var(--brand),0 16px 36px -24px var(--glow)}
+.term .th{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+.term .tn{font-weight:700;font-size:13.5px}
+.term .ts{font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:2px 8px;border-radius:999px}
+.ts.done{background:var(--good-bg);color:var(--good)}
+.ts.now{background:var(--brand-soft);color:var(--brand-strong)}
+.ts.next{background:var(--panel2);color:var(--muted);border:1px solid var(--line2)}
+.course{display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:9px;background:var(--panel2);border:1px solid var(--line);margin-bottom:6px;font-size:12px}
+.course:last-child{margin-bottom:0}
+.course .cc{font-weight:700}
+.course .cr{margin-left:auto;color:var(--muted);font-size:11px}
+.course .chk{width:15px;height:15px;color:var(--good)}
+.course.cur-c{border-color:var(--brand-tint);background:var(--brand-soft)}
+.term .sum{margin-top:9px;font-size:11px;color:var(--muted);text-align:right}
+/* bottom: trajectory + next class */
+.cols2{display:grid;grid-template-columns:1.25fr 1fr;gap:18px;margin-top:6px}
+.traj{padding:22px 24px}
+.traj h3{font-size:15px;margin-bottom:2px}
+.traj .d{font-size:12.5px;color:var(--muted)}
+.curvewrap{margin-top:14px}
+.bandlabel{display:flex;justify-content:space-between;font-size:11px;color:var(--muted);margin-top:8px}
+.range{margin-top:14px;display:flex;align-items:center;gap:12px}
+.range .rb{flex:1;height:10px;border-radius:999px;background:linear-gradient(90deg,#94a3b855,var(--brand));position:relative}
+.range .rb .dot{position:absolute;top:50%;width:16px;height:16px;border-radius:50%;background:var(--brand);border:3px solid var(--panel);transform:translate(-50%,-50%);box-shadow:0 0 0 1px var(--brand)}
+.range .lab{font-size:11px;color:var(--muted)}
+.nextc{padding:22px 24px;display:flex;flex-direction:column}
+.nextc h3{font-size:15px}
+.nextc .rec{margin-top:12px;border:1px solid var(--brand-tint);background:var(--brand-soft);border-radius:14px;padding:14px}
+.nextc .rec .cn{font-weight:800;font-size:15px}
+.nextc .rec .ct{color:var(--muted);font-size:12.5px;margin:2px 0 9px}
+.nextc .rec .meta{display:flex;gap:8px;flex-wrap:wrap}
+.mchip{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:3px 9px;border-radius:999px;background:var(--panel);border:1px solid var(--line2);color:var(--muted)}
+.mchip.ok{color:var(--good);border-color:var(--good)}
+.mchip.seat{color:var(--brand-strong);border-color:var(--brand-tint)}
+.btn{font-family:inherit;font-weight:600;border-radius:999px;cursor:pointer;border:none;display:inline-flex;align-items:center;justify-content:center;gap:8px;background:var(--brand);color:#04201c;padding:11px 16px;font-size:13.5px;margin-top:14px}
+:root:not([data-theme="dark"]) .btn{color:#fff}
+.foot{color:var(--muted);font-size:12.5px;padding:24px 0 50px;border-top:1px solid var(--line);margin-top:24px}
+.tag{display:inline-block;background:var(--brand-soft);color:var(--brand-strong);border:1px solid var(--brand-tint);font-size:11px;font-weight:600;padding:3px 9px;border-radius:6px}
+@media(max-width:820px){.hero{grid-template-columns:1fr}.tiles{grid-template-columns:1fr 1fr}.cols2{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="nav">
+    <div class="brandmark"><div class="logo"><svg class="ic" style="width:17px;height:17px;stroke:#04201c" viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2 2 5 2s5-1 5-2v-5"/></svg></div>Community College Path</div>
+    <button class="toggle" id="tt"><svg class="ic" style="width:15px;height:15px" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z"/></svg> <span id="ttl">Light</span></button>
+  </div>
+
+  <div class="dhead">
+    <div class="kick">Your path</div>
+    <h1>Accounting, A.S.</h1>
+    <div class="who">Atlanta Technical College · planning for Spring 2026</div>
+  </div>
+
+  <!-- HERO -->
+  <div class="hero">
+    <div class="card ringcard">
+      <div class="ringwrap">
+        <svg width="170" height="170" viewBox="0 0 170 170">
+          <circle cx="85" cy="85" r="68" fill="none" stroke="var(--line)" stroke-width="14"/>
+          <circle cx="85" cy="85" r="68" fill="none" stroke="var(--brand)" stroke-width="14" stroke-linecap="round"
+                  stroke-dasharray="427.3" stroke-dashoffset="318.9" transform="rotate(-90 85 85)"/>
+        </svg>
+        <div class="ctr"><div class="big">25%</div><div class="sm">17 / 67 credits</div></div>
+      </div>
+      <div class="cap"><b>5 courses</b> done · <b>50 credits</b> to go</div>
+    </div>
+
+    <div class="tiles">
+      <div class="card tile">
+        <div class="ti"><svg class="ic" style="width:19px;height:19px" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M3 9h18M8 2v4M16 2v4"/></svg></div>
+        <div class="n">≈ 4</div><div class="l">semesters to your degree, at your current pace</div>
+      </div>
+      <div class="card tile">
+        <div class="ti"><svg class="ic" style="width:19px;height:19px" viewBox="0 0 24 24"><path d="M3 17l6-6 4 4 7-8"/><path d="M21 7v5M21 7h-5"/></svg></div>
+        <div class="n">$30k</div><div class="l">median earnings graduates reach, 10 yrs after</div>
+      </div>
+      <div class="card tile">
+        <div class="ti"><svg class="ic" style="width:19px;height:19px" viewBox="0 0 24 24"><path d="M4 7h12M12 3l4 4-4 4"/><path d="M20 17H8M12 21l-4-4 4-4"/></svg></div>
+        <div class="n">4</div><div class="l">universities that accept your credits</div>
+        <span class="pill" style="margin-top:4px"><svg class="ic" style="width:11px;height:11px" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg> West Georgia: 25 count</span>
+      </div>
+      <div class="card tile">
+        <div class="ti"><svg class="ic" style="width:19px;height:19px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l3 2"/></svg></div>
+        <div class="n">18</div><div class="l">seats open in your recommended next class</div>
+        <span class="pill" style="margin-top:4px;background:var(--brand-soft);color:var(--brand-strong)">registration open now</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- TIMELINE -->
+  <div class="stitle"><svg class="ic" style="width:18px;height:18px" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg> Your semesters <span class="note">example plan — your real plan adapts as you check off courses</span></div>
+  <div class="timeline">
+    <div class="term">
+      <div class="th"><span class="tn">Fall 2025</span><span class="ts done">Done</span></div>
+      <div class="course"><svg class="ic chk" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg><span class="cc">FYES 1001</span><span class="cr">3</span></div>
+      <div class="course"><svg class="ic chk" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg><span class="cc">COMP 1000</span><span class="cr">3</span></div>
+      <div class="course"><svg class="ic chk" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg><span class="cc">BUSN 1440</span><span class="cr">4</span></div>
+      <div class="sum">10 credits</div>
+    </div>
+    <div class="term cur">
+      <div class="th"><span class="tn">Spring 2026</span><span class="ts now">Now</span></div>
+      <div class="course cur-c"><svg class="ic" style="width:15px;height:15px;color:var(--brand)" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 2"/></svg><span class="cc">ACCT 1100</span><span class="cr">4</span></div>
+      <div class="course cur-c"><svg class="ic" style="width:15px;height:15px;color:var(--brand)" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 2"/></svg><span class="cc">MKTG 1100</span><span class="cr">3</span></div>
+      <div class="sum">7 credits · in progress</div>
+    </div>
+    <div class="term">
+      <div class="th"><span class="tn">Summer 2026</span><span class="ts next">Planned</span></div>
+      <div class="course"><span class="cc">ACCT 1105</span><span class="cr">4</span></div>
+      <div class="course"><span class="cc">ACCT 1140</span><span class="cr">3</span></div>
+      <div class="sum">7 credits</div>
+    </div>
+    <div class="term">
+      <div class="th"><span class="tn">Fall 2026</span><span class="ts next">Planned</span></div>
+      <div class="course"><span class="cc">ACCT 1145</span><span class="cr">3</span></div>
+      <div class="course"><span class="cc">ACCT 2120</span><span class="cr">3</span></div>
+      <div class="course"><span class="cc">MGMT 1100</span><span class="cr">3</span></div>
+      <div class="sum">9 credits</div>
+    </div>
+    <div class="term">
+      <div class="th"><span class="tn">Spring 2027</span><span class="ts next">Planned</span></div>
+      <div class="course"><span class="cc">ACCT 2135</span><span class="cr">3</span></div>
+      <div class="course"><span class="cc">ACCT 2140</span><span class="cr">3</span></div>
+      <div class="course"><span class="cc">MGMT 1120</span><span class="cr">3</span></div>
+      <div class="sum">9 credits</div>
+    </div>
+  </div>
+
+  <!-- TRAJECTORY + NEXT CLASS -->
+  <div class="cols2">
+    <div class="card traj">
+      <h3>Where this is heading</h3>
+      <div class="d">Earnings range graduates of this program reach, 10 years after entry.</div>
+      <div class="curvewrap">
+        <svg width="100%" height="120" viewBox="0 0 400 120" preserveAspectRatio="none">
+          <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="var(--brand)" stop-opacity=".35"/><stop offset="1" stop-color="var(--brand)" stop-opacity="0"/>
+          </linearGradient></defs>
+          <path d="M0 110 C 90 108, 150 92, 210 64 C 270 36, 330 20, 400 12 L400 120 L0 120 Z" fill="url(#g)"/>
+          <path d="M0 110 C 90 108, 150 92, 210 64 C 270 36, 330 20, 400 12" fill="none" stroke="var(--brand)" stroke-width="2.5"/>
+          <circle cx="210" cy="64" r="4.5" fill="var(--brand)"/>
+        </svg>
+      </div>
+      <div class="bandlabel"><span>Start</span><span>Today</span><span>10 yrs out</span></div>
+      <div class="range">
+        <span class="lab">$14.5k</span>
+        <div class="rb"><span class="dot" style="left:58%"></span></div>
+        <span class="lab">$48.4k</span>
+      </div>
+      <div class="d" style="margin-top:8px">Median <b style="color:var(--brand-strong)">$30,350</b> · you're aiming above the midpoint by finishing the degree.</div>
+    </div>
+
+    <div class="card nextc">
+      <h3>Your best next class</h3>
+      <div class="rec">
+        <div class="cn">ACCT 1105</div>
+        <div class="ct">Financial Accounting II · 4 credits</div>
+        <div class="meta">
+          <span class="mchip ok"><svg class="ic" style="width:11px;height:11px" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg> prereq ACCT 1100 in progress</span>
+          <span class="mchip seat"><svg class="ic" style="width:11px;height:11px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/></svg> 18 seats open</span>
+          <span class="mchip">transfers to UWG</span>
+        </div>
+      </div>
+      <button class="btn">Add to Summer 2026 <svg class="ic" style="width:15px;height:15px;stroke:currentColor" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
+      <div class="d" style="font-size:11.5px;color:var(--muted);margin-top:10px">Picked because it unlocks the most later courses and keeps you on the 4-semester pace.</div>
+    </div>
+  </div>
+
+  <div class="foot">
+    <span class="tag">Concept · personal dashboard</span> &nbsp; Inspired by Flighty (premium dark, personal data made beautiful, timeline/recap), Apple (restraint, one focal number). Course codes, credits (67 total), earnings ($30,350 median; $14.5k–$48.4k range), seats (18), and transfer count (West Georgia: 25) are <b>real</b> Atlanta Tech / Accounting A.S. data. The <b>completed-credits state and semester layout are an illustrative example</b> of an in-progress student — the real version is driven by what you check off. Toggle light/dark, top-right.
+  </div>
+
+</div>
+<script>
+(function(){
+  var btn=document.getElementById('tt'), lbl=document.getElementById('ttl'), root=document.documentElement;
+  function sync(){var dark=root.getAttribute('data-theme')==='dark'; lbl.textContent=dark?'Light':'Dark';}
+  btn.addEventListener('click',function(){
+    root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark'); sync();
+  });
+  sync();
+})();
+</script>
+</body>
+</html>

--- a/docs/prototypes/plan-to-outcome/concepts/welcome-inspired.html
+++ b/docs/prototypes/plan-to-outcome/concepts/welcome-inspired.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Welcome — inspired concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#f7faf9; --panel:#fff; --ink:#0f172a; --muted:#5b6573; --line:#e6ebf0; --line2:#d3dbe2;
+  --brand:#0d9488; --brand-strong:#0f766e; --brand-soft:#effbf8; --brand-tint:#cdeee8; --bright:#2dd4bf;
+  --warm:#f59e0b; --warm-soft:#fef3c7;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:"Geist",system-ui,sans-serif;font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+.wrap{max-width:1080px;margin:0 auto;padding:0 28px}
+h1,h2,h3{margin:0;letter-spacing:-.025em;font-weight:700}
+.ic{stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round;display:inline-block;vertical-align:middle}
+a{color:var(--brand);text-decoration:none}
+/* nav */
+.nav{display:flex;align-items:center;justify-content:space-between;padding:20px 0}
+.brandmark{display:flex;align-items:center;gap:10px;font-weight:700;font-size:17px}
+.logo{width:32px;height:32px;border-radius:10px;background:var(--brand);color:#fff;display:flex;align-items:center;justify-content:center}
+.navlinks{display:flex;gap:24px;align-items:center;color:var(--muted);font-size:14px}
+.navlinks a:hover{color:var(--ink)}
+.btn{font-family:inherit;font-weight:600;border-radius:999px;cursor:pointer;border:none;display:inline-flex;align-items:center;gap:8px;transition:transform .12s ease,box-shadow .12s ease,background .12s}
+.btn.primary{background:var(--brand);color:#fff;padding:12px 20px;font-size:14px;box-shadow:0 10px 24px -12px rgba(13,148,136,.6)}
+.btn.primary:hover{background:var(--brand-strong);transform:translateY(-1px)}
+.btn.soft{background:#fff;color:var(--ink);border:1px solid var(--line2);padding:11px 18px;font-size:14px}
+.btn.soft:hover{border-color:var(--brand);color:var(--brand-strong)}
+/* hero */
+.hero{position:relative;display:grid;grid-template-columns:1.05fr .95fr;gap:30px;align-items:center;padding:46px 0 30px}
+.eyebrow{display:inline-flex;align-items:center;gap:8px;color:var(--brand-strong);font-weight:600;font-size:13px;background:var(--brand-soft);border:1px solid var(--brand-tint);padding:7px 14px;border-radius:999px;margin-bottom:22px}
+.hero h1{font-size:58px;line-height:1.03;letter-spacing:-.035em;font-weight:800}
+.hero h1 em{font-style:normal;color:var(--brand);position:relative}
+.hero h1 em::after{content:"";position:absolute;left:0;right:0;bottom:4px;height:10px;background:var(--brand-tint);border-radius:6px;z-index:-1;opacity:.7}
+.hero p{font-size:18.5px;color:var(--muted);max-width:480px;margin:20px 0 26px}
+.cta-row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.cta-note{color:var(--muted);font-size:13px;display:inline-flex;gap:7px;align-items:center}
+/* hero art: abstract shapes + a floating course-card preview */
+.art{position:relative;height:420px}
+.blob{position:absolute;border-radius:50%;filter:blur(2px)}
+.b1{width:300px;height:300px;right:-30px;top:10px;background:radial-gradient(circle at 30% 30%,#5eead4,#0d9488);opacity:.16}
+.b2{width:180px;height:180px;left:0;bottom:0;background:radial-gradient(circle at 30% 30%,#fcd34d,#f59e0b);opacity:.16}
+.ring{position:absolute;border:2px dashed var(--brand-tint);border-radius:50%}
+.r1{width:360px;height:360px;right:-10px;top:0}
+.float{position:absolute;background:#fff;border:1px solid var(--line);border-radius:16px;box-shadow:0 24px 50px -28px rgba(15,23,42,.4);padding:14px 16px}
+.f-course{right:30px;top:46px;width:230px}
+.f-course .top{display:flex;justify-content:space-between;align-items:center;font-weight:700;font-size:14px}
+.f-course .sub{color:var(--muted);font-size:12px;margin:3px 0 9px}
+.seatpill{display:inline-flex;align-items:center;gap:6px;background:#dcfce7;color:#15803d;font-size:11px;font-weight:600;padding:3px 9px;border-radius:999px}
+.seatpill .d{width:7px;height:7px;border-radius:50%;background:#16a34a}
+.f-stat{left:14px;top:182px;width:188px;display:flex;gap:10px;align-items:center}
+.f-stat .num{font-size:24px;font-weight:800;color:var(--brand)}
+.f-stat .lbl{font-size:11.5px;color:var(--muted);line-height:1.25}
+.f-transfer{left:24px;bottom:14px;width:210px}
+.f-transfer .row{display:flex;align-items:center;gap:8px;font-size:12px;padding:3px 0}
+.tickok{color:var(--brand);font-weight:800}
+/* logos / social proof */
+.proof{display:flex;align-items:center;gap:26px;flex-wrap:wrap;padding:10px 0 6px;color:var(--muted);font-size:13px;border-top:1px solid var(--line);margin-top:10px}
+.proof b{color:var(--ink)}
+.proof .logos{display:flex;gap:18px;opacity:.6;font-weight:700;letter-spacing:-.01em}
+/* how it works */
+.section{padding:64px 0}
+.section .kicker{color:var(--brand-strong);font-weight:600;font-size:13px;letter-spacing:.04em;text-transform:uppercase;text-align:center}
+.section h2{font-size:34px;text-align:center;margin:10px 0 6px;letter-spacing:-.03em}
+.section .lead{color:var(--muted);text-align:center;max-width:560px;margin:0 auto 40px;font-size:16px}
+.steps{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;position:relative}
+.stepc{background:var(--panel);border:1px solid var(--line);border-radius:18px;padding:22px;box-shadow:0 1px 2px rgba(15,23,42,.04)}
+.stepc .n{width:34px;height:34px;border-radius:10px;background:var(--brand-soft);color:var(--brand);display:flex;align-items:center;justify-content:center;font-weight:800;margin-bottom:14px}
+.stepc h3{font-size:16px;margin-bottom:4px}
+.stepc p{color:var(--muted);font-size:13px;margin:0;line-height:1.5}
+/* on-ramps */
+.ramps{display:grid;grid-template-columns:1.25fr 1fr 1fr;gap:16px}
+.ramp{background:var(--panel);border:1px solid var(--line);border-radius:20px;padding:24px;cursor:pointer;transition:transform .18s,box-shadow .18s;display:flex;flex-direction:column;gap:9px;box-shadow:0 1px 2px rgba(15,23,42,.04)}
+.ramp:hover{transform:translateY(-3px);box-shadow:0 22px 44px -28px rgba(15,118,110,.5)}
+.ramp.primary{border-color:var(--brand);background:linear-gradient(180deg,#fff,var(--brand-soft))}
+.ramp .chip{width:46px;height:46px;border-radius:14px;background:var(--brand-soft);color:var(--brand);display:flex;align-items:center;justify-content:center}
+.ramp h3{font-size:19px;margin-top:4px}
+.ramp p{color:var(--muted);font-size:13.5px;margin:0}
+.ramp .go{margin-top:auto;padding-top:8px;color:var(--brand-strong);font-weight:600;font-size:13.5px;display:inline-flex;gap:6px;align-items:center}
+.ramp.primary .go{color:#fff;background:var(--brand);align-self:flex-start;padding:9px 16px;border-radius:999px}
+/* quote */
+.quote{background:linear-gradient(135deg,#0f766e,#0d9488);color:#fff;border-radius:24px;padding:46px 48px;display:grid;grid-template-columns:1fr auto;gap:30px;align-items:center;position:relative;overflow:hidden}
+.quote::before{content:"";position:absolute;width:280px;height:280px;border-radius:50%;background:rgba(255,255,255,.07);right:-60px;top:-80px}
+.quote blockquote{margin:0;font-size:23px;line-height:1.4;font-weight:600;letter-spacing:-.01em;max-width:640px}
+.quote .who{margin-top:16px;font-size:14px;opacity:.85}
+.quote .big{text-align:center}
+.quote .big .n{font-size:46px;font-weight:800;letter-spacing:-.03em}
+.quote .big .l{font-size:13px;opacity:.85}
+.foot{color:var(--muted);font-size:12.5px;text-align:center;padding:40px 0 60px}
+.tag{display:inline-block;background:var(--brand-soft);color:var(--brand-strong);border:1px solid var(--brand-tint);font-size:11px;font-weight:600;padding:3px 9px;border-radius:6px}
+@media(max-width:860px){.hero{grid-template-columns:1fr}.art{display:none}.steps{grid-template-columns:1fr 1fr}.ramps{grid-template-columns:1fr}.quote{grid-template-columns:1fr}.hero h1{font-size:40px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="nav">
+    <div class="brandmark"><div class="logo"><svg class="ic" style="width:18px;height:18px;stroke:#fff" viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2 2 5 2s5-1 5-2v-5"/></svg></div>Community College Path</div>
+    <div class="navlinks"><a href="#">Colleges</a><a href="#">How it works</a><a href="#">Blog</a><button class="btn soft">Sign in</button></div>
+  </div>
+
+  <!-- HERO -->
+  <div class="hero">
+    <div>
+      <span class="eyebrow"><svg class="ic" style="width:15px;height:15px" viewBox="0 0 24 24"><path d="M12 3v18M3 12h18"/></svg> Free · no experience needed</span>
+      <h1>Plan college<br>that <em>actually pays off.</em></h1>
+      <p>See what to take, whether you can get a seat, whether it transfers, and where it leads — using real data from your community college. One step at a time.</p>
+      <div class="cta-row">
+        <button class="btn primary">Start planning <svg class="ic" style="width:16px;height:16px;stroke:#fff" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></button>
+        <button class="btn soft">Just show me what to take next</button>
+      </div>
+      <div class="cta-note" style="margin-top:14px"><svg class="ic" style="width:14px;height:14px;color:var(--brand)" viewBox="0 0 24 24"><path d="M5 12l5 5L20 7"/></svg> No account needed to explore</div>
+    </div>
+    <!-- abstract art + floating real-looking cards -->
+    <div class="art">
+      <div class="blob b1"></div><div class="blob b2"></div><div class="ring r1"></div>
+      <div class="float f-course">
+        <div class="top">ACCT 1100 <span style="color:var(--muted);font-weight:500;font-size:12px">4 cr</span></div>
+        <div class="sub">Financial Accounting I</div>
+        <span class="seatpill"><span class="d"></span>18 seats open</span>
+      </div>
+      <div class="float f-stat">
+        <div class="num">$30k</div><div class="lbl">median earnings,<br>10 years after</div>
+      </div>
+      <div class="float f-transfer">
+        <div style="font-weight:700;font-size:12px;margin-bottom:4px">Transfers to UWG</div>
+        <div class="row"><span class="tickok">✓</span> ACCT 1100 → ACCT 2101</div>
+        <div class="row" style="color:var(--muted)"><span style="color:#94a3b8;font-weight:800">≈</span> elective credit</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="proof">
+    <span>Real, up-to-date data from <b>50+ community colleges</b></span>
+    <span class="logos"><span>VCCS</span><span>TCSG</span><span>LACCD</span><span>Ivy&nbsp;Tech</span></span>
+  </div>
+
+  <!-- HOW IT WORKS -->
+  <div class="section">
+    <div class="kicker">How it works</div>
+    <h2>From "where do I start?" to a plan that fits your life.</h2>
+    <p class="lead">Four steps. No jargon. Built so a first-time college student can use it without help.</p>
+    <div class="steps">
+      <div class="stepc"><div class="n">1</div><h3>Plan</h3><p>See your program as classes you can take now — colored by whether seats are open this term.</p></div>
+      <div class="stepc"><div class="n">2</div><h3>Schedule</h3><p>Fit classes around work, across nearby colleges, on one weekly grid. We flag a conflict-free combo.</p></div>
+      <div class="stepc"><div class="n">3</div><h3>Transfer</h3><p>See which courses actually count toward a major at your target university — before you register.</p></div>
+      <div class="stepc"><div class="n">4</div><h3>Outcomes</h3><p>What it costs, how long it takes, and what graduates earn — shown honestly, with the gaps named.</p></div>
+    </div>
+  </div>
+
+  <!-- ON-RAMPS -->
+  <div class="section" style="padding-top:0">
+    <h2 style="font-size:28px">Start wherever you are</h2>
+    <p class="lead" style="margin-bottom:26px">Pick the door that fits — you can always change direction later.</p>
+    <div class="ramps">
+      <div class="ramp primary">
+        <div class="chip"><svg class="ic" style="width:22px;height:22px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg></div>
+        <h3>I know my major</h3><p>Plan it semester by semester, with seats and transfer built in.</p>
+        <span class="go">Start planning <svg class="ic" style="width:15px;height:15px;stroke:#fff" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </div>
+      <div class="ramp">
+        <div class="chip"><svg class="ic" style="width:22px;height:22px" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M15 9l-2 6-4 2 2-6z"/></svg></div>
+        <h3>Help me choose</h3><p>Tell us the kind of work you want; we'll match it to a program.</p>
+        <span class="go">Explore by interest <svg class="ic" style="width:15px;height:15px" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </div>
+      <div class="ramp">
+        <div class="chip"><svg class="ic" style="width:22px;height:22px" viewBox="0 0 24 24"><path d="M13 2L4 14h7l-1 8 9-12h-7z"/></svg></div>
+        <h3>What's next?</h3><p>Already enrolled — get a ready-to-register schedule for next term.</p>
+        <span class="go">Build next semester <svg class="ic" style="width:15px;height:15px" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- QUOTE / TRUST -->
+  <div class="quote">
+    <div>
+      <blockquote>"I had no idea which classes would transfer. I could finally see it before I wasted a semester — and what the degree actually pays."</blockquote>
+      <div class="who">— a first-generation student, the person this is built for</div>
+    </div>
+    <div class="big"><div class="n">37%</div><div class="l">of students out-earn a<br>typical high-school grad</div></div>
+  </div>
+
+  <div class="foot"><span class="tag">Inspired concept · welcome screen</span> &nbsp; Teal/Geist brand · airy hero with abstract shapes + floating real cards · "how it works" flow · social proof + student quote. Real GA / Atlanta Tech / Accounting data values.</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What this is (plain English)

A **design scratchpad** at `docs/prototypes/plan-to-outcome/concepts/` — self-contained HTML mockups exploring what the full student experience could look like, all in the real brand (teal + slate + Geist, line icons, light/dark). **Nothing here ships or is wired into the app.** Open **`index.html`** for a gallery that links every page, or use the shared top nav to move between them.

Users see nothing change from this PR; it's reference material the team reacts to while choosing a design direction.

## The pages

**Navigable journey set** (cross-linked; share `concept.css` + `concept-nav.js` + `concept-data.js`):

| Page | What it is | Data |
|---|---|---|
| `index.html` | Concept gallery / hub | — |
| `home-search.html` | Search-first home (Airbnb/Zillow): map+list, grade badges, fit meter | mixed (flagged) |
| `courses.html` | Course search — filters, section list, detail panel | **real** |
| `prereqs.html` | Visual prerequisite graph — moat #1 | **real** (verified edges) |
| `transfers.html` | Transfer pathway Sankey — moat #3 | **real** GA articulation |
| `schedule.html` | Multi-college schedule comparator — moat #2 | mixed (2nd college flagged) |
| `compare-outcomes.html` | Earnings / cost-by-income / peer compare | **all real** |
| `journey-dashboard.html` | Signed-in "your path" dashboard — moat #5 | mixed (flagged) |
| `us-map.html` | US tile-grid coverage map | **real audit grades** |

Plus `welcome-inspired.html` (earlier marketing-landing exploration).

## Honesty (important)

- `concept-data.js` carries the real, curated dataset: 20 Accounting courses, **hand-verified** prerequisite edges (an over-matching regex was pruned so the graph never shows a wrong dependency — a wrong prereq edge costs a student a semester), real section times/seats/instructors, real Georgia transfer rows, College Scorecard outcomes, and the **real per-state audit composite grades** (`docs/state-goals/_audit-snapshot.json`) coloring the map.
- The only illustrative data is the schedule comparator's *second* college (we don't have its sections yet) — clearly flagged inline; Atlanta Tech sections there are real. The home/dashboard/welcome pages flag their illustrative bits too. No fabricated data or social proof presented as real.

## Notes
- These share files, so browse them **served from the folder** (static server) so the relative `concept.*` includes resolve. The earlier home/outcomes/dashboard/welcome pages are also fully self-contained.
- Verified in-browser, light + dark, desktop + mobile.