### PR TITLE
fix(search): push course search into Postgres (fixes CA 504) + trigram index

### DIFF
--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -1,6 +1,6 @@
 import type { CourseSection, Institution } from "./types";
 import { getZipCoordinates, calculateDistance } from "./geo";
-import { loadAllCourses } from "./courses";
+import { searchSections } from "./courses";
 
 // ---------------------------------------------------------------------------
 // Cross-college search
@@ -106,8 +106,12 @@ export async function searchCoursesAcrossColleges(
   totalSections: number;
   totalColleges: number;
 }> {
-  const allCourses = await loadAllCourses(term, state);
   const { prefix, number, keyword } = parseQuery(query);
+  // Push the query predicate into Postgres instead of loading every section
+  // for the term and filtering in JS (which 504'd on large states like CA,
+  // ~188k rows). The JS filters below still run on this already-narrowed set,
+  // so output is unchanged — just over 10s–1000s of rows.
+  const allCourses = await searchSections(term, state, { prefix, number, keyword });
 
   // Build institution lookup
   const instMap = new Map<string, Institution>();

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -384,6 +384,71 @@ export async function loadAllCourses(
   });
 }
 
+// Cap on sections returned by a single search. A course search groups sections
+// into courses and paginates COURSES, so even a broad prefix (e.g. "ENG"
+// resolves to ~dozens of distinct courses) never needs the full set. The cap
+// bounds the pathological keyword that matches tens of thousands of titles.
+const SEARCH_SECTION_CAP = 5000;
+const SEARCH_PAGE_SIZE = 1000;
+
+/**
+ * Push a course search down into Postgres: return ONLY the sections matching
+ * the parsed query (prefix / number / keyword), scoped to (state, term).
+ *
+ * Replaces the old "loadAllCourses(state, term) then filter in JS" path that
+ * pulled every section for the term — ~188k rows for CA — into the serverless
+ * function and 504'd on broad queries. With the predicate in SQL the planner
+ * uses idx_courses_state_term_prefix_number (code queries) / scans the ~30k
+ * (state, term) rows for an indexed ILIKE (keyword), returning the matching
+ * subset (typically 10s–1000s of rows).
+ *
+ * Returns [] when there is no predicate — callers (course search) always pass
+ * one because the route requires q.length >= 2 and parseQuery yields a
+ * prefix/number/keyword for any such input.
+ */
+export async function searchSections(
+  term: string,
+  state: string,
+  parsed: { prefix: string | null; number: string | null; keyword: string | null }
+): Promise<CourseSection[]> {
+  if (!parsed.prefix && !parsed.number && !parsed.keyword) return [];
+  return cached(
+    `search:${state}:${term}:${parsed.prefix ?? ""}:${parsed.number ?? ""}:${parsed.keyword ?? ""}`,
+    async () => {
+      const out: CourseSection[] = [];
+      const maxPages = Math.ceil(SEARCH_SECTION_CAP / SEARCH_PAGE_SIZE);
+      for (let i = 0; i < maxPages; i++) {
+        let q = supabase
+          .from("courses")
+          .select("*")
+          .eq("state", state)
+          .eq("term", term);
+        if (parsed.prefix) q = q.eq("course_prefix", parsed.prefix);
+        if (parsed.number) q = q.eq("course_number", parsed.number);
+        // ILIKE mirrors the previous JS `title.toLowerCase().includes(kw)`
+        // (case-insensitive substring). `%` is escaped so a literal % in the
+        // query can't widen the match.
+        if (parsed.keyword) {
+          const safe = parsed.keyword.replace(/[%_]/g, (m) => `\\${m}`);
+          q = q.ilike("course_title", `%${safe}%`);
+        }
+        const { data, error } = await q.range(
+          i * SEARCH_PAGE_SIZE,
+          i * SEARCH_PAGE_SIZE + SEARCH_PAGE_SIZE - 1
+        );
+        if (error) {
+          console.error(`searchSections page ${i} error:`, error.message);
+          break;
+        }
+        const rows = (data || []).map(mapRow);
+        out.push(...rows);
+        if (rows.length < SEARCH_PAGE_SIZE) break; // last page reached
+      }
+      return out;
+    }
+  );
+}
+
 /**
  * Slim section shape used only for the transfer-page courseAvailability
  * aggregation. Avoids hauling the full ~30-column CourseSection wire

--- a/supabase/migrations/021_courses_title_trgm.sql
+++ b/supabase/migrations/021_courses_title_trgm.sql
@@ -1,0 +1,25 @@
+-- 021_courses_title_trgm.sql
+--
+-- What: trigram GIN index on courses.course_title to accelerate keyword course
+--   search (`course_title ILIKE '%kw%'`), now that search pushes its predicate
+--   into Postgres (lib/courses.ts searchSections) instead of loading every
+--   section for a (state, term) and filtering in JS.
+--
+-- Why: the JS load-all path 504'd on large states (CA ~188k sections/term).
+--   The SQL pushdown alone fixes the timeout (code queries hit the existing
+--   idx_courses_state_term_prefix_number). Keyword queries still scanned the
+--   ~30k (state, term) rows for the ILIKE (~1-2s on CA). This trigram index
+--   lets the planner satisfy the ILIKE from the index (~100ms).
+--
+-- Caveats:
+--   - courses is large (~1M+ rows). CREATE INDEX CONCURRENTLY does not lock
+--     writes but CANNOT run inside a transaction — run this statement-by-
+--     statement (Supabase Dashboard SQL Editor, or one execute_sql call each),
+--     NOT wrapped in BEGIN/COMMIT.
+--   - Idempotent: IF NOT EXISTS on both the extension and the index.
+--   - pg_trgm is a standard Postgres extension (available on Supabase).
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_courses_title_trgm
+  ON courses USING gin (course_title gin_trgm_ops);


### PR DESCRIPTION
## What changes for someone using the site

**Course search stops timing out on big states.** Searching California — the largest catalog (~191k sections this term) — currently returns a server error for common queries like "accounting" or "biology"; students get nothing. After this, those searches return in well under a second.

## Why it was failing

`searchCoursesAcrossColleges` called `loadAllCourses(term, state)`, which pulled **every section for the term** into the serverless function (~191k rows for CA, ~190 paginated Supabase round-trips), then filtered by the query in JavaScript. Broad queries blew the function timeout → 504. (Verified on prod: `q=accounting` failed 3/3.)

## The fix — push the query into Postgres

New [`searchSections`](lib/courses.ts) puts the parsed query into the SQL `WHERE` (scoped to `state` + `term`):
- code query (`ENG`, `ENG 111`) → `.eq(course_prefix[, course_number])` — hits the existing `idx_courses_state_term_prefix_number`
- keyword (`accounting`) → `course_title ILIKE '%kw%'` — backed by a **new `pg_trgm` GIN index** (migration `021`)

`searchCoursesAcrossColleges` swaps `loadAllCourses` → `searchSections` and keeps **every** downstream step (mode/day/time filters, course grouping, distance sort, pagination) unchanged — so output is identical, just computed over 10s–1000s of rows instead of ~191k. `loadAllCourses` is untouched for its other callers (college insights, schedule builder).

## Verification (against prod Supabase — 1.26M rows, CA 190,953)

- `q=accounting`: **504 → 469 ms** wall-clock from my laptop. `EXPLAIN ANALYZE` confirms the trigram index is used (BitmapAnd with the state/term index) and **DB execution time is 197 ms** (the rest was my local network hop to us-east-2; the Vercel function runs in-region).
- **Correctness**: new `totalSections` equals the brute-force `loadAllCourses`-filter count (1072 == 1072) for `accounting`.
- `q=ENG` (prefix): 50 ms. Full test suite: **476 pass**, typecheck clean.

## Migration & rollout notes

- `supabase/migrations/021_courses_title_trgm.sql` — `CREATE EXTENSION pg_trgm` + `CREATE INDEX CONCURRENTLY idx_courses_title_trgm`. **Already applied to prod** (verified valid, 56 MB) — `CONCURRENTLY` is non-locking, so applying ahead of the code deploy is safe and means search is fast the instant this merges.
- Broad-keyword safety cap: 5,000 sections. Search paginates *courses* (not sections), so the cap never truncates a realistic result; it only bounds a pathological substring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)