### PR TITLE
fix(import): per-state concurrency so burst merges don't drop a state

### DIFF
--- a/.github/workflows/import-on-merge.yml
+++ b/.github/workflows/import-on-merge.yml
@@ -46,13 +46,21 @@ on:
 permissions:
   contents: read
 
-# Serialize so two near-simultaneous merges don't fight over Supabase.
-# cancel-in-progress stays false: an in-flight import must finish; GitHub
-# cancels only redundant *pending* runs, which is fine because each run
-# re-imports the full current state of whatever it was scoped to.
-concurrency:
-  group: import-on-merge
-  cancel-in-progress: false
+# Concurrency is declared PER IMPORT JOB (keyed by the scoped state list),
+# NOT here at the workflow level. See the burst-safety note above each import
+# job below.
+#
+# Why not a single workflow-level `group: import-on-merge`? It was that until
+# the 2026-06-02 incident. A single group serializes the WHOLE workflow, and
+# with cancel-in-progress: false GitHub keeps only the running run + the single
+# newest *pending* run, cancelling any older pending ones. That was harmless
+# under the old `--all` design (every run re-imported all 50 states, so the
+# survivor caught everything) but became data-losing once #1041 scoped each
+# run to only the state(s) changed in ITS merge: a burst of merges for
+# DIFFERENT states (#1064 il, #1065 mo, #1066 fl) cancelled the mo run, and no
+# other run ever planned mo, so mo never reached Supabase and had to be
+# re-imported by hand. Per-state job-level groups fix this — distinct states
+# get distinct groups and never cancel each other.
 
 env:
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -139,6 +147,25 @@ jobs:
   courses:
     needs: plan
     if: ${{ needs.plan.outputs.courses_states != '' }}
+    # Burst safety: group by the scoped state list rather than one global
+    # `import-on-merge` group. Two merges for DIFFERENT states (il, mo) get
+    # DIFFERENT groups (`import-courses-il`, `import-courses-mo`) and run in
+    # parallel — safe, because `import-courses.ts --state X` rewrites only
+    # state X's rows, so distinct states touch DISJOINT rows. Two merges for
+    # the SAME state collapse to one group and serialize (cancel-in-progress
+    # false → the in-flight run finishes; only a redundant *pending* run for
+    # the same state is dropped, and the survivor checks out the newer main
+    # which already contains both merges' data). This preserves the original
+    # "don't let two runs fight over the same Supabase rows" guarantee while
+    # no longer cancelling an unrelated state's only import.
+    # Residual edge: a single PR touching multiple states yields a multi-state
+    # group string (e.g. `import-courses-mo fl`); a concurrent `import-courses-il mo`
+    # would not serialize against it on the shared `mo` rows. Multi-state PRs
+    # are rare and the worst case is a transient last-writer-wins on mo that
+    # the next mo merge corrects — strictly better than today's silent drop.
+    concurrency:
+      group: import-courses-${{ needs.plan.outputs.courses_states }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     # Per-state pushes (the steady state) finish in seconds; this cap only
     # matters for the manual `--all` backfill path. The 2026-06-01 backfill
@@ -168,6 +195,10 @@ jobs:
   transfers:
     needs: plan
     if: ${{ needs.plan.outputs.transfers_states != '' }}
+    # Per-state concurrency group — see the courses job for the full rationale.
+    concurrency:
+      group: import-transfers-${{ needs.plan.outputs.transfers_states }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     # Same rationale as courses. The 2026-06-01 backfill cancelled at 45 min
     # mid-NY — MD alone took 22 min (122,925 mappings), NY 254,448 mappings
@@ -197,6 +228,10 @@ jobs:
   programs:
     needs: plan
     if: ${{ needs.plan.outputs.programs_states != '' }}
+    # Per-state concurrency group — see the courses job for the full rationale.
+    concurrency:
+      group: import-programs-${{ needs.plan.outputs.programs_states }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -234,6 +269,14 @@ jobs:
   rebuild:
     needs: [plan, courses, transfers, programs]
     if: ${{ always() && !cancelled() && needs.plan.outputs.any == 'true' }}
+    # A Vercel rebuild reads the FULL Supabase dataset (all states), so a burst
+    # of merges only needs the latest rebuild to fire — earlier ones are pure
+    # waste. Unlike the per-state import groups above, this group is shared and
+    # DOES cancel in-progress: the newest rebuild supersedes older ones and
+    # still publishes every state's freshly-imported rows.
+    concurrency:
+      group: import-rebuild
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel rebuild


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible changes on the site itself — this is an infra fix to the data-import pipeline. The user-facing payoff: when several states' data PRs merge close together, **every state's data now actually reaches the live site**. Today, a burst silently drops one of them, so that state keeps showing stale data until someone notices and re-imports it by hand. After this, no manual rescue needed.

Concretely: on **2026-06-02**, merging #1064 (il), #1065 (mo), #1066 (fl) within seconds of each other left **mo's import cancelled** — mo's fresh data never hit Supabase and had to be re-imported manually.

## What changed technically

The import workflow used one workflow-level concurrency group:

```yaml
concurrency:
  group: import-on-merge
  cancel-in-progress: false
```

With `cancel-in-progress: false`, GitHub keeps the running run plus only the **single newest pending** run and **cancels older pending runs**. That was harmless under the original `--all` design (any surviving run re-imported all 50 states). But PR #1041 scoped each run to only the state(s) changed in **its own merge diff** — so once mo's run is cancelled, *no other run ever plans mo*, and mo is lost.

**Fix — option (b): per-state job-level concurrency groups.** Concurrency moves from the workflow level onto the three import jobs, keyed by their scoped state list:

```yaml
concurrency:
  group: import-courses-${{ needs.plan.outputs.courses_states }}
  cancel-in-progress: false
```

- Distinct states (il, mo, fl) → distinct groups → run in parallel, never cancel each other.
- This is **safe** because `import-courses.ts --state X` rewrites only state X's rows — distinct states touch **disjoint rows**, so the original "don't let two runs fight over the same Supabase rows" guarantee is preserved exactly where it matters.
- Same-state merges → same group → still serialize (in-flight run finishes; only a redundant *pending* same-state run is dropped, and the survivor checks out the newer `main` which already contains both merges' data).

Job-level (not workflow-level) is **required**: workflow-level `concurrency` can't read `needs.*` job outputs, so the state list isn't available there.

Also dedups redundant Vercel rebuilds during a burst (`rebuild` gets a shared `import-rebuild` group with `cancel-in-progress: true`) — each rebuild reads the full dataset, so only the latest needs to fire.

### Known residual (documented in-code)
A single PR touching **multiple** states produces a multi-state group string (e.g. `import-courses-mo fl`), which wouldn't serialize against a concurrent `import-courses-il mo` on the shared `mo` rows. Multi-state PRs are rare; worst case is a transient last-writer-wins on mo that the next mo merge corrects — strictly better than today's silent drop.

## Test plan
- [x] `js-yaml` parses the workflow; confirmed workflow-level concurrency removed and all four job-level groups present with expected keys.
- [ ] After merge: merge two distinct-state data PRs in quick succession and confirm both import runs complete (neither cancelled) and both states' rows update in Supabase.

## Notes
- Based off `origin/main` (includes #1041/#1042); built in an isolated worktree.
- No script or data changes — workflow YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)