### PR TITLE
feat(search): classifier provider fallback (Groq → Cloudflare, no 503 on rate limit)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 #   anthropic  (default) | cloudflare | groq | ollama
 CLASSIFIER_PROVIDER=anthropic
 
+# Optional fallback provider, tried automatically when the primary errors
+# (e.g. Groq's free-tier 429 rate limit). Recommended pairing: primary=groq
+# (fast) + fallback=cloudflare (reliable). Set the chosen fallback's vars too.
+#   (unset) | cloudflare | groq | ollama | anthropic
+# CLASSIFIER_FALLBACK=cloudflare
+
 # Cloudflare Workers AI (CLASSIFIER_PROVIDER=cloudflare). Account ID from the
 # dashboard sidebar; token from My Profile → API Tokens with the "Workers AI"
 # (Read) permission. CF_MODEL is optional (defaults to llama-3.3-70b fp8-fast).

--- a/lib/search-intent/__tests__/classify-fallback.test.ts
+++ b/lib/search-intent/__tests__/classify-fallback.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { chain } from "../classify";
+import type { ClassifiedIntent } from "../types";
+
+const intent = (type: string): ClassifiedIntent => ({
+  intent: { type: "transfer", course: null, subjectPrefix: null, university: type } as never,
+  secondaryIntent: null,
+  confidence: 1,
+  studentSummary: type,
+  clarifyingQuestion: null,
+  sourceCollege: null,
+  suggestedFollowups: [],
+});
+
+describe("chain (provider fallback)", () => {
+  it("uses the primary when it succeeds and never calls the fallback", async () => {
+    const primary = vi.fn().mockResolvedValue(intent("primary"));
+    const fallback = vi.fn().mockResolvedValue(intent("fallback"));
+    const result = await chain(primary, fallback)("q", "va");
+    expect(result.studentSummary).toBe("primary");
+    expect(primary).toHaveBeenCalledOnce();
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the secondary when the primary throws (e.g. 429)", async () => {
+    const primary = vi.fn().mockRejectedValue(new Error("json-chat openai 429: rate limit"));
+    const fallback = vi.fn().mockResolvedValue(intent("fallback"));
+    const result = await chain(primary, fallback)("q", "va");
+    expect(result.studentSummary).toBe("fallback");
+    expect(primary).toHaveBeenCalledOnce();
+    expect(fallback).toHaveBeenCalledOnce();
+  });
+
+  it("propagates the fallback's error when BOTH fail (route → 503 → UI drops card)", async () => {
+    const primary = vi.fn().mockRejectedValue(new Error("primary down"));
+    const fallback = vi.fn().mockRejectedValue(new Error("fallback down"));
+    await expect(chain(primary, fallback)("q", "va")).rejects.toThrow("fallback down");
+  });
+
+  it("passes query + state through to whichever provider runs", async () => {
+    const primary = vi.fn().mockRejectedValue(new Error("x"));
+    const fallback = vi.fn().mockResolvedValue(intent("fb"));
+    await chain(primary, fallback)("prereqs for BIO 256", "nc");
+    expect(fallback).toHaveBeenCalledWith("prereqs for BIO 256", "nc");
+  });
+});

--- a/lib/search-intent/classify.ts
+++ b/lib/search-intent/classify.ts
@@ -21,16 +21,28 @@ export interface ClassifierWithOptions {
 }
 
 /**
- * Resolve the default LLM + cache namespace from `CLASSIFIER_PROVIDER`.
- *
- * Returns null for the implicit "anthropic" default (handled by the caller so
- * the Anthropic client is only constructed when actually used). The
- * `modelVersion` is part of the Supabase cache PRIMARY KEY, so switching
- * providers automatically starts a fresh cache namespace — and flipping back
- * reuses the old one. Cutover and rollback are a single env-var change.
+ * Try `primary`; if it throws (rate limit, timeout, network, bad response),
+ * fall back to `fallback`. Used to make a free-tier primary (e.g. Groq, whose
+ * RPM cap 429s under bursts) robust by retrying on a second provider instead of
+ * surfacing a 503. If BOTH fail, the original error from `fallback` propagates
+ * → the route 503s → the UI drops the answer card (graceful, unchanged).
  */
