### PR TITLE
fix(transfer): show best outcome per course×university in the comparator (not last-wins)

### DIFF
--- a/app/[state]/transfer/TransferCompare.tsx
+++ b/app/[state]/transfer/TransferCompare.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import type { TransferMapping } from "@/lib/types";
 import type { CCCourse, CompareFilters, UniversityScore, CellStatus } from "./compare/types";
-import { getCellInfo } from "./compare/types";
+import { getCellInfo, buildBestMappingLookup } from "./compare/types";
 import CompareFilterBar from "./compare/CompareFilterBar";
 import CompareScoreCard from "./compare/CompareScoreCard";
 import CompareTable from "./compare/CompareTable";
@@ -99,14 +99,12 @@ export default function TransferCompare({
       .filter(([, courses]) => courses.length > 0);
   }, [coursesByPrefix, searchQuery]);
 
-  const transferLookup = useMemo(() => {
-    const map = new Map<string, TransferMapping>();
-    for (const m of mappings) {
-      const key = `${m.cc_prefix} ${m.cc_number}|${m.university}`;
-      map.set(key, m);
-    }
-    return map;
-  }, [mappings]);
+  // Collapse one-to-many mappings to the best outcome per (course, university) —
+  // NOT last-wins, which silently downgrades cells (see buildBestMappingLookup).
+  const transferLookup = useMemo(
+    () => buildBestMappingLookup(mappings),
+    [mappings]
+  );
 
   const selectedCoursesList = useMemo(() => {
     return allCourses.filter((c) => selectedCourses.has(c.course));

--- a/app/[state]/transfer/compare/__tests__/types.test.ts
+++ b/app/[state]/transfer/compare/__tests__/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { buildBestMappingLookup, rankMapping, getCellInfo } from "../types";
+import type { TransferMapping } from "@/lib/types";
+import type { CCCourse } from "../types";
+
+function mk(partial: Partial<TransferMapping>): TransferMapping {
+  return {
+    cc_prefix: "ACCT",
+    cc_number: "1100",
+    cc_course: "ACCT 1100",
+    cc_title: "Financial Accounting I",
+    cc_credits: "4",
+    university: "uga",
+    university_name: "University of Georgia",
+    univ_course: "",
+    univ_title: "",
+    univ_credits: "",
+    notes: "",
+    no_credit: false,
+    is_elective: false,
+    ...partial,
+  };
+}
+
+const ACCT1100: CCCourse = { prefix: "ACCT", number: "1100", course: "ACCT 1100", title: "Financial Accounting I" };
+
+describe("rankMapping", () => {
+  it("orders direct > elective > no-credit", () => {
+    expect(rankMapping(mk({}))).toBeGreaterThan(rankMapping(mk({ is_elective: true })));
+    expect(rankMapping(mk({ is_elective: true }))).toBeGreaterThan(rankMapping(mk({ no_credit: true })));
+  });
+});
+
+describe("buildBestMappingLookup", () => {
+  it("keeps the best outcome per (course, university) regardless of array order (worst last)", () => {
+    // Real-world shape: one CC course maps to several university courses, with the
+    // WORST outcome last in the array — last-wins would wrongly show 'no-credit'.
+    const mappings = [
+      mk({ univ_course: "ACCT 2101", no_credit: false, is_elective: false }), // direct
+      mk({ univ_course: "ACCT 0XXX", is_elective: true }), // elective
+      mk({ univ_course: "", no_credit: true }), // no-credit (LAST)
+    ];
+    const cell = getCellInfo(ACCT1100, "uga", buildBestMappingLookup(mappings));
+    expect(cell.status).toBe("direct");
+    expect(cell.course).toBe("ACCT 2101");
+  });
+
+  it("upgrades no-credit to elective when an elective mapping exists", () => {
+    const mappings = [mk({ no_credit: true }), mk({ is_elective: true, univ_course: "X 1XXX" })];
+    const cell = getCellInfo(ACCT1100, "uga", buildBestMappingLookup(mappings));
+    expect(cell.status).toBe("elective");
+  });
+
+  it("keeps separate best entries per university", () => {
+    const mappings = [
+      mk({ university: "uga", no_credit: false, is_elective: false }), // direct at uga
+      mk({ university: "gatech", no_credit: true }), // no-credit at gatech
+    ];
+    const lookup = buildBestMappingLookup(mappings);
+    expect(lookup.size).toBe(2);
+    expect(getCellInfo(ACCT1100, "uga", lookup).status).toBe("direct");
+    expect(getCellInfo(ACCT1100, "gatech", lookup).status).toBe("no-credit");
+  });
+
+  it("is deterministic on ties — keeps the first direct mapping", () => {
+    const mappings = [
+      mk({ univ_course: "ACCT 2101" }), // direct (first)
+      mk({ univ_course: "ACCT 2102" }), // direct (second, same rank)
+    ];
+    const cell = getCellInfo(ACCT1100, "uga", buildBestMappingLookup(mappings));
+    expect(cell.course).toBe("ACCT 2101");
+  });
+
+  it("returns unknown for a course with no mapping", () => {
+    const cell = getCellInfo(ACCT1100, "uga", buildBestMappingLookup([]));
+    expect(cell.status).toBe("unknown");
+  });
+});

--- a/app/[state]/transfer/compare/types.ts
+++ b/app/[state]/transfer/compare/types.ts
@@ -63,3 +63,31 @@ export function getCellInfo(
     return { status: "elective", label: "~", course: m.univ_course, title: m.univ_title, credits: m.univ_credits, notes: m.notes || "" };
   return { status: "direct", label: "\u2713", course: m.univ_course, title: m.univ_title, credits: m.univ_credits, notes: m.notes || "" };
 }
+
+// Higher is better: direct (3) > elective (2) > no-credit (1).
+export function rankMapping(m: TransferMapping): number {
+  return m.no_credit ? 1 : m.is_elective ? 2 : 3;
+}
+
+/**
+ * Collapse one-to-many transfer mappings to the BEST outcome per (course, university).
+ *
+ * A single CC course can map to several university courses with different statuses
+ * (one row direct, another elective, another no-credit). The comparison cell must
+ * reflect the best a student can actually get \u2014 direct > elective > no-credit \u2014 NOT
+ * whichever row happened to be last in the array. A naive `map.set(key, m)` is last-wins
+ * and silently downgrades cells (e.g. shows "does not transfer" when a direct equivalent
+ * exists), which is exactly the kind of wrong transfer signal that can cost a student a
+ * semester. Ties keep the first matching row, so the result is deterministic.
+ */
+export function buildBestMappingLookup(
+  mappings: TransferMapping[]
+): Map<string, TransferMapping> {
+  const map = new Map<string, TransferMapping>();
+  for (const m of mappings) {
+    const key = `${m.cc_prefix} ${m.cc_number}|${m.university}`;
+    const existing = map.get(key);
+    if (!existing || rankMapping(m) > rankMapping(existing)) map.set(key, m);
+  }
+  return map;
+}


### PR DESCRIPTION
## What changes for someone using the site

On the **transfer comparison** (`/{state}/transfer`), a community-college course that maps to several university courses now shows the **best result a student can actually get** — instead of whichever data row happened to be last. Today the matrix sometimes shows "does not transfer" or "elective credit" for a course that has a **direct equivalent**, because the lookup was last-wins over one-to-many data.

Concrete impact (real data): **Georgia — 309 cells corrected** (e.g. `MGMT 1100 → Georgia Tech` now correctly shows a **direct** match instead of "elective"; in VA, `PSY 211 → UVA` would flip from "does not transfer" to direct). North Carolina 208, Virginia 14, Texas 34. The change is **strictly an upgrade** — it can only raise a cell to the true best status, never lower one (**0 downgrades** measured).

This also corrects everything derived from those cells: the per-university **best-fit ranking** + scores, problem-course flags, CSV export, and the mobile cards.

## Technical

`TransferCompare` built its lookup as `map.set(\`${course}|${university}\`, m)` — **last-wins**. Transfer mappings are one-to-many (a CC course → multiple university courses with differing `is_elective` / `no_credit`), so the final array row decided the cell. Replaced with `buildBestMappingLookup()` in `compare/types.ts`: collapse to the best outcome per `(course, university)` via `rankMapping` (direct 3 > elective 2 > no-credit 1), ties keep the first row (deterministic). Single point — all consumers read the same `Map`.

## Verification
- New unit tests (`compare/__tests__/types.test.ts`, 6 cases: worst-last order, upgrade no-credit→elective, per-university separation, tie determinism, unknown).
- All 35 transfer-suite tests pass; `tsc --noEmit` clean.
- Real-data repro: GA 309 cells improved / 0 downgraded; `MGMT 1100|gatech` elective→direct.
- No data-fetch or bundle change (pure client-side collapse logic).

## Known sibling (follow-up, not in scope)
The course-table / college-page transfer **badges** use a different builder (`buildTransferLookupForCourses`, array-per-course). Whether its consumers pick best-vs-last per university is a separate path worth a follow-up audit.

First Tier-A item from the productization audit (#1039 / #1074).