### PR TITLE
feat(ci): add prod smoke-test gate to catch silent prod regressions

### DIFF
--- a/.github/workflows/prod-health-check.yml
+++ b/.github/workflows/prod-health-check.yml
@@ -70,7 +70,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set +e
-          npm run check:prod-health > /tmp/probe-output.txt 2>&1
+          # Invoked via tsx directly rather than an npm script wrapper so
+          # this workflow has zero package.json coupling — adding a script
+          # entry to package.json is a separate convenience that doesn't
+          # belong on the critical path of "is prod alive."
+          npx tsx scripts/check-prod-health.ts > /tmp/probe-output.txt 2>&1
           code=$?
           cat /tmp/probe-output.txt
           # Persist for downstream issue body, regardless of pass/fail.

--- a/.github/workflows/prod-health-check.yml
+++ b/.github/workflows/prod-health-check.yml
@@ -1,0 +1,126 @@
+name: Prod health check
+
+# Smoke-tests production every 30 minutes to catch the silent-failure pattern
+# that broke us on 2026-06-01 (import pipeline froze for ~5.5h, scrapers kept
+# running, merges kept landing, nothing reached students). See
+# scripts/check-prod-health.ts for the specific checks.
+#
+# Failure handling is "one open issue at a time" — we don't want to flood
+# notifications when prod is down for an hour. The workflow:
+#   1. Runs the check (continue-on-error so we always reach the issue steps).
+#   2. On failure: if there's no open `prod-health-incident` issue, opens one
+#      with the run URL + check output. If one already exists, comments with
+#      "still failing as of X." Then fails the workflow run.
+#   3. On recovery: if there's an open incident, comments "recovered" and
+#      closes it. The workflow run succeeds.
+#
+# Tunable: PROD_BASE_URL, IMPORT_MAX_AGE_HOURS. Defaults in the script.
+
+on:
+  schedule:
+    # Every 30 minutes. The incident this guards against would be visible
+    # within 15-30 min — finer-grain polling burns API quota without much
+    # better detection time.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  # Need write on issues to open / comment / close the rolling incident.
+  issues: write
+  contents: read
+  # Read-only repo metadata so the script can hit GitHub's Actions API to
+  # check the import-on-merge last-success age.
+  actions: read
+
+# Don't pile up concurrent runs if a check is slow.
+concurrency:
+  group: prod-health-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+
+      # Idempotent — `|| true` swallows "label already exists." The first
+      # ever incident would otherwise fail trying to attach an undefined
+      # label and we'd lose the alert.
+      - name: Ensure prod-health-incident label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create prod-health-incident \
+            --color "B60205" \
+            --description "Auto-managed by .github/workflows/prod-health-check.yml" \
+            || true
+
+      - name: Run prod health check
+        id: probe
+        continue-on-error: true
+        env:
+          # The script's GitHub API call (import-age check) needs auth to
+          # avoid the 60 req/hr unauth limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          npm run check:prod-health > /tmp/probe-output.txt 2>&1
+          code=$?
+          cat /tmp/probe-output.txt
+          # Persist for downstream issue body, regardless of pass/fail.
+          {
+            echo "probe_exit=$code"
+            echo "probe_output<<EOF"
+            cat /tmp/probe-output.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $code
+
+      - name: Open / update incident issue on failure
+        if: steps.probe.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTPUT: ${{ steps.probe.outputs.probe_output }}
+        run: |
+          set -euo pipefail
+          issue_num=$(gh issue list --label prod-health-incident --state open --json number --jq '.[0].number // empty' || true)
+          body=$(cat <<EOF
+          Prod health check failed at $(date -u +%Y-%m-%dT%H:%M:%SZ).
+
+          Run: $RUN_URL
+
+          \`\`\`
+          $OUTPUT
+          \`\`\`
+          EOF
+          )
+          if [ -z "$issue_num" ]; then
+            gh issue create \
+              --label prod-health-incident \
+              --title "Prod health check failing — $(date -u +%Y-%m-%dT%H:%MZ)" \
+              --body "$body"
+          else
+            gh issue comment "$issue_num" --body "$body"
+          fi
+          # Re-propagate the failure so this run is marked red in the Actions tab.
+          exit 1
+
+      - name: Close incident on recovery
+        if: steps.probe.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          issue_num=$(gh issue list --label prod-health-incident --state open --json number --jq '.[0].number // empty' || true)
+          if [ -n "$issue_num" ]; then
+            gh issue comment "$issue_num" --body "Prod health recovered at $(date -u +%Y-%m-%dT%H:%M:%SZ). Closing this incident. Run: $RUN_URL"
+            gh issue close "$issue_num"
+          fi

--- a/scripts/check-prod-health.ts
+++ b/scripts/check-prod-health.ts
@@ -1,0 +1,203 @@
+/**
+ * Production smoke-test gate.
+ *
+ * Why this exists:
+ * On 2026-06-01 the merge -> Supabase import pipeline silently froze for ~5.5
+ * hours. Scrapers ran, PRs merged, scheduled-scrape jobs landed cleanly — and
+ * none of it reached students because import-on-merge.yml was timing out at
+ * the courses step. The CLAUDE.md "post-merge prod check" exists for exactly
+ * this case, but it's a manual habit. This script automates it.
+ *
+ * What it checks:
+ *   1. Production course-search returns a real (non-404, non-504) response
+ *      for a small set of representative states (mix of big/small/recently-
+ *      stranded). If any 504 or returns 0 sections, that's a finding.
+ *   2. The most recent import-on-merge run that actually completed has a
+ *      `success` conclusion AND happened recently enough (default: 6h). If
+ *      every recent run is `cancelled`/`failure`, that means data is queuing
+ *      up in the repo but not reaching Supabase — the exact incident shape.
+ *
+ * Exit code:
+ *   0  all checks passed
+ *   1  at least one check failed (the GH workflow turns this into a red
+ *      check run + opens / comments on a single rolling issue)
+ *
+ * The state list deliberately sticks to ~5 — enough to cover the failure
+ * modes we've actually seen (large-state 504, recently-stranded data, brand-
+ * new states, default state) without burning the 30/min rate limit. The
+ * import-age check is the cheaper and more important signal: it catches the
+ * silent-freeze pattern even if every probed state happens to be healthy.
+ */
+
+const PROD_BASE = process.env.PROD_BASE_URL ?? "https://communitycollegepath.com";
+const GH_REPO = process.env.GH_REPO ?? "rohan-c0de/cc-coursemap";
+const IMPORT_WORKFLOW_FILE = "import-on-merge.yml";
+const IMPORT_MAX_AGE_HOURS = Number(process.env.IMPORT_MAX_AGE_HOURS ?? "6");
+
+// Representative probe set. Picked to cover the failure modes we've actually
+// observed: ca = largest-state-by-data (504 risk), va = origin state (always
+// must work), nh = the 2026-06-01 horizon bug (regression guard for #1045),
+// ok = the 50k-transfer recovery (data-completeness regression guard), dc =
+// smallest-data state (catches edge cases that fail for "0 colleges" reasons).
+// Keep at ~5. Bigger = more rate-limit pressure with diminishing signal.
+const PROBE_STATES = ["ca", "va", "nh", "ok", "dc"];
+const PROBE_QUERY = "english";
+
+interface ProdProbeResult {
+  state: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface SearchResponse {
+  totalSections?: number;
+  totalCourses?: number;
+  servedTerm?: string;
+  error?: string;
+}
+
+async function probeState(state: string): Promise<ProdProbeResult> {
+  const url = `${PROD_BASE}/api/${state}/courses/search?q=${PROBE_QUERY}&limit=1`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 20_000);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { "User-Agent": "ccpath-prod-health/1.0" },
+    });
+    if (res.status === 504) {
+      return { state, ok: false, detail: `HTTP 504 (function timeout)` };
+    }
+    if (!res.ok) {
+      return { state, ok: false, detail: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as SearchResponse;
+    if (body.error) return { state, ok: false, detail: `error: ${body.error}` };
+    // 0 sections for "english" on any populated state strongly indicates the
+    // current-term resolution or the import pipeline is broken. We don't
+    // assert a minimum count — the canary is just "did we see ANYTHING."
+    if (!body.totalSections || body.totalSections === 0) {
+      return {
+        state,
+        ok: false,
+        detail: `0 sections for q=${PROBE_QUERY} (servedTerm=${body.servedTerm ?? "?"})`,
+      };
+    }
+    return {
+      state,
+      ok: true,
+      detail: `${body.totalSections} sections, term=${body.servedTerm ?? "?"}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { state, ok: false, detail: `fetch failed: ${msg}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface ImportAgeCheck {
+  ok: boolean;
+  detail: string;
+}
+
+async function checkImportAge(): Promise<ImportAgeCheck> {
+  const url = `https://api.github.com/repos/${GH_REPO}/actions/workflows/${IMPORT_WORKFLOW_FILE}/runs?per_page=20`;
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    "User-Agent": "ccpath-prod-health/1.0",
+    Accept: "application/vnd.github+json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, { headers });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, detail: `GitHub API fetch failed: ${msg}` };
+  }
+  if (!res.ok) {
+    return { ok: false, detail: `GitHub API HTTP ${res.status}` };
+  }
+  const json = (await res.json()) as {
+    workflow_runs?: Array<{
+      conclusion: string | null;
+      status: string;
+      created_at: string;
+      html_url: string;
+    }>;
+  };
+  const runs = json.workflow_runs ?? [];
+  // The new import-on-merge runs as a `plan` job that fans out to courses /
+  // transfers / programs. The OVERALL `runs` API gives us the umbrella run's
+  // conclusion. We accept `success` only — a `cancelled` or `failure` means
+  // at least one datatype didn't land. (Programs/transfers/courses each fall
+  // into the umbrella's conclusion via GH's job rollup.)
+  const lastSuccess = runs.find((r) => r.conclusion === "success");
+  if (!lastSuccess) {
+    return {
+      ok: false,
+      detail: `no successful import in last ${runs.length} runs (looked back ${runs.length} runs)`,
+    };
+  }
+  const ageMs = Date.now() - new Date(lastSuccess.created_at).getTime();
+  const ageHours = ageMs / (1000 * 60 * 60);
+  if (ageHours > IMPORT_MAX_AGE_HOURS) {
+    return {
+      ok: false,
+      detail: `last successful import was ${ageHours.toFixed(1)}h ago (threshold ${IMPORT_MAX_AGE_HOURS}h) — ${lastSuccess.html_url}`,
+    };
+  }
+  return {
+    ok: true,
+    detail: `last successful import ${ageHours.toFixed(1)}h ago`,
+  };
+}
+
+async function runProdHealthCheck() {
+  console.log(`prod health check — base=${PROD_BASE} repo=${GH_REPO}`);
+  console.log("");
+
+  // Sequential probes — keeps us well under the 30/min IP rate limit on the
+  // search route and produces interleaved logs that are easier to read.
+  const probeResults: ProdProbeResult[] = [];
+  for (const s of PROBE_STATES) {
+    const r = await probeState(s);
+    probeResults.push(r);
+    console.log(`  ${r.ok ? "OK " : "FAIL"} probe ${s}: ${r.detail}`);
+    // Brief throttle so we don't accidentally trip the 30/min limit when the
+    // workflow runs alongside other automation hitting prod.
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+
+  console.log("");
+  const importCheck = await checkImportAge();
+  console.log(
+    `  ${importCheck.ok ? "OK " : "FAIL"} import pipeline: ${importCheck.detail}`,
+  );
+
+  console.log("");
+  const failures = [
+    ...probeResults.filter((r) => !r.ok).map((r) => `probe ${r.state}: ${r.detail}`),
+    ...(importCheck.ok ? [] : [`import pipeline: ${importCheck.detail}`]),
+  ];
+  if (failures.length === 0) {
+    console.log(`PASS — ${probeResults.length} probes + import age check all green.`);
+    process.exit(0);
+  }
+  console.log(`FAIL — ${failures.length} issue(s):`);
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("prod-health-check crashed:", err);
+  process.exit(2);
+});
+
+// Make this file a module so its top-level interfaces and `main` function
+// don't pollute the global scope. Without this they collide with similarly-
+// named declarations in other `scripts/**` files (e.g. ProdProbeResult / main
+// in scripts/sc/discover-sc-systems.ts) under the project-wide tsc compile.
+export {};

--- a/scripts/check-prod-health.ts
+++ b/scripts/check-prod-health.ts
@@ -191,7 +191,7 @@ async function runProdHealthCheck() {
   process.exit(1);
 }
 
-main().catch((err) => {
+runProdHealthCheck().catch((err) => {
   console.error("prod-health-check crashed:", err);
   process.exit(2);
 });


### PR DESCRIPTION
## What changes for someone using the site

Nothing immediate — **this PR is insurance against the kind of incident we just lived through.** On 2026-06-01 the merge → Supabase import pipeline silently froze for ~5.5 hours: scrapers ran, PRs merged, GitHub Actions showed green-ish, and **none of the data reached students** because the courses-import step was timing out and the rebuild hook never fired. Nobody noticed until I went looking. This PR sets up an automated heartbeat that catches that exact failure mode within ~30 min instead of hours.

## What it does

- **[`scripts/check-prod-health.ts`](scripts/check-prod-health.ts)** probes `/api/{state}/courses/search?q=english` for 5 representative states (ca/va/nh/ok/dc) AND checks the [`import-on-merge.yml`](.github/workflows/import-on-merge.yml) last-success age via the GitHub API. Exits 1 on any failure.
- **[`.github/workflows/prod-health-check.yml`](.github/workflows/prod-health-check.yml)** runs the script every 30 minutes via cron (+ manual `workflow_dispatch`). On failure it opens or comments on a single rolling `prod-health-incident` GitHub issue so we don't flood notifications. On recovery it closes the issue.

## State picks

Deliberately small — bigger probe sets burn rate-limit without much extra signal:

| State | Why |
|---|---|
| ca | Largest-state-by-data — most likely 504 timeout |
| va | Origin state — must always work |
| nh | Regression guard for the [#1045](https://github.com/rohan-c0de/cc-coursemap/pull/1045) horizon fix (had stray-2027SU bug today) |
| ok | Regression guard for the [#997](https://github.com/rohan-c0de/cc-coursemap/pull/997) 50k transfer-mapping recovery |
| dc | Smallest-data state — catches edge cases that fail for "0 colleges" reasons |

The **import age check** is the more important signal — it would have caught today's incident on the first run even if every probed state happened to be healthy by accident.

## Verified locally against prod

```
$ npx tsx scripts/check-prod-health.ts
  OK  probe ca: 575 sections, term=2026FA
  OK  probe va: 67 sections, term=2026SU
  OK  probe nh: 22 sections, term=2027SP
  OK  probe ok: 178 sections, term=2026FA
  OK  probe dc: 3 sections, term=2026FA
  OK  import pipeline: last successful import 2.0h ago
PASS — 5 probes + import age check all green.
$ echo $?
0
```

(Notably the NH result — `term=2027SP`, 22 sections — confirms [#1045](https://github.com/rohan-c0de/cc-coursemap/pull/1045) is live in prod.)

## Two non-obvious notes

1. **Typecheck on this branch shows pre-existing errors** in `scripts/sc/discover-sc-systems.ts` and `scripts/lib/cluster-fingerprints.ts` (both have global `interface ProbeResult` declarations that merge with each other). Reproduced on origin/main with this PR's file removed — not caused by this PR. Worth a separate cleanup. My script uses uniquely-named types + `export {}` to stay out of the merge.
2. **The workflow invokes `npx tsx scripts/check-prod-health.ts` directly** rather than through an `npm run check:prod-health` wrapper. A wrapper was on the first commit but the package.json edit got reverted by a linter; the second commit removes the wrapper dependency entirely.

## After merge

The workflow runs every 30 min starting from the next cron tick. If anything goes red, you'll see a new issue labeled `prod-health-incident` appear. If you want to test the failure path before then, dispatch the workflow manually from the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)