### PR TITLE
fix(seats): header reads 'N of M sections open' consistently across states

### DIFF
--- a/lib/__tests__/seats.test.ts
+++ b/lib/__tests__/seats.test.ts
@@ -93,8 +93,18 @@ describe("labels & tone", () => {
     expect(seatLabel(describeSeats(null, null))).toBe("—");
   });
 
-  it("aggregateLabel prefers real seats, falls back to sections, else null", () => {
-    expect(aggregateLabel(aggregateSeats([{ seats_open: 5, seats_total: 30 }]))).toBe("5 seats open");
+  it("aggregateLabel always frames as open-of-total SECTIONS (consistent across states)", () => {
+    // Count state (GA-shape): even with real seat counts, header reads sections.
+    expect(
+      aggregateLabel(
+        aggregateSeats([
+          { seats_open: 5, seats_total: 30 }, // open
+          { seats_open: 0, seats_total: 25 }, // full
+          { seats_open: 12, seats_total: 30 }, // open
+        ]),
+      ),
+    ).toBe("2 of 3 sections open");
+    // Flag state (VA-shape): 0/1 flags → same framing.
     expect(
       aggregateLabel(
         aggregateSeats([
@@ -103,6 +113,11 @@ describe("labels & tone", () => {
         ]),
       ),
     ).toBe("1 of 2 sections open");
+    // Singular when there's a single section.
+    expect(aggregateLabel(aggregateSeats([{ seats_open: 5, seats_total: 30 }]))).toBe(
+      "1 of 1 section open",
+    );
+    // No data → null (header shows nothing).
     expect(aggregateLabel(aggregateSeats([{ seats_open: null, seats_total: null }]))).toBeNull();
   });
 

--- a/lib/seats.ts
+++ b/lib/seats.ts
@@ -125,13 +125,16 @@ export function seatTone(info: SeatInfo): SeatTone {
   }
 }
 
-/** Aggregate label for a header / matrix cell. Null = nothing trustworthy to show. */
+/**
+ * Aggregate label for a header summary. Always framed as open-vs-total
+ * SECTIONS ("245 of 320 sections open") so it reads the same in every state —
+ * count states and flag states alike — instead of a large, hard-to-grok
+ * statewide seat sum ("4,605 seats open"). Null = no trustworthy data to show.
+ *
+ * (Raw seat sums are still available via aggregateSeats().openSeats for callers
+ * that genuinely want per-college counts, e.g. the compare matrix.)
+ */
 export function aggregateLabel(a: SeatAggregate): string | null {
-  if (a.openSeats != null) {
-    return `${a.openSeats} ${a.openSeats === 1 ? "seat" : "seats"} open`;
-  }
-  if (a.anyData) {
-    return `${a.openSections} of ${a.totalSections} ${a.totalSections === 1 ? "section" : "sections"} open`;
-  }
-  return null;
+  if (!a.anyData) return null;
+  return `${a.openSections} of ${a.totalSections} ${a.totalSections === 1 ? "section" : "sections"} open`;
 }


### PR DESCRIPTION
## What changes for someone using the site

On the course-detail and instructor pages, the seat-availability line in the header now reads the **same way in every state**:
- **Before:** count states showed a big statewide seat sum — e.g. GA ENGL 1101 said **"4,605 seats open"** (accurate, but unhelpfully large and sitting right next to "320 sections at 22 colleges"), while flag states (VA) already said "213 of 232 sections open."
- **After:** every state shows **"245 of 320 sections open"** style — scannable, self-consistent, and more useful than a 4-digit total.

Per-section badges are unchanged — GA still shows "9 of 20 seats" / "Full", VA shows "Open" / "Full" (from #1087).

## What changes on the technical front

One-function change in `lib/seats.ts`: `aggregateLabel()` now always frames as open-of-total **sections** instead of preferring a raw seat sum. The raw sum is still available via `aggregateSeats().openSeats` for callers that genuinely want per-college counts (the upcoming compare-colleges matrix). Only the two header consumers (`course/[code]`, `instructor`) are affected — confirmed by grep.

## Test plan
- `aggregateLabel` test rewritten for the new behavior (count-state, flag-state, singular "1 of 1 section open", and no-data → null).
- `tsc` + `eslint` clean; **full suite 557 pass / 0 fail**; `next build` OK.
- Live SSR verified: GA `/ga/course/engl-1101` → "245 of 320 sections open"; VA `/va/course/eng-111` → "213 of 232 sections open".

Follow-up to #1087 (merged). Next: the compare-colleges matrix builds on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)