### PR TITLE
fix(import): canonicalize term codes in the importer (durable fix)

### DIFF
--- a/scripts/import-courses.ts
+++ b/scripts/import-courses.ts
@@ -7,6 +7,7 @@
  * Usage:
  *   npx tsx scripts/import-courses.ts --state va
  *   npx tsx scripts/import-courses.ts --all
+ *   npx tsx scripts/import-courses.ts --state mi --dry-run   # preview, no writes
  */
 
 import { importCoursesToSupabase } from "./lib/supabase-import";
@@ -19,6 +20,7 @@ async function main() {
   const stateIdx = args.indexOf("--state");
   const isAll = args.includes("--all");
   const force = args.includes("--force");
+  const dryRun = args.includes("--dry-run");
 
   let states: string[];
   if (isAll) {
@@ -39,15 +41,21 @@ async function main() {
     return;
   }
 
-  console.log(`Importing courses for: ${states.join(", ")}`);
+  console.log(
+    `${dryRun ? "[DRY RUN] " : ""}Importing courses for: ${states.join(", ")}`
+  );
 
   let grandTotal = 0;
   for (const state of states) {
-    const count = await importCoursesToSupabase(state, { force });
+    const count = await importCoursesToSupabase(state, { force, dryRun });
     grandTotal += count || 0;
   }
 
-  console.log(`\nDone. Total: ${grandTotal} sections imported.`);
+  console.log(
+    dryRun
+      ? `\nDone (dry run — nothing written).`
+      : `\nDone. Total: ${grandTotal} sections imported.`
+  );
 }
 
 main().catch((err) => {

--- a/scripts/lib/__tests__/canonical-term.test.ts
+++ b/scripts/lib/__tests__/canonical-term.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   inferTermFromStartDates,
   resolveCanonicalTerm,
+  buildImportUnits,
   CANONICAL_TERM,
+  type RawTermFile,
 } from "../canonical-term";
 
 const row = (start_date: string | null) => ({ start_date });
@@ -79,5 +81,98 @@ describe("resolveCanonicalTerm", () => {
     expect(CANONICAL_TERM.test("2026FA")).toBe(true);
     expect(CANONICAL_TERM.test("2026WI")).toBe(false);
     expect(CANONICAL_TERM.test("FL26")).toBe(false);
+  });
+});
+
+const sec = (crn: string, start_date: string | null = "2026-08-20") => ({ crn, start_date });
+
+describe("buildImportUnits", () => {
+  // ---- Safety invariant: colleges with ANY canonical term are untouched ----
+
+  it("a canonical-only college gets one unit per file, term=stem, no rewriting", () => {
+    const files: RawTermFile[] = [
+      { stem: "2026FA", sections: [sec("100"), sec("101")] },
+      { stem: "2026SU", sections: [sec("200")] },
+    ];
+    const units = buildImportUnits(files);
+    expect(units).toHaveLength(2);
+    expect(units.map((u) => u.term)).toEqual(["2026FA", "2026SU"]);
+    expect(units.every((u) => u.canonicalized === false)).toBe(true);
+    // Same row arrays, untouched.
+    expect(units[0].sections).toHaveLength(2);
+    expect(units[1].sections).toHaveLength(1);
+  });
+
+  it("does NOT touch non-canonical files when a canonical one is present (WA 2027WI case)", () => {
+    // WA: canonical FA/SU/SP + a winter file. Winter must pass through under
+    // its raw stem, NOT be folded into 2027SP — that would clobber real spring.
+    const files: RawTermFile[] = [
+      { stem: "2026FA", sections: [sec("1")] },
+      { stem: "2027SP", sections: [sec("2", "2027-04-01")] },
+      { stem: "2027WI", sections: [sec("3", "2027-01-05")] }, // Jan dates -> would infer SP
+    ];
+    const units = buildImportUnits(files);
+    const byTerm = Object.fromEntries(units.map((u) => [u.term, u]));
+    expect(units).toHaveLength(3);
+    expect(byTerm["2027WI"]).toBeDefined();
+    expect(byTerm["2027WI"].canonicalized).toBe(false);
+    expect(byTerm["2027SP"].sections).toHaveLength(1); // not merged with winter
+  });
+
+  // ---- Fully-invisible colleges (no canonical file) get canonicalized ----
+
+  it("canonicalizes every file for a fully-invisible college", () => {
+    const files: RawTermFile[] = [
+      { stem: "FL26", sections: [sec("1", "2026-08-20")] },
+      { stem: "SU26", sections: [sec("2", "2026-06-10")] },
+    ];
+    const units = buildImportUnits(files);
+    const terms = units.map((u) => u.term).sort();
+    expect(terms).toEqual(["2026FA", "2026SU"]);
+    expect(units.every((u) => u.canonicalized)).toBe(true);
+    // rows carry through
+    expect(units.find((u) => u.term === "2026FA")!.sections).toHaveLength(1);
+  });
+
+  it("merges files that resolve to the same term and dedups by CRN (schoolcraft case)", () => {
+    const files: RawTermFile[] = [
+      { stem: "2026-02", sections: [sec("A", "2026-06-01"), sec("B", "2026-06-02")] },
+      { stem: "2026-03", sections: [sec("B", "2026-06-15"), sec("C", "2026-07-01")] }, // B dup
+      { stem: "2026-04", sections: [sec("D", "2026-09-01")] },
+    ];
+    const units = buildImportUnits(files);
+    const su = units.find((u) => u.term === "2026SU")!;
+    const fa = units.find((u) => u.term === "2026FA")!;
+    expect(su.sections.map((s) => (s as { crn: string }).crn).sort()).toEqual(["A", "B", "C"]); // B deduped
+    expect(fa.sections).toHaveLength(1);
+  });
+
+  it("keeps an unresolvable file under its raw stem (never lost, never guessed)", () => {
+    const files: RawTermFile[] = [
+      { stem: "FL26", sections: [sec("1", "2026-08-20")] },
+      { stem: "WEIRD", sections: [sec("2", null), sec("3", "TBA")] }, // no dates
+    ];
+    const units = buildImportUnits(files);
+    const byTerm = Object.fromEntries(units.map((u) => [u.term, u]));
+    expect(byTerm["2026FA"]).toBeDefined();
+    expect(byTerm["WEIRD"]).toBeDefined(); // preserved
+    expect(byTerm["WEIRD"].canonicalized).toBe(false);
+    expect(byTerm["WEIRD"].sections).toHaveLength(2);
+  });
+
+  it("does not collapse CRN-less rows together", () => {
+    const files: RawTermFile[] = [
+      { stem: "FL26", sections: [
+        { start_date: "2026-08-20" }, // no crn
+        { start_date: "2026-08-21" }, // no crn
+      ] },
+    ];
+    const units = buildImportUnits(files);
+    expect(units[0].term).toBe("2026FA");
+    expect(units[0].sections).toHaveLength(2); // both kept
+  });
+
+  it("handles an empty college", () => {
+    expect(buildImportUnits([])).toEqual([]);
   });
 });

