### PR TITLE
fix(seats): render seat availability honestly across all states

### DIFF
--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -14,6 +14,8 @@ import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { getAvailableTerms } from "@/lib/courses";
+import SectionSeats from "@/components/SectionSeats";
+import { aggregateSeats, aggregateLabel } from "@/lib/seats";
 import { isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getInstructorBySlug, getTopInstructors, type InstructorProfile } from "@/lib/instructors";
@@ -220,14 +222,9 @@ export default async function InstructorPage(props: PageProps) {
     .filter((i) => i.slug !== slug)
     .slice(0, 20);
 
-  // Seats summary
-  const totalSeats = sections.reduce(
-    (sum, s) => sum + (s.seats_open ?? 0),
-    0
-  );
-  const sectionsWithSeats = sections.filter(
-    (s) => s.seats_open !== null && s.seats_open > 0
-  ).length;
+  // Seats summary — aggregated honestly via lib/seats (negatives/sentinels/0-1
+  // flags never inflate the count).
+  const seatSummaryLabel = aggregateLabel(aggregateSeats(sections));
 
   // JSON-LD
   const siteUrl =
@@ -349,11 +346,9 @@ export default async function InstructorPage(props: PageProps) {
             {uniqueCourses === 1 ? "course" : "courses"} &middot;{" "}
             <span className="text-gray-400 dark:text-slate-500">{term}</span>
           </p>
-          {sectionsWithSeats > 0 && (
+          {seatSummaryLabel && (
             <p className="text-emerald-600 dark:text-emerald-400 text-sm mt-1">
-              {totalSeats} {totalSeats === 1 ? "seat" : "seats"} open across{" "}
-              {sectionsWithSeats}{" "}
-              {sectionsWithSeats === 1 ? "section" : "sections"}
+              {seatSummaryLabel}
             </p>
           )}
         </div>
@@ -447,24 +442,7 @@ export default async function InstructorPage(props: PageProps) {
                         </span>
                       </td>
                       <td className="px-3 py-2">
-                        {s.seats_open !== null && s.seats_open !== undefined ? (
-                          <span
-                            className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                              s.seats_open > 10
-                                ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-                                : s.seats_open > 0
-                                  ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
-                                  : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
-                            }`}
-                          >
-                            {s.seats_open}
-                            {s.seats_total ? `/${s.seats_total}` : ""}
-                          </span>
-                        ) : (
-                          <span className="text-[10px] text-gray-400 dark:text-slate-500">
-                            &mdash;
-                          </span>
-                        )}
+                        <SectionSeats open={s.seats_open} total={s.seats_total} />
                       </td>
                     </tr>
                   );

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -21,6 +21,8 @@ import {
   getCourseLastUpdated,
   formatLastUpdated,
 } from "@/lib/data-freshness";
+import SectionSeats from "@/components/SectionSeats";
+import { aggregateSeats, aggregateLabel } from "@/lib/seats";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -341,9 +343,9 @@ export default async function CoursePage(props: PageProps) {
     .sort(([a], [b]) => a.localeCompare(b))
     .slice(0, 12);
 
-  // Seats summary
-  const totalSeats = sections.reduce((sum, s) => sum + (s.seats_open ?? 0), 0);
-  const sectionsWithSeats = sections.filter((s) => s.seats_open !== null && s.seats_open > 0).length;
+  // Seats summary — aggregated honestly (negatives = waitlist, sentinels, and
+  // 0/1 flag states never inflate the count). See lib/seats.ts.
+  const seatSummaryLabel = aggregateLabel(aggregateSeats(sections));
 
   const lastUpdated = getCourseLastUpdated(state);
 
@@ -493,9 +495,9 @@ export default async function CoursePage(props: PageProps) {
               {colleges.length === 1 ? "college" : "colleges"}
             </span>
             <span className="text-gray-400 dark:text-slate-500">{term}</span>
-            {sectionsWithSeats > 0 && (
+            {seatSummaryLabel && (
               <span className="text-emerald-600 dark:text-emerald-400">
-                {totalSeats} {totalSeats === 1 ? "seat" : "seats"} open
+                {seatSummaryLabel}
               </span>
             )}
             {lastUpdated && (
@@ -930,19 +932,7 @@ function CollegeBlock({
                       </span>
                     </td>
                     <td className="px-3 py-2">
-                      {s.seats_open !== null && s.seats_open !== undefined ? (
-                        <span className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                          s.seats_open > 10
-                            ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-                            : s.seats_open > 0
-                              ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
-                              : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
-                        }`}>
-                          {s.seats_open}{s.seats_total ? `/${s.seats_total}` : ""}
-                        </span>
-                      ) : (
-                        <span className="text-[10px] text-gray-400 dark:text-slate-500">&mdash;</span>
-                      )}
+                      <SectionSeats open={s.seats_open} total={s.seats_total} />
                     </td>
                   </tr>
                 );

--- a/app/api/[state]/sections-for-courses/route.ts
+++ b/app/api/[state]/sections-for-courses/route.ts
@@ -4,8 +4,12 @@
  * Bulk seat-availability lookup for the SemesterPlanner. For each requested
  * (course_prefix, course_number) pair, returns:
  *   - section_count          how many sections offered this term
- *   - total_seats_open       sum of seats_open across those sections
- *   - total_seats_total      sum of seats_total across those sections
+ *   - total_seats_open       trustworthy sum of open seats (via lib/seats —
+ *                            negatives/sentinels/0-1 flags excluded), or null
+ *                            when no section reports a real count
+ *   - open_sections          sections that are open/available (fallback for
+ *                            flag-only states where total_seats_open is null)
+ *   - total_seats_total      always null — summed capacities aren't trustworthy
  *   - scraped_at             timestamp of the freshest section row (proxy
  *                            for 'last updated'; used by the planner to
  *                            display 'seats as of [timestamp]')
@@ -31,6 +35,7 @@ import { rateLimit, getClientKey } from "@/lib/rate-limit";
 import { isValidState } from "@/lib/states/registry";
 import { getCurrentTerm } from "@/lib/terms";
 import { getAvailableTerms } from "@/lib/courses";
+import { aggregateSeats } from "@/lib/seats";
 
 type RouteContext = { params: Promise<{ state: string }> };
 
@@ -56,8 +61,9 @@ type SectionRow = {
 interface SectionSummary {
   course_code: string;
   section_count: number;
-  total_seats_open: number | null;
-  total_seats_total: number | null;
+  total_seats_open: number | null; // trustworthy open-seat sum, null if none real
+  open_sections: number; // sections that are open/available (flag-state fallback)
+  total_seats_total: number | null; // always null — summed totals aren't trustworthy
   scraped_at: string | null;
   is_stale: boolean;
   sample_sections: Array<{
@@ -179,6 +185,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         course_code: code,
         section_count: 0,
         total_seats_open: null,
+        open_sections: 0,
         total_seats_total: null,
         scraped_at: null,
         is_stale: false,
@@ -186,20 +193,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
       };
     }
 
-    let seatsOpenSum = 0;
-    let seatsTotalSum = 0;
-    let hadOpen = false;
-    let hadTotal = false;
+    // Aggregate seats honestly: negatives (waitlist), sentinels (≥1000), and
+    // 0/1 flag-state values never inflate the count. See lib/seats.ts.
+    const seatAgg = aggregateSeats(rows);
     let freshest = 0;
     for (const r of rows) {
-      if (r.seats_open != null) {
-        seatsOpenSum += r.seats_open;
-        hadOpen = true;
-      }
-      if (r.seats_total != null) {
-        seatsTotalSum += r.seats_total;
-        hadTotal = true;
-      }
       const t = new Date(r.created_at).getTime();
       if (t > freshest) freshest = t;
     }
@@ -218,8 +216,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
     return {
       course_code: code,
       section_count: rows.length,
-      total_seats_open: hadOpen ? seatsOpenSum : null,
-      total_seats_total: hadTotal ? seatsTotalSum : null,
+      // Honest: trustworthy open-seat sum (null if no section has a real count),
+      // plus open-section count for flag/sentinel states to fall back on.
+      total_seats_open: seatAgg.openSeats,
+      open_sections: seatAgg.openSections,
+      total_seats_total: null,
       scraped_at: freshest > 0 ? new Date(freshest).toISOString() : null,
       is_stale: freshest > 0 ? now - freshest > STALE_THRESHOLD_MS : false,
       sample_sections,

--- a/components/SectionSeats.tsx
+++ b/components/SectionSeats.tsx
@@ -1,0 +1,46 @@
+import { describeSeats, seatLabel, seatTone } from "@/lib/seats";
+
+const TONE: Record<string, string> = {
+  good: "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400",
+  low: "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400",
+  full: "bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400",
+  muted: "text-gray-400 dark:text-slate-500",
+};
+
+/**
+ * Honest seat badge for a single section. Routes raw seats_open/seats_total
+ * through describeSeats so negatives render "Full", flags/sentinels render
+ * "Open", and only trustworthy numbers render as counts. Pure render — safe in
+ * server and client components alike.
+ */
+export default function SectionSeats({
+  open,
+  total,
+  className = "",
+  hideUnknown = false,
+}: {
+  open: number | null | undefined;
+  total: number | null | undefined;
+  className?: string;
+  /** Render nothing (instead of "—") when seats are unknown — for compact
+   *  inline badge rows where a dash would be noise. */
+  hideUnknown?: boolean;
+}) {
+  const info = describeSeats(open, total);
+  if (info.status === "unknown") {
+    if (hideUnknown) return null;
+    return <span className={`text-[10px] ${TONE.muted} ${className}`}>&mdash;</span>;
+  }
+  const title =
+    info.status === "full" && info.waitlist
+      ? `Full — ${info.waitlist} on the waitlist`
+      : undefined;
+  return (
+    <span
+      className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${TONE[seatTone(info)]} ${className}`}
+      title={title}
+    >
+      {seatLabel(info)}
+    </span>
+  );
+}

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -26,7 +26,8 @@ interface PlanCourse {
 interface SeatSummary {
   course_code: string;
   section_count: number;
-  total_seats_open: number | null;
+  total_seats_open: number | null; // trustworthy open-seat sum, null if none real
+  open_sections: number; // open/available sections (flag-state fallback)
   total_seats_total: number | null;
   scraped_at: string | null;
   is_stale: boolean;
@@ -372,20 +373,25 @@ function SeatBadge({ seats }: { seats: SeatSummary }) {
       </span>
     );
   }
+  // Honest: prefer a trustworthy open-seat count; otherwise (flag/sentinel
+  // states with no real counts) fall back to open-vs-full from section flags.
+  const hasCount = seats.total_seats_open != null;
   const open = seats.total_seats_open ?? 0;
-  const color =
-    open === 0
-      ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
-      : open <= 10
-        ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
-        : "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400";
+  const available = hasCount ? open > 0 : seats.open_sections > 0;
+  const label = hasCount ? (open === 0 ? "Full" : String(open)) : available ? "Open" : "Full";
+  const color = !available
+    ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
+    : hasCount && open <= 10
+      ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
+      : "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400";
   // Stale: dim the color with reduced opacity. Keeps the at-a-glance
   // signal but flags reduced confidence per the 3-day staleness convention.
   const staleClass = seats.is_stale ? "opacity-60" : "";
   const tooltip = (() => {
     const parts = [
-      `${open} seat${open === 1 ? "" : "s"} open`,
-      seats.total_seats_total != null ? `${seats.total_seats_total} total` : null,
+      hasCount
+        ? `${open} seat${open === 1 ? "" : "s"} open`
+        : `${seats.open_sections} of ${seats.section_count} section${seats.section_count === 1 ? "" : "s"} open`,
       `${seats.section_count} section${seats.section_count === 1 ? "" : "s"}`,
       seats.scraped_at
         ? `as of ${new Date(seats.scraped_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
@@ -399,7 +405,7 @@ function SeatBadge({ seats }: { seats: SeatSummary }) {
       className={`text-[9px] px-1.5 py-0.5 rounded-full border font-medium ${color} ${staleClass}`}
       title={tooltip}
     >
-      {open === 0 ? "Full" : open}
+      {label}
     </span>
   );
 }

--- a/components/schedule/ScheduleResults.tsx
+++ b/components/schedule/ScheduleResults.tsx
@@ -6,6 +6,7 @@ import type { GeneratedSchedule, ScheduleResponse, ScheduleSection } from "@/lib
 import WeeklyCalendar from "./WeeklyCalendar";
 import ScoreBar from "./ScoreBar";
 import { isValidTime, expandDays } from "@/lib/time-utils";
+import SectionSeats from "@/components/SectionSeats";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
@@ -429,17 +430,7 @@ function ScheduleCard({
                   {s.distance !== null && (
                     <span className="ml-1 text-gray-400 dark:text-slate-500">{s.distance} mi</span>
                   )}
-                  {s.seats_open !== null && s.seats_open !== undefined && (
-                    <span className={`ml-1.5 inline-block rounded-full px-1.5 py-0 text-[10px] font-medium ${
-                      s.seats_open > 10
-                        ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-                        : s.seats_open > 0
-                          ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
-                          : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
-                    }`}>
-                      {s.seats_open} seat{s.seats_open !== 1 ? "s" : ""}
-                    </span>
-                  )}
+                  <SectionSeats open={s.seats_open} total={s.seats_total} className="ml-1.5" hideUnknown />
                   {transferStyle && (
                     <span className={`ml-1.5 inline-block rounded-full px-1.5 py-0 text-[10px] font-medium ${transferStyle.bg} ${transferStyle.text}`}>
                       {transferStyle.label}
@@ -642,19 +633,7 @@ function ScheduleCard({
                         </span>
                       </td>
                       <td className="px-3 py-2 text-gray-600 dark:text-slate-400">
-                        {s.seats_open !== null && s.seats_open !== undefined ? (
-                          <span className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                            s.seats_open > 10
-                              ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-                              : s.seats_open > 0
-                                ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
-                                : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
-                          }`}>
-                            {s.seats_open}{s.seats_total ? `/${s.seats_total}` : ""}
-                          </span>
-                        ) : (
-                          <span className="text-[10px] text-gray-400 dark:text-slate-500">—</span>
-                        )}
+                        <SectionSeats open={s.seats_open} total={s.seats_total} />
                       </td>
                       {sections.some((sec) => sec.transferStatus) && (
                         <td className="px-3 py-2">

--- a/lib/__tests__/seats.test.ts
+++ b/lib/__tests__/seats.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeSeats,
+  aggregateSeats,
+  seatLabel,
+  aggregateLabel,
+  seatTone,
+} from "@/lib/seats";
+
+describe("describeSeats — audited real-world patterns", () => {
+  it("null open → unknown (nh, sd, partial states)", () => {
+    expect(describeSeats(null, null)).toEqual({ status: "unknown" });
+    expect(describeSeats(null, 25)).toEqual({ status: "unknown" });
+  });
+
+  it("negative open → full + waitlist (35 states, −1..−363)", () => {
+    expect(describeSeats(-5, 30)).toEqual({ status: "full", waitlist: 5 });
+    expect(describeSeats(-363, null)).toEqual({ status: "full", waitlist: 363 });
+  });
+
+  it("zero open → full", () => {
+    expect(describeSeats(0, 25)).toEqual({ status: "full" });
+    expect(describeSeats(0, null)).toEqual({ status: "full" }); // flag state closed
+  });
+
+  it("sentinel (≥1000, esp. 9999) → open, never the number", () => {
+    expect(describeSeats(9999, 9999)).toEqual({ status: "open" });
+    expect(describeSeats(1000, 50)).toEqual({ status: "open" });
+    expect(describeSeats(5960, 275)).toEqual({ status: "open" }); // ms outlier
+  });
+
+  it("flag state open (1, no total) → Open, NOT '1 seat left'", () => {
+    expect(describeSeats(1, null)).toEqual({ status: "open" });
+  });
+
+  it("real count with sane total → count with both (GA/NC/TX)", () => {
+    expect(describeSeats(12, 30)).toEqual({ status: "count", open: 12, total: 30 });
+    expect(describeSeats(1, 25)).toEqual({ status: "count", open: 1, total: 25 }); // genuine 1-of-25
+  });
+
+  it("real open count, no/garbage total → count with open only", () => {
+    expect(describeSeats(12, null)).toEqual({ status: "count", open: 12 }); // CO-style null total
+    expect(describeSeats(12, 9999)).toEqual({ status: "count", open: 12 }); // sentinel total dropped
+    expect(describeSeats(20, 5)).toEqual({ status: "count", open: 20 }); // impossible total>open dropped
+  });
+});
+
+describe("aggregateSeats", () => {
+  it("sums only trustworthy open counts; ignores negatives/sentinels/nulls", () => {
+    const a = aggregateSeats([
+      { seats_open: 5, seats_total: 30 }, // +5, open
+      { seats_open: -3, seats_total: 30 }, // full (waitlist), 0
+      { seats_open: 9999, seats_total: 9999 }, // sentinel → open section, no count
+      { seats_open: null, seats_total: null }, // unknown
+      { seats_open: 0, seats_total: 25 }, // full
+      { seats_open: 8, seats_total: null }, // +8 open
+    ]);
+    expect(a.openSeats).toBe(13); // 5 + 8 only
+    expect(a.openSections).toBe(3); // the 5, the 8, and the sentinel
+    expect(a.totalSections).toBe(6);
+    expect(a.anyData).toBe(true);
+  });
+
+  it("flag-only college → openSeats null, falls back to sections", () => {
+    const a = aggregateSeats([
+      { seats_open: 1, seats_total: null },
+      { seats_open: 1, seats_total: null },
+      { seats_open: 0, seats_total: null },
+    ]);
+    expect(a.openSeats).toBeNull(); // no trustworthy counts
+    expect(a.openSections).toBe(2); // two open flags
+    expect(a.totalSections).toBe(3);
+  });
+
+  it("no data at all → openSeats null, anyData false", () => {
+    const a = aggregateSeats([
+      { seats_open: null, seats_total: null },
+      { seats_open: null, seats_total: null },
+    ]);
+    expect(a.openSeats).toBeNull();
+    expect(a.anyData).toBe(false);
+  });
+});
+
+describe("labels & tone", () => {
+  it("seatLabel reflects status honestly", () => {
+    expect(seatLabel(describeSeats(12, 30))).toBe("12 of 30 seats");
+    expect(seatLabel(describeSeats(8, null))).toBe("8 seats open");
+    expect(seatLabel(describeSeats(1, null))).toBe("Open"); // flag, not "1 seat"
+    expect(seatLabel(describeSeats(-5, 30))).toBe("Full");
+    expect(seatLabel(describeSeats(0, 25))).toBe("Full");
+    expect(seatLabel(describeSeats(9999, 9999))).toBe("Open");
+    expect(seatLabel(describeSeats(null, null))).toBe("—");
+  });
+
+  it("aggregateLabel prefers real seats, falls back to sections, else null", () => {
+    expect(aggregateLabel(aggregateSeats([{ seats_open: 5, seats_total: 30 }]))).toBe("5 seats open");
+    expect(
+      aggregateLabel(
+        aggregateSeats([
+          { seats_open: 1, seats_total: null },
+          { seats_open: 0, seats_total: null },
+        ]),
+      ),
+    ).toBe("1 of 2 sections open");
+    expect(aggregateLabel(aggregateSeats([{ seats_open: null, seats_total: null }]))).toBeNull();
+  });
+
+  it("seatTone: full=full, low count=low, open/healthy=good, missing=muted", () => {
+    expect(seatTone(describeSeats(-5, 30))).toBe("full");
+    expect(seatTone(describeSeats(3, 30))).toBe("low");
+    expect(seatTone(describeSeats(40, 50))).toBe("good");
+    expect(seatTone(describeSeats(1, null))).toBe("good"); // "Open"
+    expect(seatTone(describeSeats(null, null))).toBe("muted");
+  });
+});

--- a/lib/seats.ts
+++ b/lib/seats.ts
@@ -1,0 +1,137 @@
+// Honest interpretation of section seat data.
+//
+// `courses.seats_open` / `seats_total` mean DIFFERENT things across scrapers —
+// audited across all 51 states (2026-06, ~1.28M rows):
+//   • Real counts (~38 states): true open / total numbers.
+//   • Flag states (mn, nd, nv, va): seats_open is a 0/1 open-or-closed flag and
+//     seats_total is null — NOT a seat count.
+//   • Negative seats_open (35 states, ~14k rows, −1..−363): section is FULL with
+//     |open| students waitlisted.
+//   • Sentinels (ca, in, ga, ms, tx): seats_open / seats_total ≥ 1000 (mostly
+//     9999) mark "unlimited / online", not a real number.
+//   • Missing (nh, sd, + partial elsewhere): null.
+//
+// Rendering any of these raw lies to students — "1 seat left!" (really an open
+// flag), "−5" (really a waitlist), "9999 seats" (a sentinel). Every UI that
+// shows seats MUST go through describeSeats() / aggregateSeats().
+
+export type SeatStatus =
+  | "count" // real seats remaining (open, optional total)
+  | "open" // available, but no trustworthy count (flag=1, sentinel, lone 1)
+  | "full" // 0 seats, or negative (waitlist)
+  | "unknown"; // no data
+
+export interface SeatInfo {
+  status: SeatStatus;
+  open?: number; // "count" only
+  total?: number; // "count" only, when a sane total exists
+  waitlist?: number; // "full" only, when derived from a negative
+}
+
+// No real class SECTION seats this many; values at/above are sentinels
+// ("unlimited"/online placeholders, overwhelmingly 9999).
+export const SEAT_SENTINEL = 1000;
+
+/** Normalize one section's raw seats into an honest, displayable status. */
+export function describeSeats(
+  open: number | null | undefined,
+  total: number | null | undefined,
+): SeatInfo {
+  if (open == null) return { status: "unknown" };
+  if (open >= SEAT_SENTINEL) return { status: "open" }; // sentinel → unlimited/online
+  if (open < 0) return { status: "full", waitlist: -open }; // negative → full + waitlist
+  if (open === 0) return { status: "full" };
+  // open ≥ 1
+  const saneTotal =
+    total != null && total > 0 && total < SEAT_SENTINEL && total >= open
+      ? total
+      : null;
+  if (saneTotal != null) return { status: "count", open, total: saneTotal };
+  // No usable total: a lone "1" is ambiguous (flag vs. one real seat) — show
+  // "Open" rather than the false-scarcity "1 seat left!".
+  if (open === 1) return { status: "open" };
+  return { status: "count", open }; // 2..999 with no total: a real open count
+}
+
+export interface SeatAggregate {
+  /** Sum of real open seat counts across sections; null when no section has a
+   *  trustworthy count (e.g. flag-only states) — callers fall back to sections. */
+  openSeats: number | null;
+  /** Sections that are open/available (real availability or open flag). */
+  openSections: number;
+  totalSections: number;
+  /** Any section reported a non-null seats_open at all. */
+  anyData: boolean;
+}
+
+/** Aggregate a college's (or course's) sections without trusting raw sums —
+ *  negatives, sentinels, and flags never inflate the count. */
+export function aggregateSeats(
+  sections: { seats_open: number | null; seats_total: number | null }[],
+): SeatAggregate {
+  let openSeats = 0;
+  let hasCount = false;
+  let openSections = 0;
+  let anyData = false;
+  for (const s of sections) {
+    if (s.seats_open != null) anyData = true;
+    const info = describeSeats(s.seats_open, s.seats_total);
+    if (info.status === "count" && info.open != null) {
+      hasCount = true;
+      openSeats += info.open;
+      if (info.open > 0) openSections++;
+    } else if (info.status === "open") {
+      openSections++;
+    }
+    // "full" / "unknown" contribute nothing to availability
+  }
+  return {
+    openSeats: hasCount ? openSeats : null,
+    openSections,
+    totalSections: sections.length,
+    anyData,
+  };
+}
+
+/** Short human label for one section's seats. */
+export function seatLabel(info: SeatInfo): string {
+  switch (info.status) {
+    case "count":
+      return info.total != null
+        ? `${info.open} of ${info.total} seats`
+        : `${info.open} ${info.open === 1 ? "seat" : "seats"} open`;
+    case "open":
+      return "Open";
+    case "full":
+      return "Full";
+    case "unknown":
+      return "—";
+  }
+}
+
+export type SeatTone = "good" | "low" | "full" | "muted";
+
+/** Color intent for one section's seats. */
+export function seatTone(info: SeatInfo): SeatTone {
+  switch (info.status) {
+    case "unknown":
+      return "muted";
+    case "full":
+      return "full";
+    case "open":
+      return "good";
+    case "count":
+      return info.open != null && info.open <= 5 ? "low" : "good";
+  }
+}
+
+/** Aggregate label for a header / matrix cell. Null = nothing trustworthy to show. */
+export function aggregateLabel(a: SeatAggregate): string | null {
+  if (a.openSeats != null) {
+    return `${a.openSeats} ${a.openSeats === 1 ? "seat" : "seats"} open`;
+  }
+  if (a.anyData) {
+    return `${a.openSections} of ${a.totalSections} ${a.totalSections === 1 ? "section" : "sections"} open`;
+  }
+  return null;
+}


### PR DESCRIPTION
## What changes for someone using the site

Seat counts on the site were lying, and an audit of all 51 states showed it was systemic. Examples that are now fixed:
- **Virginia (and mn/nd/nv):** every open section showed **"1"** in amber — reading as *"only 1 seat left!"* across the entire catalog. Virginia's scraper only records open-vs-closed (a 0/1 flag), not a seat count. Now it shows **"Open" / "Full"**.
- **35 states** had **negative** values (−1…−363 = full with a waitlist) rendered as a red **"−5"**. Now **"Full"** (with a "5 on the waitlist" tooltip).
- **CA/IN/GA/MS/TX** had **sentinel** values (≥1000, mostly 9999 = "unlimited/online") rendered as **"9999 seats"**. Now **"Open"**.
- States with **real counts** (GA/NC/TX/…) correctly show **"9 of 20 seats"** and **"Full"**.

Headers were worse — they *summed* the raw values, so "X seats open" on course/instructor pages and the planner's seat badges were corrupted by negatives, sentinels, and flags. Now: **"4,605 seats open"** where counts are real, **"213 of 232 sections open"** in flag states.

**Governing principle:** showing bad data is worse than showing none. Where a number isn't trustworthy, we show a status ("Open"/"Full") or nothing — never a fabricated count.

## The audit (all 51 states, ~1.28M sections)

| Pattern | Meaning | States |
|---|---|---|
| 0/1 flag, null totals | open/closed, not a count | mn, nd, nv, va |
| negative (−1…−363, 13.9k rows) | full + waitlist | 35 states |
| ≥1000 (mostly 9999) | unlimited/online sentinel | ca, in, ga, ms, tx |
| null | unknown | nh, sd, + partial co/me/mt/fl/… |
| real open/total (<1000) | true counts | ~38 states |

## What changes on the technical front

One honest helper, **`lib/seats.ts`** (rules derived from the audit — no hardcoded state list, satisfies invariant #1):
- `describeSeats(open, total)` → `count | open | full | unknown` (handles null, negative=waitlist, 0=full, ≥1000=sentinel, sane-total=count, lone-1-no-total=Open, 2..999-no-total=count).
- `aggregateSeats(sections)` → trustworthy `openSeats` (null if none real) + `openSections` fallback, so headers never sum garbage.

Every seat-display site now routes through it:
| Site | Change |
|---|---|
| `components/SectionSeats.tsx` (new) | shared per-section badge |
| `course/[code]` + `instructor` pages | per-section badge + honest header summary |
| `schedule/ScheduleResults.tsx` | both render sites |
| `api/[state]/sections-for-courses` + `SemesterPlanner` SeatBadge | honest aggregate (`total_seats_open` trustworthy-or-null, new `open_sections`, `total_seats_total` dropped) |

### Known follow-ups (not in this PR)
- Schedule *scoring* (`lib/schedule.ts`) still reads raw `seats_open` for ranking (not a display lie, but a sentinel could mis-rank) — separate change.
- This is the prerequisite for the **compare-colleges matrix** (Tier-B #3), which will reuse `lib/seats.ts` for a data-aware "seats" column.

## Test plan
- **46 tests pass** (13 new in `lib/__tests__/seats.test.ts` covering null/negative/zero/sentinel/flag/real-count/garbage-total + aggregation + labels/tone). tsc + eslint clean; `next build` OK.
- Live-data verification (dev): VA course page → "Open"/"Full" + "213 of 232 sections open"; GA → "9 of 20 seats"/"Full" + "4,605 seats open"; planner API → `null`+`open_sections` for VA, real count for GA; no `−N`/`9999` leaks anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)