### PR TITLE
feat(security): security headers + Report-Only CSP + proxy SEO-safety test

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the cookie-touching session refresh so we can assert exactly WHEN it
+// runs. The whole point of this suite is the SEO-critical invariant: a public
+// / pSEO route must NEVER reach updateSession, because updateSession writes the
+// Supabase auth cookie, which flips an ISR response to
+// `Cache-Control: private` and silently kills the edge cache on ~200
+// prerendered pages. (See proxy.ts header comment.)
+const SESSION_SENTINEL = Symbol("updateSession-result");
+const updateSessionMock = vi.fn((_request?: unknown) => SESSION_SENTINEL);
+vi.mock("@/lib/supabase/middleware", () => ({
+  updateSession: (request: unknown) => updateSessionMock(request),
+}));
+
+// Deterministic registry: only "va" is a real state.
+vi.mock("@/lib/states/registry", () => ({
+  isValidState: (slug: string) => slug === "va",
+}));
+
+import { NextRequest } from "next/server";
+import { proxy } from "../proxy";
+
+function reqFor(path: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  updateSessionMock.mockClear();
+});
+
+describe("proxy()", () => {
+  it.each(["/va", "/va/colleges", "/va/course/bio-141", "/va/transfer"])(
+    "never touches cookies (no session refresh, no Set-Cookie) for pSEO route %s",
+    async (path) => {
+      const res = await proxy(reqFor(path));
+      expect(updateSessionMock).not.toHaveBeenCalled();
+      expect(res.headers.get("set-cookie")).toBeNull();
+    },
+  );
+
+  it("returns 404 for a malformed course code", async () => {
+    const res = await proxy(reqFor("/va/course/esl-42:"));
+    expect(res.status).toBe(404);
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unregistered state slug", async () => {
+    const res = await proxy(reqFor("/xx/colleges"));
+    expect(res.status).toBe(404);
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("lets a well-formed course code through", async () => {
+    const res = await proxy(reqFor("/va/course/bio-141"));
+    expect(res.status).toBe(200);
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["/account", "/api/account/delete", "/auth/callback"])(
+    "refreshes the session for auth route %s",
+    async (path) => {
+      await proxy(reqFor(path));
+      expect(updateSessionMock).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -124,6 +124,44 @@ const nextConfig: NextConfig = {
       { source: "/program/:slug", destination: "/va/program/:slug", permanent: true },
     ];
   },
+  async headers() {
+    // Baseline security headers applied to every route. These are STATIC
+    // (identical for every request, no per-user variation and no cookies), so
+    // they do NOT affect ISR/CDN cacheability — unlike anything that touches
+    // cookies, which would flip responses to `Cache-Control: private`. Setting
+    // them here (rather than in proxy.ts) keeps them off the SEO-sensitive
+    // proxy path entirely.
+    //
+    // Deliberately NOT included: Content-Security-Policy. A correct CSP must
+    // allowlist AdSense, Google Analytics, Supabase, and the font/CDN origins;
+    // shipping one blind would break the live site. CSP should be added later
+    // in Report-Only mode first, tuned against real traffic, then enforced.
+    const securityHeaders = [
+      // Stop browsers from MIME-sniffing a response away from its declared type.
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      // Send only the origin (not the full path/query) on cross-origin nav.
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      // Clickjacking protection. SAMEORIGIN (not DENY) since nothing embeds the
+      // site today; if a future partner-embed feature ships, swap this for a
+      // CSP `frame-ancestors` allowlist scoped to the embeddable pages and keep
+      // /account un-framable (its delete button is clickjacking-sensitive).
+      { key: "X-Frame-Options", value: "SAMEORIGIN" },
+      // Force HTTPS for 2 years. No `preload` (that's a near-irreversible
+      // browser-list commitment); includeSubDomains is safe — all hosts are
+      // HTTPS-only on Vercel.
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=63072000; includeSubDomains",
+      },
+      // Disable powerful APIs the site doesn't use (verified: no
+      // navigator.geolocation / camera / microphone usage in the app).
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+    ];
+    return [{ source: "/:path*", headers: securityHeaders }];
+  },
 };
 
 const withMDX = createMDX({});

--- a/next.config.ts
+++ b/next.config.ts
@@ -132,11 +132,41 @@ const nextConfig: NextConfig = {
     // them here (rather than in proxy.ts) keeps them off the SEO-sensitive
     // proxy path entirely.
     //
-    // Deliberately NOT included: Content-Security-Policy. A correct CSP must
-    // allowlist AdSense, Google Analytics, Supabase, and the font/CDN origins;
-    // shipping one blind would break the live site. CSP should be added later
-    // in Report-Only mode first, tuned against real traffic, then enforced.
+    // Content-Security-Policy is shipped in REPORT-ONLY mode. Report-Only
+    // never blocks anything — the browser only logs would-be violations to
+    // the console (and to report-uri/report-to if configured) — so it is safe
+    // to enable on production immediately. The point is to surface what a
+    // future ENFORCING policy would break BEFORE flipping it on, since a wrong
+    // enforcing CSP would break AdSense/GA/Supabase and take the site down.
+    //
+    // Allowlist derived from the actual third parties in the code:
+    //   - AdSense:   pagead2.googlesyndication.com (+ its ad-serving domains,
+    //                which are broad and may surface more in console reports)
+    //   - GA/gtag:   googletagmanager.com / google-analytics.com (+ an inline
+    //                gtag bootstrap → 'unsafe-inline' in script-src)
+    //   - Supabase:  *.supabase.co (connect-src, browser client)
+    //   - Fonts:     self-hosted via next/font → 'self' only, no CDN
+    // 'unsafe-inline'/'unsafe-eval' are present because Next's bootstrap and
+    // AdSense both need them; tightening to nonces is a later step once the
+    // report-only run confirms the rest of the allowlist is complete.
+    const cspReportOnly = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'self'",
+      "form-action 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://*.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://tpc.googlesyndication.com https://www.google.com https://adservice.google.com https://*.g.doubleclick.net",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://*.supabase.co https://*.google-analytics.com https://*.analytics.google.com https://*.googlesyndication.com https://pagead2.googlesyndication.com https://*.g.doubleclick.net",
+      "frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com https://*.googlesyndication.com",
+    ].join("; ");
+
     const securityHeaders = [
+      // CSP in Report-Only — observe violations in the console, tune, then
+      // promote to the enforcing `Content-Security-Policy` header in a follow-up.
+      { key: "Content-Security-Policy-Report-Only", value: cspReportOnly },
       // Stop browsers from MIME-sniffing a response away from its declared type.
       { key: "X-Content-Type-Options", value: "nosniff" },
       // Send only the origin (not the full path/query) on cross-origin nav.


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible in the UI — but every page now ships standard **security headers** (clickjacking, MIME-sniff, HTTPS pinning) plus a **Content-Security-Policy in Report-Only mode**, and a new test guarantees a future edit can't silently break the SEO caching the whole site depends on.

## What changed technically

**1. `next.config.ts` → `headers()`** adds six headers to every route:

| Header | Value | Why |
|---|---|---|
| `X-Content-Type-Options` | `nosniff` | Stop MIME-sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Don't leak full URLs cross-origin |
| `X-Frame-Options` | `SAMEORIGIN` | Clickjacking protection (esp. the account-delete button) |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | Force HTTPS for 2 years (no `preload` — near-irreversible) |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable APIs the app doesn't use (verified) |
| `Content-Security-Policy-Report-Only` | (allowlist below) | Observe what an enforcing CSP would block, without blocking |

All are **static** (no per-request variation, no cookies) so they don't affect ISR/CDN cacheability. Set in `next.config` rather than `proxy.ts` to keep them off the SEO-sensitive proxy path.

**The CSP ships in Report-Only on purpose.** Report-Only logs would-be violations to the browser console but **blocks nothing**, so it's safe on prod immediately. A wrong *enforcing* CSP would break AdSense / Google Analytics / Supabase and take the site down — so the plan is: observe console reports → tune the allowlist → promote to the enforcing `Content-Security-Policy` header in a follow-up. The allowlist was built from the actual third parties in the code (AdSense `pagead2.googlesyndication.com` + ad domains, GA `googletagmanager.com`/`google-analytics.com` + inline gtag, Supabase `*.supabase.co`, self-hosted `next/font`). `'unsafe-inline'`/`'unsafe-eval'` are present because Next's bootstrap and AdSense need them; tightening to nonces is part of the later enforcing step.

**2. `__tests__/proxy.test.ts`** — new 10-case regression suite pinning the proxy's SEO-critical invariant: the cookie-touching `updateSession` must **never** run on a public/pSEO route (it would flip those ISR responses to `Cache-Control: private` and kill the edge cache on ~200 prerendered pages). Also pins the malformed-course-code → 404 and unregistered-state → 404 behaviors. `proxy.ts` itself is unchanged — this locks in its current correct behavior.

Completes the **P0.5** security items from the auth plan ([#1067](https://github.com/rohan-c0de/cc-coursemap/pull/1067)).

## Test plan

- **Headers verified live**: booted a dev server from this branch and confirmed all six headers (incl. the full CSP-Report-Only allowlist) on real `GET /` and `GET /va` responses.
- **Proxy suite**: 10/10 pass.
- `npm run typecheck` clean, `eslint` clean.

## Follow-up (not in this PR)
Promote the CSP from Report-Only to enforcing once console reports confirm the allowlist is complete (watch for AdSense surfacing additional ad-serving domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)