-function providerDefault(): { llm: Classifier; modelVersion: string } | null {
-  switch (process.env.CLASSIFIER_PROVIDER) {
+export function chain(primary: Classifier, fallback: Classifier): Classifier {
+  return async (query, state) => {
+    try {
+      return await primary(query, state);
+    } catch (err) {
+      console.warn(
+        `[classifier] primary failed (${err instanceof Error ? err.message.slice(0, 120) : "unknown"}); trying fallback`,
+      );
+      return fallback(query, state);
+    }
+  };
+}
+
+/** Build one provider's llm + cache namespace by name. Null = anthropic/unknown. */
+function buildProvider(name: string | undefined): { llm: Classifier; modelVersion: string } | null {
+  switch (name) {
     case "cloudflare": {
       const model = process.env.CF_MODEL ?? "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
       return {
@@ -81,6 +93,32 @@ function providerDefault(): { llm: Classifier; modelVersion: string } | null {
     default:
       return null; // anthropic — the existing Claude Haiku path
   }
+}
+
+/**
+ * Resolve the default LLM + cache namespace from `CLASSIFIER_PROVIDER`, with an
+ * optional `CLASSIFIER_FALLBACK` provider that's tried when the primary fails.
+ *
+ * Returns null for the implicit "anthropic" default (handled by the caller so
+ * the Anthropic client is only constructed when actually used). The
+ * `modelVersion` is part of the Supabase cache PRIMARY KEY, so switching
+ * providers starts a fresh cache namespace — and flipping back reuses the old
+ * one. Cutover and rollback are a single env-var change. (The cache namespaces
+ * by the PRIMARY's modelVersion; a fallback-produced result is cached there
+ * too, which is fine — both providers emit the same ClassifiedIntent shape.)
+ */
+function providerDefault(): { llm: Classifier; modelVersion: string } | null {
+  const primary = buildProvider(process.env.CLASSIFIER_PROVIDER);
+  if (!primary) return null;
+
+  const fallbackName = process.env.CLASSIFIER_FALLBACK;
+  if (fallbackName && fallbackName !== process.env.CLASSIFIER_PROVIDER) {
+    const fallback = buildProvider(fallbackName);
+    if (fallback) {
+      return { llm: chain(primary.llm, fallback.llm), modelVersion: primary.modelVersion };
+    }
+  }
+  return primary;
 }
 
 /** Compose a cache-backed classifier from injectable parts. */


### PR DESCRIPTION
## What changes for someone using the site

Makes the natural-language search **answer card** resilient. Right now, with Groq as the classifier, Groq's **free-tier rate limit** (429) makes the card occasionally 503 and disappear. With this, you set one env var (`CLASSIFIER_FALLBACK=cloudflare`) and a Groq failure **transparently retries on Cloudflare** instead — the student still gets the answer card. Only if *both* providers fail does it fall back to plain search (unchanged behavior). Invisible when Groq is healthy.

## How to enable (after merge)

In Vercel (Production), in addition to the Groq vars already set:
```
CLASSIFIER_FALLBACK = cloudflare
CF_ACCOUNT_ID       = <your account id>
CF_API_TOKEN        = <a Workers AI token>
```
Redeploy. Now: Groq answers most queries fast (~1–2s); when it's rate-limited, Cloudflare picks up (slower, ~7–31s, but a card beats no card) and the result is cached.

## Technical (`lib/search-intent/classify.ts`)

- `buildProvider(name)` — construct any provider (cloudflare/groq/ollama) by name.
- `chain(primary, fallback)` — try primary; on any throw (429/timeout/network/bad response), log and call fallback. If both throw, the error propagates → route 503 → UI drops the card (unchanged graceful path).
- `providerDefault()` wires `chain(primary, fallback)` when `CLASSIFIER_FALLBACK` is set and differs from the primary.
- Cache namespaces by the **primary's** `model_version`; a fallback-produced result caches there too — harmless, both providers emit the identical `ClassifiedIntent`.

### Test plan
- 4 new unit tests (`classify-fallback.test.ts`): primary-success doesn't call fallback; primary-throws falls back; both-fail propagates; query/state passed through. **58 search-intent tests pass; typecheck + lint clean.**
- **Verified end-to-end**: with a deliberately-invalid Groq key + valid Cloudflare creds, the primary 401'd, the fallback fired, and Cloudflare correctly returned `transfer / ENG 111 / gmu` for "Does ENG 111 transfer to GMU?".

Recommended pairing: `CLASSIFIER_PROVIDER=groq` (fast) + `CLASSIFIER_FALLBACK=cloudflare` (reliable). Builds on #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)