### PR TITLE
fix(schema): accept null schedule/detail fields so async-online sections import

### DIFF
--- a/lib/__tests__/schemas.test.ts
+++ b/lib/__tests__/schemas.test.ts
@@ -51,6 +51,32 @@ describe("CourseSectionSchema", () => {
     expect(CourseSectionSchema.safeParse(broken).success).toBe(false);
   });
 
+  it("accepts null detail/schedule fields (absent-by-design; coerced at import)", () => {
+    // An async-online section can legitimately have no meeting days/times/
+    // location/campus and no listed credits. Scrapers that emit null here
+    // used to trip the >5% abort and drop whole (college, term) sets (the AR
+    // cluster). row-prep coerces these to "" / 0 before insert.
+    const result = CourseSectionSchema.safeParse({
+      ...validCourseSection,
+      credits: null,
+      days: null,
+      start_time: null,
+      end_time: null,
+      location: null,
+      campus: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still rejects missing crn and course_title (real scraper bugs, not absent-by-design)", () => {
+    expect(
+      CourseSectionSchema.safeParse({ ...validCourseSection, crn: "" }).success
+    ).toBe(false);
+    expect(
+      CourseSectionSchema.safeParse({ ...validCourseSection, course_title: "" }).success
+    ).toBe(false);
+  });
+
   it("rejects negative credits", () => {
     const result = CourseSectionSchema.safeParse({
       ...validCourseSection,

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -27,16 +27,23 @@ export const CourseSectionSchema = z.object({
   course_prefix: z.string().min(1, "course_prefix required"),
   course_number: z.string().min(1, "course_number required"),
   course_title: z.string().min(1, "course_title required"),
-  credits: z.number().nonnegative("credits must be >= 0"),
+  // Detail fields that may be genuinely absent for a section (an async online
+  // class has no credits listed yet / no meeting days). Accept null — the
+  // importer coerces these to safe defaults (credits 0, days "") at row-prep
+  // (scripts/lib/supabase-import.ts). Before this, a scraper that emitted null
+  // here failed validation BEFORE the coercion ran, tripping the >5% abort
+  // and dropping the whole (college, term) — e.g. the AR cluster (cossatot,
+  // ozarka, national-park, …) imported 0 sections over null days/time fields.
+  credits: z.number().nonnegative("credits must be >= 0").nullable(),
   crn: z.string().min(1, "crn required"),
 
-  // Schedule fields — may legitimately be empty strings or "TBA".
-  days: z.string(),
-  start_time: z.string(),
-  end_time: z.string(),
+  // Schedule fields — may legitimately be empty strings, "TBA", or null.
+  days: z.string().nullable(),
+  start_time: z.string().nullable(),
+  end_time: z.string().nullable(),
   start_date: z.string().nullable().optional(),
-  location: z.string(),
-  campus: z.string(),
+  location: z.string().nullable(),
+  campus: z.string().nullable(),
 
   // Constrained vocabulary. Anything else means the scraper invented a mode.
   // `zoom` = synchronous remote class (distinct from asynchronous `online`).


### PR DESCRIPTION
## What changes for someone using the site

Several colleges currently show **zero courses** — not because their data is missing, but because the import safety-check rejected it. This unblocks them. The clearest cluster is in **Arkansas** (Cossatot, Ozarka, Phillips, NWACC, Rich Mountain, Batesville, National Park) — their scraper records online-async sections with no meeting days/times, and the importer was throwing out the *entire* college over it. After this, those colleges' courses import and become searchable.

## Why they were blocked

The import validates every row against `CourseSectionSchema`; if >5% fail, it aborts the whole `(college, term)` to avoid replacing good data with a broken scrape. The schema required `days`, `start_time`, `end_time`, `location`, `campus` to be strings and `credits` to be a number — but an async-online section legitimately has **none of those**, and those scrapers emit `null`. So validation failed *before* the importer's own row-prep step, which already coerces these to `""` / `0`.

## The fix

Make those six fields `.nullable()` in [`lib/schemas.ts`](lib/schemas.ts). Stored data is unchanged (row-prep still coerces null → `""` / `0`); we just stop rejecting rows for a legitimately-absent detail. **`crn` and `course_title` stay required** — a missing CRN or title is a real scraper bug (the IL city-colleges and FL clusters), not absent-by-design, and importing an empty CRN would be wrong.

## Impact — measured across all 1,730 on-disk `(college, term)` units

- **AR cluster fully unblocked**: Cossatot / Ozarka / Phillips go from **100% → 0%** invalid; National Park 2%. All now import.
- The entire `days`/`start_time`/`end_time`/`location` null-abort class is **eliminated**.
- **69 units still abort**, now only on genuinely-separate clusters — tracked as follow-ups:
  | remaining cluster | field | fix path |
  |---|---|---|
  | CA (contra-costa, diablo-valley, los-medanos, san-diego×3, …) | `mode: "unknown"` | mode-normalization (lossy; scraper infers better) |
  | IL city-colleges-of-chicago ×7, MO crowder/mineral-area | `crn` missing | scraper fix + re-scrape (data gone) |
  | FL broward, seminolestate | `course_title` missing | scraper fix + re-scrape |
  | CA foothill | `campus` (non-null bad type) | small scraper fix |
  | williamsburg, northeastern | `prerequisite_courses` | array-shape fix |

## Test plan

- +2 schema tests (null detail fields accepted; `crn`/`course_title` still required). Suite **22 pass**, typecheck clean.
- Validated against the full dataset (script run, not committed): the AR colleges flip from abort to import; no canonical college regresses.
- Post-merge: per-state imports for `ar` (and any other unblocked state) land via #1041 scoping; re-probe `/api/ar/courses/search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)