### PR TITLE
perf(egress): cross-instance cache for transfers + narrow courses select(*)

### DIFF
--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -69,6 +69,16 @@ export async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
   return promise;
 }
 
+// Exactly the columns `mapRow` reads to build a CourseSection — i.e. the full
+// CourseSection shape and nothing more. Replacing `select("*")` with this
+// projection drops every other column the `courses` table carries (ids,
+// scrape metadata, timestamps, etc.) from the wire, cutting per-row egress
+// with zero behavior change (those columns were already discarded by mapRow).
+// Egress reduction matters: wide `courses` reads were a secondary contributor
+// to the Supabase egress-quota overage (the transfers loader was the primary).
+const COURSE_COLUMNS =
+  "college_code, term, course_prefix, course_number, course_title, credits, crn, days, start_time, end_time, start_date, location, campus, mode, instructor, seats_open, seats_total, prerequisite_text, prerequisite_courses";
+
 /**
  * Load all course sections for a given college and term from Supabase.
  */
@@ -107,7 +117,7 @@ export async function loadCoursesForCollege(
       tasks.push(async () => {
         const { data, error } = await supabase
           .from("courses")
-          .select("*")
+          .select(COURSE_COLUMNS)
           .eq("college_code", collegeSlug)
           .eq("term", term)
           .eq("state", state)
@@ -370,7 +380,7 @@ export async function loadAllCourses(
       tasks.push(async () => {
         const { data, error } = await supabase
           .from("courses")
-          .select("*")
+          .select(COURSE_COLUMNS)
           .eq("term", term)
           .eq("state", state)
           .range(start, end);
@@ -426,7 +436,7 @@ export async function searchSections(
       for (let i = 0; i < maxPages; i++) {
         let q = supabase
           .from("courses")
-          .select("*")
+          .select(COURSE_COLUMNS)
           .eq("state", state)
           .eq("term", term);
         if (parsed.prefix) q = q.eq("course_prefix", parsed.prefix);
@@ -525,7 +535,7 @@ export async function loadCourseByCode(
   return cached(`course:${state}:${term}:${prefix}:${number}`, async () => {
     const { data, error } = await supabase
       .from("courses")
-      .select("*")
+      .select(COURSE_COLUMNS)
       .eq("state", state)
       .eq("term", term)
       .eq("course_prefix", prefix)
@@ -576,7 +586,7 @@ export async function loadCoursesBySubject(
         (async () => {
           const { data, error } = await supabase
             .from("courses")
-            .select("*")
+            .select(COURSE_COLUMNS)
             .eq("state", state)
             .eq("term", term)
             .eq("course_prefix", prefix)

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { unstable_cache } from "next/cache";
 import type { TransferMapping, TransferMappingClient } from "./types";
 import { supabase } from "./supabase";
 import { cached } from "./courses";
@@ -111,18 +112,36 @@ export async function loadTransferMappingsByUniversity(
    */
   cap?: number
 ): Promise<TransferMapping[]> {
-  // Cache per (state, university, cap). This loader backs the force-dynamic
-  // /[state]/transfer route, so it previously re-paginated the transfers table
-  // on EVERY request (incl. every crawler hit) with no caching — it was the
-  // single heaviest egress source in the app (~13.4M calls, ~50% of DB egress;
-  // the 485/250 GB quota overage). Wrapping it in the shared in-memory cache
-  // (same pattern as getUniversitiesWithCounts) collapses repeat reads on a
-  // warm instance to one query per TTL window.
+  // Two cache layers, both keyed by (state, university, cap):
+  //   1. in-memory `cached()` — intra-instance dedup + fast warm hits, and a
+  //      safety net for results too large for the cross-instance Data Cache's
+  //      ~2 MB item limit (huge universities), which unstable_cache silently
+  //      skips caching.
+  //   2. unstable_cache (below) — Vercel Data Cache, shared ACROSS serverless
+  //      instances so cold starts don't re-query Postgres. This is the gap the
+  //      in-memory-only cache (PR #1075) left: under crawler load Vercel spins
+  //      up many short-lived instances, each previously a fresh cache miss.
+  // This loader backs the force-dynamic /[state]/transfer route and was the
+  // single heaviest egress source (~13.4M calls, ~50% of DB egress — the
+  // 485/250 GB quota overage).
   return cached(
     `transfer-by-university:${state}:${university}:${cap ?? "all"}`,
-    () => _loadTransferMappingsByUniversity(state, university, cap),
+    () => _xInstanceTransfersByUniversity(state, university, cap),
   );
 }
+
+// Cross-instance persistent cache (Vercel Data Cache). revalidate 1800s (30m)
+// matches the in-memory CACHE_TTL and is well within the ~3×/week scrape
+// cadence. unstable_cache keys on the function arguments automatically; the
+// keyParts entry is just a stable namespace. Only the transfers loader gets
+// this — the courses loaders run inside build scripts (no Next cache context),
+// whereas this loader is only ever called from Next routes (verified).
+const _xInstanceTransfersByUniversity = unstable_cache(
+  (state: string, university: string, cap?: number) =>
+    _loadTransferMappingsByUniversity(state, university, cap),
+  ["transfer-by-university"],
+  { revalidate: 1800, tags: ["transfers"] },
+);
 
 async function _loadTransferMappingsByUniversity(
   state: string,


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — identical course and transfer results. This is the durable follow-up to [#1075](https://github.com/rohan-c0de/cc-coursemap/pull/1075) for the **Supabase egress overage** (485/250 GB). #1075 cached the worst query in-memory, but that cache is **per serverless instance** — under crawler load Vercel spins up many short-lived instances, so cold starts still re-queried Postgres. This closes that gap so the project stays under quota before the June 30 deadline (after which Fair-Use throttling would down the site).

## What changed technically

**1. Cross-instance cache for the transfers loader (`lib/transfer.ts`).** Wrapped `loadTransferMappingsByUniversity` — the #1 egress source (~50% of DB time, 13.4M calls) — in `unstable_cache` (Vercel's **Data Cache**, shared *across* instances), `revalidate: 1800` (30 min, well within the ~3×/week scrape cadence). It's layered *inside* the existing in-memory cache:
   - in-memory layer = intra-instance dedup + a safety net for results too big for the Data Cache's ~2 MB item limit (huge universities, which `unstable_cache` silently skips);
   - Data Cache layer = a cold-start instance now serves the cached result instead of re-paginating `transfers`.
   
   Only the transfers loader gets this — the `courses` loaders run inside build scripts (no Next cache context), whereas this one is only ever called from Next routes (verified). `unstable_cache` is still supported in Next 16 (the `use cache` directive that replaces it requires opting into experimental Cache Components project-wide — out of scope here).

**2. Narrowed `courses` `select("*")` (`lib/courses.ts`).** Replaced all 5 `select("*")` on the `courses` table with an explicit `COURSE_COLUMNS` projection = exactly the 19 columns `mapRow` reads to build a `CourseSection`. Drops every other table column (ids, scrape metadata, timestamps) from the wire — a pure per-row egress cut with **provably zero behavior change**, since those columns were already discarded after the fetch.

## Test plan

- **Feature checks on a dev server** (the narrowing is the risky part — a wrong column name would null a field):
  - `GET /api/va/courses/search?q=BIO` → sections return with **all fields populated** (title, credits, crn, dates, location, campus, mode, …) — no column-name regression.
  - `GET /api/va/transfer/mappings?university=vt` → same **1,411** mappings, all 13 fields, through the new `unstable_cache` layer.
- `npm run typecheck` clean, `eslint` clean.
- Note: the cross-instance benefit only materializes on Vercel (locally `unstable_cache` uses a file cache); correctness is verified, the egress reduction will show on the Usage graph after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)