### PR TITLE
feat(search): fast fallback chain (Groq 120b → 20b → Cloudflare) for /ask

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,11 +23,14 @@ ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 #   anthropic  (default) | cloudflare | groq | ollama
 CLASSIFIER_PROVIDER=anthropic
 
-# Optional fallback provider, tried automatically when the primary errors
-# (e.g. Groq's free-tier 429 rate limit). Recommended pairing: primary=groq
-# (fast) + fallback=cloudflare (reliable). Set the chosen fallback's vars too.
-#   (unset) | cloudflare | groq | ollama | anthropic
-# CLASSIFIER_FALLBACK=cloudflare
+# Optional fallback chain, tried in order when the primary (then each prior
+# fallback) errors — e.g. Groq's free-tier 429. Comma-separated list of
+# `provider[:model]` specs. A `:model` override lets a fallback use a DIFFERENT
+# model: Groq's rate limits are PER-MODEL, so gpt-oss-120b → gpt-oss-20b dodges
+# the 429 in ~0.5s (vs slow Cloudflare). Recommended prod value:
+#   CLASSIFIER_FALLBACK=groq:openai/gpt-oss-20b,cloudflare
+# (fast Groq fallback first; Cloudflare only as a last resort, 12s fast-fail).
+# CLASSIFIER_FALLBACK=groq:openai/gpt-oss-20b,cloudflare
 
 # Cloudflare Workers AI (CLASSIFIER_PROVIDER=cloudflare). Account ID from the
 # dashboard sidebar; token from My Profile → API Tokens with the "Workers AI"
@@ -35,6 +38,9 @@ CLASSIFIER_PROVIDER=anthropic
 CF_ACCOUNT_ID=
 CF_API_TOKEN=
 # CF_MODEL=@cf/meta/llama-3.3-70b-instruct-fp8-fast
+# CF call timeout (ms). Default 12000 = fast-fail as a last-resort fallback.
+# Raise it (e.g. 45000) only if running Cloudflare as the PRIMARY (it's slow).
+# CF_TIMEOUT_MS=12000
 
 # Groq (CLASSIFIER_PROVIDER=groq) — very fast hosted open models (~1-2s), free
 # tier. GROQ_MODEL must support response_format json_schema (gpt-oss-120b/20b,

--- a/lib/search-intent/__tests__/classify-fallback.test.ts
+++ b/lib/search-intent/__tests__/classify-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { chain } from "../classify";
+import { chain, chainAll } from "../classify";
 import type { ClassifiedIntent } from "../types";
 
 const intent = (type: string): ClassifiedIntent => ({
@@ -42,5 +42,38 @@ describe("chain (provider fallback)", () => {
     const fallback = vi.fn().mockResolvedValue(intent("fb"));
     await chain(primary, fallback)("prereqs for BIO 256", "nc");
     expect(fallback).toHaveBeenCalledWith("prereqs for BIO 256", "nc");
+  });
+});
+
+describe("chainAll (multi-provider fallback chain)", () => {
+  it("falls through the chain until one succeeds (e.g. 120b 429 → 20b → cloudflare)", async () => {
+    const a = vi.fn().mockRejectedValue(new Error("429"));   // groq 120b rate-limited
+    const b = vi.fn().mockRejectedValue(new Error("429"));   // groq 20b also rate-limited
+    const c = vi.fn().mockResolvedValue(intent("cloudflare")); // cloudflare answers
+    const result = await chainAll([a, b, c])("q", "va");
+    expect(result.studentSummary).toBe("cloudflare");
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+    expect(c).toHaveBeenCalledOnce();
+  });
+
+  it("stops at the first success (later providers untouched)", async () => {
+    const a = vi.fn().mockRejectedValue(new Error("429"));
+    const b = vi.fn().mockResolvedValue(intent("20b"));
+    const c = vi.fn().mockResolvedValue(intent("cloudflare"));
+    const result = await chainAll([a, b, c])("q", "va");
+    expect(result.studentSummary).toBe("20b");
+    expect(c).not.toHaveBeenCalled();
+  });
+
+  it("propagates the last error when every provider fails (→ 503 → UI fallback)", async () => {
+    const a = vi.fn().mockRejectedValue(new Error("a"));
+    const b = vi.fn().mockRejectedValue(new Error("b down"));
+    await expect(chainAll([a, b])("q", "va")).rejects.toThrow("b down");
+  });
+
+  it("a single-element chain is just that classifier", async () => {
+    const only = vi.fn().mockResolvedValue(intent("solo"));
+    expect((await chainAll([only])("q", "va")).studentSummary).toBe("solo");
   });
 });

