### PR TITLE
fix(seat-watch): redact student emails from cron logs (PII)

### DIFF
--- a/scripts/seat-watch.ts
+++ b/scripts/seat-watch.ts
@@ -48,6 +48,18 @@ function log(msg: string, extra?: Record<string, unknown>) {
   }
 }
 
+/**
+ * Redact a user for logs. We must NEVER write a student's email address to
+ * these logs: this script runs in GitHub Actions, whose logs are retained
+ * ~90 days and readable by anyone with repo access. An email paired with the
+ * exact courses a student is planning is identifiable academic-intent data.
+ * Log a truncated, pseudonymous user_id instead — enough to correlate a run,
+ * useless as PII without service-role DB access (which the operator already has).
+ */
+function redactUser(userId: string | undefined): string {
+  return userId ? `user:${userId.slice(0, 8)}` : "user:unknown";
+}
+
 async function main() {
   log(`Starting seat-watch run (DRY_RUN=${DRY_RUN})`);
   const service = getServiceClient();
@@ -82,7 +94,7 @@ async function main() {
   if (DRY_RUN) {
     for (const n of notifications) {
       log("DRY_RUN would send:", {
-        to: n.user_email,
+        user: redactUser(n.user_id),
         course: n.course_code,
         plan: n.plan_name,
         seats: `${n.seats_open}/${n.seats_total ?? "?"}`,
@@ -124,14 +136,14 @@ async function main() {
         // Email already sent; ledger insert failed. Log loudly so an
         // operator can investigate, but don't crash the batch.
         console.error(
-          `[seat-watch] WARN: sent email but ledger insert failed for ${n.user_email} ${n.course_code}: ${error.message}`,
+          `[seat-watch] WARN: sent email but ledger insert failed for ${redactUser(n.user_id)} ${n.course_code}: ${error.message}`,
         );
       }
       sent++;
     } catch (e) {
       failed++;
       console.error(
-        `[seat-watch] ERROR sending to ${n.user_email} for ${n.course_code}:`,
+        `[seat-watch] ERROR sending to ${redactUser(n.user_id)} for ${n.course_code}:`,
         e instanceof Error ? e.message : e,
       );
     }


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible on the site — but this closes a **live privacy leak**. The seat-watch cron (which emails students when a watched class opens a seat) was writing students' **email addresses** into its logs — and in the dry-run path, right next to the **exact courses they're planning to take**. That cron runs every 6 hours in GitHub Actions, whose logs are retained ~90 days and are readable by anyone with repo access. An email tied to a student's course intent is identifiable academic data, so this was leaking student PII on every pass — and the cron is in dry-run *today*, so it's been leaking continuously.

## What changed technically

`scripts/seat-watch.ts` logged `n.user_email` in three places: the `DRY_RUN would send` line and both real-send error branches. This PR adds a `redactUser()` helper that logs a truncated, pseudonymous `user_id` (e.g. `user:1a2b3c4d`) instead. That's enough to correlate a run in the logs but useless as PII without the service-role DB access the operator already has.

The email is **still** passed to Resend for the actual send (`seat-watch.ts:115`) — that's delivery, not logging, and is unchanged.

This is item **P0-5** from the auth/accounts plan (#1067), pulled out as a standalone fix because it's leaking now and shouldn't wait on that review.

## Test plan

- `npm run typecheck` passes.
- `grep` confirms no `user_email` remains in any `console.*`/`log()` call; only the legitimate Resend send call references it.
- Behavior is otherwise byte-identical — only the log strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)