### PR TITLE
feat(api): signal when ?term= was silently swapped for the current term

### DIFF
--- a/app/api/[state]/courses/search/route.ts
+++ b/app/api/[state]/courses/search/route.ts
@@ -56,14 +56,24 @@ export async function GET(request: NextRequest, context: RouteContext) {
   // (cached) and ignore unknown values so a stale or hand-typed code doesn't
   // produce empty results without explanation. Default to current term when
   // omitted, preserving existing behavior.
-  const termParam = searchParams.get("term")?.trim();
+  //
+  // The response signals the fallback explicitly via `requestedTerm` /
+  // `servedTerm` / `termFallback`. Until 2026-06-01 this fallback was
+  // silent: a student following a stale link with ?term=2027SU on a state
+  // with no 2027SU rows would see current-term results with no indication
+  // their requested term had been swapped. Exposing these fields lets the
+  // UI surface a "Spring 2027 had no listed sections — showing Fall 2026
+  // instead" note without changing the search behavior.
+  const termParamRaw = searchParams.get("term")?.trim();
+  const requestedTerm = termParamRaw && termParamRaw.length > 0 ? termParamRaw : null;
   let term: string;
-  if (termParam) {
+  if (requestedTerm) {
     const available = await getAvailableTerms(state);
-    term = available.includes(termParam) ? termParam : await getCurrentTerm(state);
+    term = available.includes(requestedTerm) ? requestedTerm : await getCurrentTerm(state);
   } else {
     term = await getCurrentTerm(state);
   }
+  const termFallback = requestedTerm !== null && requestedTerm !== term;
 
   const results = await searchCoursesAcrossColleges(
     term,
@@ -75,5 +85,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
     state
   );
 
-  return NextResponse.json(results);
+  return NextResponse.json({
+    ...results,
+    requestedTerm,
+    servedTerm: term,
+    termFallback,
+  });
 }

--- a/app/api/__tests__/courses-search.route.test.ts
+++ b/app/api/__tests__/courses-search.route.test.ts
@@ -12,6 +12,9 @@ vi.mock("@/lib/institutions", () => ({
 vi.mock("@/lib/terms", () => ({
   getCurrentTerm: vi.fn(async () => "2026SP"),
 }));
+vi.mock("@/lib/courses", () => ({
+  getAvailableTerms: vi.fn(async () => ["2026SP", "2026SU", "2026FA"]),
+}));
 vi.mock("@/lib/rate-limit", () => ({
   rateLimit: vi.fn(() => ({ allowed: true, remaining: 99 })),
   getClientKey: vi.fn(() => "ip:1.2.3.4"),
@@ -141,5 +144,43 @@ describe("GET /api/[state]/courses/search", () => {
     const body = await res.json();
     expect(body.totalSections).toBe(5);
     expect(body.totalColleges).toBe(3);
+  });
+
+  // Term-fallback signals (added 2026-06-01). Until this, an explicit
+  // ?term= that didn't match the state's available list was silently
+  // swapped for the current term — a student following a stale URL would
+  // get current-term results with no indication their term was changed.
+  describe("term fallback signal", () => {
+    it("omits requestedTerm when no ?term= is passed; termFallback false", async () => {
+      const { req, ctx } = makeRequest("va", { q: "ENG 111" });
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.requestedTerm).toBeNull();
+      expect(body.servedTerm).toBe("2026SP");
+      expect(body.termFallback).toBe(false);
+    });
+
+    it("honors an explicit ?term= that matches an available term", async () => {
+      const { req, ctx } = makeRequest("va", { q: "ENG 111", term: "2026FA" });
+      const res = await GET(req, ctx);
+      const body = await res.json();
+      expect(body.requestedTerm).toBe("2026FA");
+      expect(body.servedTerm).toBe("2026FA");
+      expect(body.termFallback).toBe(false);
+      // searchCoursesAcrossColleges received the requested term, not the default
+      expect(searchMock.mock.calls[0][0]).toBe("2026FA");
+    });
+
+    it("flags termFallback when ?term= isn't in the state's available list", async () => {
+      const { req, ctx } = makeRequest("va", { q: "ENG 111", term: "2099XX" });
+      const res = await GET(req, ctx);
+      const body = await res.json();
+      expect(body.requestedTerm).toBe("2099XX");
+      expect(body.servedTerm).toBe("2026SP");
+      expect(body.termFallback).toBe(true);
+      // Search was performed against the fallback term, not the rejected param
+      expect(searchMock.mock.calls[0][0]).toBe("2026SP");
+    });
   });
 });


### PR DESCRIPTION
## What changes for someone using the site

Today, if you visit `/api/{state}/courses/search?term=2027SU&q=english` for a state with no Summer 2027 data, you silently get current-term results — no indication the term you asked for was swapped. That's confusing for someone following a stale link or a shared URL. After this PR, the API response carries three new fields so the UI can later show a small "Spring 2027 had no listed sections — showing Fall 2026 instead" note. **No user-visible change yet** — this only opens the door; the UI surfacing is a separate PR.

## What changed (technical)

[app/api/\[state\]/courses/search/route.ts](app/api/%5Bstate%5D/courses/search/route.ts) was already gracefully falling back when an explicit `?term=` didn't match the state's `getAvailableTerms` list. That fallback was silent. This PR keeps the fallback (correct default) but adds the truth to the response shape:

```ts
{
  ...existingFields,
  requestedTerm: string | null,   // raw ?term= the caller passed, or null
  servedTerm:    string,          // term actually used for the search
  termFallback:  boolean,         // true iff requestedTerm !== servedTerm
}
```

The behavior change is **zero** — same fallback logic, just the signal is now exposed.

## How this came up

While verifying [#1045](https://github.com/rohan-c0de/cc-coursemap/pull/1045) (the `getCurrentTerm` horizon fix), I went looking for a "second bug" I thought I'd seen: identical `totalSections` counts across different `?term=` params for ct/ut/ar/nv on prod. Probing prod fresh, the cause turned out to be this silent fallback — not a separate bug. Documenting it via the response shape so a future UI can surface it cleanly.

## Test plan

- **Route tests**: 15/15 pass (3 new — no-term / valid-term / fallback-term).
- **Full vitest**: 428/428 pass, no regressions.
- **Typecheck**: clean.
- **Post-merge prod check**: `curl 'communitycollegepath.com/api/ct/courses/search?q=english&term=2027SP&limit=1'` should return `requestedTerm: "2027SP", servedTerm: "2026FA", termFallback: true`. The course rows in the body should be unchanged from before this PR.

## Not in this PR (separate work)

- The UI banner that surfaces `termFallback: true` to students — needs a small component change in the search results view; deliberately scoped out so reviewers see only the API shape.
- The `getCurrentTerm` horizon fix is in [#1045](https://github.com/rohan-c0de/cc-coursemap/pull/1045) (this PR is independent of that one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)