--- a/lib/search-intent/classify.ts
+++ b/lib/search-intent/classify.ts
@@ -40,23 +40,36 @@ export function chain(primary: Classifier, fallback: Classifier): Classifier {
   };
 }
 
-/** Build one provider's llm + cache namespace by name. Null = anthropic/unknown. */
-function buildProvider(name: string | undefined): { llm: Classifier; modelVersion: string } | null {
+/**
+ * Build one provider's llm + cache namespace from a spec.
+ *
+ * Spec is `provider` or `provider:model` (model = everything after the first
+ * colon, so Groq's "openai/gpt-oss-20b" and Cloudflare's "@cf/..." both work).
+ * The per-spec model override lets a fallback use a DIFFERENT model than the
+ * primary — e.g. primary groq:gpt-oss-120b, fallback groq:gpt-oss-20b. Groq's
+ * free-tier rate limits are PER-MODEL, so falling back to a second Groq model
+ * usually dodges the primary's 429 and answers in ~0.5s — far better than the
+ * slow (7-30s) Cloudflare 70B. Null = anthropic/unknown.
+ */
+function buildProvider(spec: string | undefined): { llm: Classifier; modelVersion: string } | null {
+  if (!spec) return null;
+  const colon = spec.indexOf(":");
+  const name = colon === -1 ? spec : spec.slice(0, colon);
+  const modelOverride = colon === -1 ? undefined : spec.slice(colon + 1);
   switch (name) {
     case "cloudflare": {
-      const model = process.env.CF_MODEL ?? "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
+      const model = modelOverride ?? process.env.CF_MODEL ?? "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
       return {
         llm: localClassifier({
           wire: "openai",
           baseUrl: `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/ai/v1`,
           apiKey: process.env.CF_API_TOKEN,
           model,
-          // Workers AI's 70B latency is variable (often 7-30s under load). The
-          // answer card is non-blocking and Supabase-cached, so we'd rather wait
-          // and populate (+ cache) it than abort. Kept under the route's
-          // maxDuration. If snappier responses matter, CLASSIFIER_PROVIDER=groq
-          // is the same code path and sub-second.
-          timeoutMs: 45_000,
+          // Workers AI's 70B is slow + variable (7-30s+). It's now used mainly as
+          // a LAST-RESORT fallback, so fail fast (12s) rather than make a user
+          // wait 45s for a card that may not come. Override with CF_TIMEOUT_MS
+          // if running Cloudflare as the primary.
+          timeoutMs: Number(process.env.CF_TIMEOUT_MS ?? 12_000),
         }),
         modelVersion: `cf:${model}`,
       };
@@ -64,8 +77,9 @@ function buildProvider(name: string | undefined): { llm: Classifier; modelVersio
     case "groq": {
       // Must be a Groq model that supports response_format json_schema (Groq's
       // structured-outputs list). llama-3.3-70b-versatile does NOT — it only
-      // does json_object. gpt-oss-120b is fast (~1-2s) and schema-capable.
-      const model = process.env.GROQ_MODEL ?? "openai/gpt-oss-120b";
+      // does json_object. gpt-oss-120b is the accurate default (~1-2s);
+      // gpt-oss-20b is faster (~0.5s) and a good rate-limit fallback.
+      const model = modelOverride ?? process.env.GROQ_MODEL ?? "openai/gpt-oss-120b";
       return {
         llm: localClassifier({
           wire: "openai",
@@ -78,7 +92,7 @@ function buildProvider(name: string | undefined): { llm: Classifier; modelVersio
       };
     }
     case "ollama": {
-      const model = process.env.OLLAMA_MODEL ?? "qwen2.5:7b-instruct";
+      const model = modelOverride ?? process.env.OLLAMA_MODEL ?? "qwen2.5:7b-instruct";
       return {
         llm: localClassifier({
           wire: "ollama",
@@ -93,6 +107,11 @@ function buildProvider(name: string | undefined): { llm: Classifier; modelVersio
     default:
       return null; // anthropic — the existing Claude Haiku path
   }
+}
+
+/** Chain N classifiers: try each in order, falling to the next on any throw. */
+export function chainAll(classifiers: Classifier[]): Classifier {
+  return classifiers.reduce((primary, next) => chain(primary, next));
 }
 
 /**
@@ -111,14 +130,23 @@ function providerDefault(): { llm: Classifier; modelVersion: string } | null {
   const primary = buildProvider(process.env.CLASSIFIER_PROVIDER);
   if (!primary) return null;
 
-  const fallbackName = process.env.CLASSIFIER_FALLBACK;
-  if (fallbackName && fallbackName !== process.env.CLASSIFIER_PROVIDER) {
-    const fallback = buildProvider(fallbackName);
-    if (fallback) {
-      return { llm: chain(primary.llm, fallback.llm), modelVersion: primary.modelVersion };
-    }
-  }
-  return primary;
+  // CLASSIFIER_FALLBACK is a comma-separated list of `provider[:model]` specs,
+  // tried in order when the primary (then each prior fallback) errors. Skip any
+  // that resolve to the same cache namespace as the primary (a pointless retry).
+  // Recommended prod chain: groq:openai/gpt-oss-20b,cloudflare
+  const fallbacks = (process.env.CLASSIFIER_FALLBACK ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(buildProvider)
+    .filter((p): p is { llm: Classifier; modelVersion: string } => p !== null)
+    .filter((p) => p.modelVersion !== primary.modelVersion);
+
+  if (fallbacks.length === 0) return primary;
+  return {
+    llm: chainAll([primary, ...fallbacks].map((p) => p.llm)),
+    modelVersion: primary.modelVersion,
+  };
 }
 
 /** Compose a cache-backed classifier from injectable parts. */


### PR DESCRIPTION
## What changes for someone using the site

Makes the answer card actually survive Groq's free-tier rate limit. The first fallback (#1085) sent rate-limited requests to Cloudflare's 70B, which is slow (7–30s) and usually **timed out at ~45s → still 503** under bursts (verified on prod). This switches the fallback to a **second, faster Groq model**: when `gpt-oss-120b` is rate-limited, it falls to `gpt-oss-20b` — which is on a **separate per-model rate-limit bucket** and answers in ~0.5s. So a rate-limited query now gets a fast answer instead of a 45-second timeout.

## How to enable (after merge)

Change one Vercel env var (Production) from `CLASSIFIER_FALLBACK=cloudflare` to:
```
CLASSIFIER_FALLBACK = groq:openai/gpt-oss-20b,cloudflare
```
(fast Groq fallback first; Cloudflare only as a last resort, now 12s fast-fail). Redeploy.

## Technical (`lib/search-intent/classify.ts`)

- `CLASSIFIER_FALLBACK` is now a **comma-separated chain** of `provider[:model]` specs, tried in order.
- `buildProvider()` parses `provider:model` (model = after the first `:`, so `openai/gpt-oss-20b` and `@cf/...` both parse), so a fallback can use a **different model** than the primary. Specs resolving to the primary's own cache namespace are skipped.
- `chainAll()` chains N classifiers — each error falls through to the next; if all fail, the error propagates → 503 → UI drops the card (unchanged).
- Cloudflare timeout **45s → 12s** (override `CF_TIMEOUT_MS`) so a last-resort CF attempt fails fast.

### Why per-model Groq fallback (not Cloudflare)
Groq free-tier limits are **per model**. Prod burst test of #1085 (groq→cloudflare): most requests hit the 45s CF timeout and 503'd. `gpt-oss-20b` is a separate bucket and ~0.5s — far better insurance. (The true rate-limit fix is still Groq's paid tier; this is fast belt-and-suspenders.)

### Test plan
- 8 unit tests (`classify-fallback.test.ts`) — `chain` + `chainAll`: fall-through to a working provider, stop-at-first-success, all-fail propagation, single-element.
- **Verified end-to-end** on live Groq: bogus primary model → chain fell to `groq:openai/gpt-oss-20b` → `transfer/ENG 111/gmu`. 20b smoke ~0.4s, correct on transfer/prereqs/course.
- Typecheck + lint clean. Builds on #1085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)