--- a/scripts/lib/canonical-term.ts
+++ b/scripts/lib/canonical-term.ts
@@ -83,3 +83,75 @@ export function resolveCanonicalTerm(
   if (inf.term && inf.confidence >= minConfidence) return inf.term;
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Import-unit planning
+// ---------------------------------------------------------------------------
+
+export interface RawTermFile {
+  /** Filename without ".json" — the term as the scraper wrote it. */
+  stem: string;
+  sections: TermSection[];
+}
+
+export interface ImportUnit {
+  /** The term the rows should be stored under in Supabase. */
+  term: string;
+  sections: TermSection[];
+  /** True when `term` was rewritten from a non-canonical stem. */
+  canonicalized: boolean;
+}
+
+/**
+ * Decide what (term, rows) units a single college's course files should import
+ * as. This is the one place that turns "files on disk" into "rows keyed by
+ * term", so the importer's delete-then-insert can't clobber across files.
+ *
+ * Safety invariant: if the college has ANY canonical (`YYYYSP|SU|FA`) term
+ * file, behaviour is IDENTICAL to the legacy per-file path — one unit per file,
+ * term = filename stem, no grouping, no row rewriting. This means every college
+ * that already works (incl. ones with a canonical primary term plus extra
+ * winter / summer-sub-session files, e.g. WA's 2027WI) is completely
+ * unaffected.
+ *
+ * Only FULLY-INVISIBLE colleges — zero canonical term files, so their entire
+ * catalog is hidden from search — get canonicalized: each file's term is
+ * resolved from its rows' start_dates, files resolving to the same canonical
+ * term are merged (CRN-deduped) into one unit, and files that can't be resolved
+ * confidently keep their raw stem (never guessed, never lost).
+ */
+export function buildImportUnits(files: RawTermFile[]): ImportUnit[] {
+  const hasCanonical = files.some((f) => CANONICAL_TERM.test(f.stem));
+  if (hasCanonical) {
+    // Legacy behaviour, byte-for-byte: one unit per file, no rewriting.
+    return files.map((f) => ({
+      term: f.stem,
+      sections: f.sections,
+      canonicalized: false,
+    }));
+  }
+
+  // Fully-invisible college: resolve + group by canonical term.
+  const groups = new Map<string, Map<string, TermSection>>();
+  const order: string[] = [];
+  for (const f of files) {
+    const term = resolveCanonicalTerm(f.stem, f.sections) ?? f.stem;
+    let bucket = groups.get(term);
+    if (!bucket) {
+      bucket = new Map();
+      groups.set(term, bucket);
+      order.push(term);
+    }
+    f.sections.forEach((s, i) => {
+      const crn = (s as { crn?: unknown }).crn;
+      // CRN dedups across merged files; rows without a CRN are never collapsed.
+      const key = crn != null && String(crn).trim() ? String(crn) : `${f.stem}#${i}`;
+      bucket!.set(key, s);
+    });
+  }
+  return order.map((term) => ({
+    term,
+    sections: [...groups.get(term)!.values()],
+    canonicalized: CANONICAL_TERM.test(term),
+  }));
+}

--- a/scripts/lib/supabase-import.ts
+++ b/scripts/lib/supabase-import.ts
@@ -24,6 +24,7 @@ import {
   validateRows,
   isTransferHeaderRow,
 } from "../../lib/schemas";
+import { buildImportUnits, type RawTermFile } from "./canonical-term";
 
 const BATCH_SIZE = 500;
 
@@ -144,9 +145,10 @@ interface CourseRow {
  */
 export async function importCoursesToSupabase(
   state: string,
-  opts: { force?: boolean } = {}
+  opts: { force?: boolean; dryRun?: boolean } = {}
 ): Promise<number> {
   const force = !!opts.force;
+  const dryRun = !!opts.dryRun;
   let sb: SupabaseClient;
   try {
     sb = getSupabase();
@@ -177,13 +179,48 @@ export async function importCoursesToSupabase(
       .readdirSync(collegeDir)
       .filter((f) => f.endsWith(".json"));
 
+    // Read every term file, then resolve them into (term, rows) import units.
+    // For colleges with at least one canonical term file this is one unit per
+    // file with term = filename stem — identical to the legacy path. Only
+    // fully-invisible colleges (no canonical term at all) get their terms
+    // canonicalized + merged here, so they stop importing under terms search
+    // never queries. See buildImportUnits in lib/canonical-term.ts.
+    const rawFiles: RawTermFile[] = [];
     for (const file of termFiles) {
-      const term = file.replace(".json", "");
-      const filePath = path.join(collegeDir, file);
-      const raw = fs.readFileSync(filePath, "utf-8");
+      const raw = fs.readFileSync(path.join(collegeDir, file), "utf-8");
       const sections = JSON.parse(raw) as Array<Record<string, unknown>>;
+      if (sections.length === 0) continue;
+      rawFiles.push({ stem: file.replace(".json", ""), sections });
+    }
+    const units = buildImportUnits(rawFiles);
+    for (const u of units.filter((u) => u.canonicalized)) {
+      console.log(
+        `  CANONICALIZED ${slug}: -> ${u.term} (${u.sections.length} rows from non-canonical term file(s))`
+      );
+    }
+
+    for (const unit of units) {
+      const term = unit.term;
+      const sections = unit.sections as Array<Record<string, unknown>>;
 
       if (sections.length === 0) continue;
+
+      // Dry-run: show what WOULD change vs. what's in Supabase now, write
+      // nothing. Lets you preview the canonicalization against prod safely
+      // (npm run import:courses -- --state mi --dry-run).
+      if (dryRun) {
+        const { count } = await sb
+          .from("courses")
+          .select("id", { count: "exact", head: true })
+          .eq("state", state)
+          .eq("college_code", slug)
+          .eq("term", term);
+        const tag = unit.canonicalized ? " [canonicalized]" : "";
+        console.log(
+          `  [dry-run] ${slug}/${term}: existing ${count ?? 0} -> incoming ${sections.length}${tag}`
+        );
+        continue;
+      }
 
       // Change-detection preflight: if incoming is far below existing,
       // the scraper is probably broken. Abort unless --force. See issue #51.


### PR DESCRIPTION
> **Stacked on #1051** — its base is the `canonicalize-invisible-terms` branch, so this diff shows only the importer change. Merge #1051 first; GitHub will retarget this to `main` automatically.

## What changes for someone using the site

Nothing new to *see* — but it makes the visibility fixes **stick**. #1051 (and #1048/#1049) repaired the on-disk data for colleges whose courses were invisible due to odd term codes. But their scrapers still write those odd names (`FL26`, `26-FAL`, `2026-02`, …), so the *next* scheduled scrape would quietly hide them again. This moves the fix into the importer — the one place every scraper's data flows through — so it no longer matters what the scraper writes. Those colleges stay searchable permanently.

## How it works (and why it's safe)

New `buildImportUnits` in [`scripts/lib/canonical-term.ts`](scripts/lib/canonical-term.ts) turns a college's term files into `(term, rows)` import units:

- **Safety invariant:** a college with **any** canonical (`YYYYSP|SU|FA`) term file behaves *exactly* as before — one unit per file, term = filename stem, no grouping, no rewriting. So every already-working college is byte-for-byte unaffected. This includes the tricky case of WA, which has canonical `2026FA`/`2027SP` **plus** a `2027WI` winter file whose January start-dates would naïvely infer to Spring — it must **not** fold into `2027SP` and clobber real spring data. There's a dedicated test for exactly this.
- Only **fully-invisible** colleges (zero canonical terms) get canonicalized: term resolved from row `start_date`s, same-term files merged (CRN-deduped), unresolvable files kept under their raw stem (never guessed, never lost).

[`supabase-import.ts`](scripts/lib/supabase-import.ts) now reads all term files, builds units, then runs the **unchanged** change-detection / validate / delete-then-insert body per unit. Because canonical colleges produce identical units, their path is provably unchanged.

## Dry-run mode (new)

`npx tsx scripts/import-courses.ts --state mi --dry-run` prints, per `(college, term)`, existing-in-Supabase vs incoming counts plus the canonicalization plan, **writing nothing**. Lets you preview against prod before any write.

## Verification

- **`buildImportUnits` unit tests** (7 new): canonical-untouched invariant, the **WA `2027WI` no-clobber guard**, schoolcraft collision-merge with CRN-dedup, unresolved-file preservation, CRN-less rows not collapsed. Full suite **469 pass**, typecheck clean.
- **Dry-run against prod**, confirmed live:
  ```
  CANONICALIZED oglala-lakota-college: -> 2026FA (325 rows...)
  CANONICALIZED oglala-lakota-college: -> 2026SU (49 rows...)
  [dry-run] oglala-lakota-college/2026FA: existing 0 -> incoming 325 [canonicalized]
  [dry-run] southeast-technical-college/2026FA: existing 137 -> incoming 137   ← untouched (has canonical)
  Total for SD: 0 sections   (nothing written)
  ```

## Known limitation

Rows already in Supabase under old non-canonical terms (e.g. `FL26`) remain until overwritten — they're invisible to search (junk), harmless, and get cleaned as each college re-imports. A one-time orphan purge could follow but isn't needed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)