### PR TITLE
fix(home): scroll state picker when 51 states overflow the viewport

### DIFF
--- a/components/CourseSearchHero.tsx
+++ b/components/CourseSearchHero.tsx
@@ -114,12 +114,15 @@ export default function CourseSearchHero({
   useEffect(() => {
     if (!pickerOpen || !pickerRef.current) return;
     const rect = pickerRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom - 16;
     setDropdownStyle({
       position: "fixed",
       top: rect.bottom + 8,
       left: "50%",
       transform: "translateX(-50%)",
       width: Math.min(576, window.innerWidth - 32),
+      maxHeight: Math.max(240, spaceBelow),
+      overflowY: "auto",
       zIndex: 9999,
     });
   }, [pickerOpen]);


### PR DESCRIPTION
## What changes for someone using the site

On the homepage, when you click the state filter pill (\"select your state ▾\" or your auto-detected state) and the list of all 51 states is taller than the room below the search bar, **you can now scroll inside the dropdown to reach the bottom of the list** (SC, SD, TN, TX, UT, VT, VA, WA, WV, WI, WY). Before, those rows were clipped off the bottom of the viewport with no way to get to them — most visible on laptops with shorter screens and on mobile.

No layout changes when the list does fit: on a tall window the dropdown still shows all 51 states in one shot, no scrollbar.

## What changed on the technical front

One useEffect in [components/CourseSearchHero.tsx](components/CourseSearchHero.tsx) — the one that positions the portal dropdown after \`pickerOpen\` flips. It now also sets:

- \`maxHeight: max(240, windowH - pillBottom - 16)\` — bound the panel to the space between the pill and the bottom of the viewport, with a 240px floor so the picker stays usable even when reopened near the bottom of a very short window
- \`overflowY: \"auto\"\` — internal scroll once content exceeds the cap

The dropdown is rendered through \`createPortal\` to \`document.body\`, so no parent container could be made to clip it; the height has to come from inline style on the portal node itself.

## Test plan

- [x] Desktop 1280×800, dark theme: opened the picker — panel sits at y=423–792, scrollHeight 551, all 51 buttons render, Wyoming reachable by scrolling inside the panel
- [x] Mobile 375×812: panel 343×337 (16px gutters left & right), scrollHeight 775, scrollbar visible, all 51 states reachable
- [x] No state selected (initial render) and after picking a state — both paths use the same useEffect
- [ ] Spot-check on a real phone after Vercel deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)