### PR TITLE
perf(egress): cache transfers-by-university loader + lengthen cache TTL

### DIFF
--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -25,7 +25,13 @@ const SITEMAP_SUBJECTS: Record<string, Array<{ prefix: string; count: number }>>
 // In-memory cache (server-side, survives across requests in dev/prod)
 // ---------------------------------------------------------------------------
 
-const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+// 30 minutes. Course/transfer data is scraped ~3×/week (Mon/Wed/Fri), so a
+// short TTL bought no freshness — it just re-paginated Supabase on every warm
+// request, which was a major driver of the egress-quota overage (485/250 GB).
+// A longer TTL lets a warm serverless instance serve repeat (crawler) reads
+// from memory instead of re-querying Postgres. 30 min is well within the data's
+// real change cadence.
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 interface CacheEntry<T> {
   data: T;

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -111,6 +111,24 @@ export async function loadTransferMappingsByUniversity(
    */
   cap?: number
 ): Promise<TransferMapping[]> {
+  // Cache per (state, university, cap). This loader backs the force-dynamic
+  // /[state]/transfer route, so it previously re-paginated the transfers table
+  // on EVERY request (incl. every crawler hit) with no caching — it was the
+  // single heaviest egress source in the app (~13.4M calls, ~50% of DB egress;
+  // the 485/250 GB quota overage). Wrapping it in the shared in-memory cache
+  // (same pattern as getUniversitiesWithCounts) collapses repeat reads on a
+  // warm instance to one query per TTL window.
+  return cached(
+    `transfer-by-university:${state}:${university}:${cap ?? "all"}`,
+    () => _loadTransferMappingsByUniversity(state, university, cap),
+  );
+}
+
+async function _loadTransferMappingsByUniversity(
+  state: string,
+  university: string,
+  cap?: number
+): Promise<TransferMapping[]> {
   try {
     const allData: TransferMapping[] = [];
     let offset = 0;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — transfer and course results are identical. This fixes the **Supabase egress overage** that, left unchecked, would get the project Fair-Use-throttled after June 30 (which *would* take the live site down).

The Usage page showed **Egress at 485 / 250 GB (194%)** — the only metric over quota (compute and storage are fine, and there are only ~3 monthly active users). So the problem is **bytes flowing out of Postgres**, and Query Performance pinned the source: one query was **49.9% of all DB time at 13.4M calls** — `loadTransferMappingsByUniversity`, which pages the `transfers` table.

## Root cause

That loader backs the **`force-dynamic` `/[state]/transfer`** route but ran with **no caching** — every request (and with ~3 real users, that means *crawlers*) re-paginated the whole transfers table for a university. Bots hitting it across the site dumped hundreds of GB out of the DB.

## The fix (both shape-preserving — identical data returned)

1. **Cache `loadTransferMappingsByUniversity`** in the shared in-memory `cached()` helper, keyed by `(state, university, cap)` — the exact pattern the adjacent `getUniversitiesWithCounts` already uses. A warm instance now runs one query per TTL window instead of one per request.
2. **Raise `CACHE_TTL` 5 min → 30 min** (`lib/courses.ts`). Course/transfer data is scraped ~3×/week, so the 5-min TTL bought no real freshness — it just forced re-pagination on every warm request. Applies to all cached loaders (courses + transfers).

## Test plan

- **Feature check**: booted a dev server from this branch; `GET /api/va/transfer/mappings?university=vt` returns the same **1,411** mappings on repeat calls with correct shape — refactor preserves behavior.
- `npm run typecheck` clean, `eslint` clean.

## Follow-ups (deliberately not in this PR — keeping it a safe, focused change)
- Narrow the `courses` `select('*')` (4 spots in `lib/courses.ts`) to needed columns — cuts per-row egress.
- Consider `unstable_cache` / ISR for the transfer route so the cache is shared **across** serverless instances (the in-memory cache is per-instance, so cold starts still miss). This is the next lever if egress stays high after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)