### PR TITLE
feat(course): compare-colleges matrix (data-aware, on the honest seat foundation)

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/lib/data-freshness";
 import SectionSeats from "@/components/SectionSeats";
 import { aggregateSeats, aggregateLabel } from "@/lib/seats";
+import { buildCollegeCompareRows } from "@/lib/compare-colleges";
+import CourseCollegeCompare from "@/components/CourseCollegeCompare";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -307,6 +309,15 @@ export default async function CoursePage(props: PageProps) {
 
   // Group by college
   const colleges = groupByCollege(sections, institutions);
+
+  // Compare-colleges matrix: one honest, sortable row per offering college,
+  // plus the in-state colleges that don't offer it this term.
+  const compareRows = buildCollegeCompareRows(colleges);
+  const offeringSlugs = new Set(colleges.map((c) => c.slug));
+  const notOfferedColleges = institutions
+    .filter((i) => !offeringSlugs.has(i.id))
+    .map((i) => i.name)
+    .sort();
 
   // Mode breakdown across all sections (consumed by the existing pill row)
   const modeBreakdown: Record<string, number> = {};
@@ -764,7 +775,25 @@ export default async function CoursePage(props: PageProps) {
           </section>
         )}
 
-        {/* Availability by college */}
+        {/* Compare colleges — side-by-side matrix (only worthwhile with ≥2). */}
+        {colleges.length >= 2 && (
+          <section className="mb-8">
+            <SectionHeading id="compare" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+              Compare colleges
+            </SectionHeading>
+            <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">
+              Where to take {prefix} {number} — sort and filter by when it meets,
+              open seats, and format.
+            </p>
+            <CourseCollegeCompare
+              rows={compareRows}
+              state={state}
+              notOffered={notOfferedColleges}
+            />
+          </section>
+        )}
+
+        {/* Availability by college — full per-section detail */}
         <section className="mb-8">
           <SectionHeading id="colleges" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
             Available at {colleges.length} {colleges.length === 1 ? "college" : "colleges"}

--- a/components/CourseCollegeCompare.tsx
+++ b/components/CourseCollegeCompare.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  applyCompare,
+  type CollegeCompareRow,
+  type CompareSort,
+} from "@/lib/compare-colleges";
+import DataProvenanceNote from "@/components/DataProvenanceNote";
+
+const MODE_PILL: Record<string, string> = {
+  "in-person": "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400",
+  online: "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400",
+  hybrid: "bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400",
+  zoom: "bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400",
+};
+const MODE_LABEL: Record<string, string> = {
+  "in-person": "In-person", online: "Online", hybrid: "Hybrid", zoom: "Zoom",
+};
+
+const SORTS: { value: CompareSort; label: string }[] = [
+  { value: "availability", label: "Most availability" },
+  { value: "soonest", label: "Soonest start" },
+  { value: "sections", label: "Most sections" },
+  { value: "name", label: "A–Z" },
+];
+
+function Chip({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+        on
+          ? "bg-teal-600 text-white"
+          : "bg-gray-100 dark:bg-slate-800 text-gray-600 dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-700"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function CourseCollegeCompare({
+  rows,
+  state,
+  notOffered,
+}: {
+  rows: CollegeCompareRow[];
+  state: string;
+  /** Names of in-state colleges that don't offer this course this term. */
+  notOffered: string[];
+}) {
+  const [sort, setSort] = useState<CompareSort>("availability");
+  const [openOnly, setOpenOnly] = useState(false);
+  const [onlineOnly, setOnlineOnly] = useState(false);
+  const [eveningOnly, setEveningOnly] = useState(false);
+
+  const visible = useMemo(
+    () => applyCompare(rows, { sort, openOnly, onlineOnly, eveningOnly }),
+    [rows, sort, openOnly, onlineOnly, eveningOnly],
+  );
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          <Chip on={openOnly} onClick={() => setOpenOnly((v) => !v)}>Open seats</Chip>
+          <Chip on={onlineOnly} onClick={() => setOnlineOnly((v) => !v)}>Online</Chip>
+          <Chip on={eveningOnly} onClick={() => setEveningOnly((v) => !v)}>Evening</Chip>
+        </div>
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-gray-500 dark:text-slate-400">
+          Sort
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as CompareSort)}
+            className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-slate-200 focus:border-teal-500 focus:outline-none"
+          >
+            {SORTS.map((s) => (
+              <option key={s.value} value={s.value}>{s.label}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-slate-700">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-gray-50 dark:bg-slate-800 text-[11px] uppercase tracking-wider text-gray-500 dark:text-slate-400">
+            <tr>
+              <th className="px-4 py-2.5 font-medium">College</th>
+              <th className="px-4 py-2.5 font-medium">Soonest section</th>
+              <th className="px-4 py-2.5 font-medium">Seats</th>
+              <th className="px-4 py-2.5 font-medium">Format</th>
+              <th className="px-4 py-2.5 font-medium text-center">Sections</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-slate-700">
+            {visible.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-gray-500 dark:text-slate-400">
+                  No colleges match these filters.
+                </td>
+              </tr>
+            ) : (
+              visible.map((r) => (
+                <tr key={r.slug} className="hover:bg-gray-50 dark:hover:bg-slate-800/60">
+                  <td className="px-4 py-2.5">
+                    <Link
+                      href={`/${state}/college/${r.slug}`}
+                      className="font-medium text-gray-900 dark:text-slate-100 hover:text-teal-600 dark:hover:text-teal-400"
+                    >
+                      {r.name}
+                    </Link>
+                    {r.auditAllowed && (
+                      <span className="ml-2 rounded-full bg-green-50 dark:bg-green-900/30 px-1.5 py-0.5 text-[10px] font-medium text-green-700 dark:text-green-400">
+                        Audit OK
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-600 dark:text-slate-300">{r.soonest}</td>
+                  <td className="px-4 py-2.5">
+                    <span
+                      className={`text-xs font-medium ${
+                        r.hasOpen ? "text-emerald-700 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"
+                      }`}
+                    >
+                      {r.seatLabel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex flex-wrap gap-1">
+                      {Object.entries(r.modes)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([mode, n]) => (
+                          <span
+                            key={mode}
+                            className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${MODE_PILL[mode] ?? MODE_PILL["in-person"]}`}
+                          >
+                            {MODE_LABEL[mode] ?? mode} {n}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 text-center text-gray-500 dark:text-slate-400 tabular-nums">
+                    {r.sectionCount}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <DataProvenanceNote>
+        Seats and schedules are pulled automatically from each college&apos;s
+        catalog and change in real time — confirm on the college&apos;s site
+        before you register.
+      </DataProvenanceNote>
+
+      {notOffered.length > 0 && (
+        <p className="mt-2 text-xs text-gray-400 dark:text-slate-500">
+          Not offered this term at {notOffered.length} other{" "}
+          {notOffered.length === 1 ? "college" : "colleges"}:{" "}
+          {notOffered.slice(0, 6).join(", ")}
+          {notOffered.length > 6 ? `, and ${notOffered.length - 6} more` : ""}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/__tests__/compare-colleges.test.ts
+++ b/lib/__tests__/compare-colleges.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { buildCollegeCompareRows, applyCompare, type CollegeOfferingInput } from "@/lib/compare-colleges";
+import type { CourseSection } from "@/lib/types";
+
+function sec(p: Partial<CourseSection>): CourseSection {
+  return {
+    college_code: "x", term: "2026SU", course_prefix: "ENG", course_number: "111",
+    course_title: "Comp", credits: 3, crn: "1", days: "MW", start_time: "9:00 AM",
+    end_time: "10:15 AM", start_date: "2026-06-01", location: "", campus: "Main",
+    mode: "in-person", instructor: "Smith", seats_open: 5, seats_total: 30,
+    prerequisite_text: null, prerequisite_courses: [], ...p,
+  };
+}
+function college(p: Partial<CollegeOfferingInput>): CollegeOfferingInput {
+  return { slug: "c", name: "College", auditAllowed: null, sections: [], modeBreakdown: {}, ...p };
+}
+
+describe("buildCollegeCompareRows", () => {
+  it("count state → 'N seats open' from honest sum", () => {
+    const [r] = buildCollegeCompareRows([
+      college({ sections: [sec({ seats_open: 5, seats_total: 30 }), sec({ seats_open: 8, seats_total: 30 }), sec({ seats_open: 0, seats_total: 30 })] }),
+    ]);
+    expect(r.seatLabel).toBe("13 seats open"); // 5+8, the 0 excluded
+    expect(r.availability).toBe(13);
+    expect(r.hasOpen).toBe(true);
+    expect(r.sectionCount).toBe(3);
+  });
+
+  it("flag state (0/1, null totals) → 'N of M sections open', never fake seats", () => {
+    const [r] = buildCollegeCompareRows([
+      college({ sections: [sec({ seats_open: 1, seats_total: null }), sec({ seats_open: 1, seats_total: null }), sec({ seats_open: 0, seats_total: null })] }),
+    ]);
+    expect(r.seatLabel).toBe("2 of 3 sections open");
+    expect(r.availability).toBe(2);
+  });
+
+  it("no seat data → '—'", () => {
+    const [r] = buildCollegeCompareRows([college({ sections: [sec({ seats_open: null, seats_total: null })] })]);
+    expect(r.seatLabel).toBe("—");
+    expect(r.hasOpen).toBe(false);
+  });
+
+  it("soonest = earliest start date, schedule formatted; online/async when no times", () => {
+    const [r] = buildCollegeCompareRows([
+      college({ sections: [
+        sec({ start_date: "2026-08-20", days: "TuTh", start_time: "1:00 PM", end_time: "2:15 PM" }),
+        sec({ start_date: "2026-06-01", days: "MW", start_time: "9:00 AM", end_time: "10:15 AM" }),
+      ] }),
+    ]);
+    expect(r.soonest).toBe("Mon Wed 9:00 AM–10:15 AM"); // earliest (June) wins
+  });
+
+  it("flags online and evening sections", () => {
+    const [r] = buildCollegeCompareRows([
+      college({ sections: [
+        sec({ mode: "online", days: "", start_time: "TBA", end_time: "TBA" }),
+        sec({ mode: "in-person", start_time: "6:00 PM", end_time: "8:45 PM" }),
+      ] }),
+    ]);
+    expect(r.hasOnline).toBe(true);
+    expect(r.hasEvening).toBe(true);
+  });
+
+  it("no evening when all sections are daytime", () => {
+    const [r] = buildCollegeCompareRows([college({ sections: [sec({ start_time: "9:00 AM", end_time: "10:15 AM" })] })]);
+    expect(r.hasEvening).toBe(false);
+  });
+});
+
+describe("applyCompare", () => {
+  const rows = buildCollegeCompareRows([
+    college({ slug: "a", name: "Alpha", sections: [sec({ seats_open: 2, mode: "in-person", start_date: "2026-06-10" })] }),
+    college({ slug: "b", name: "Bravo", sections: [sec({ seats_open: 50, mode: "online", days: "", start_time: "TBA", end_time: "TBA", start_date: "2026-06-01" }), sec({ seats_open: 5, start_date: "2026-06-01" })] }),
+    college({ slug: "c", name: "Charlie", sections: [sec({ seats_open: 0, start_date: "2026-07-01" })] }),
+  ]);
+
+  it("sorts by availability (most open first)", () => {
+    expect(applyCompare(rows, { sort: "availability" }).map((r) => r.slug)).toEqual(["b", "a", "c"]);
+  });
+  it("sorts by soonest (earliest start first)", () => {
+    expect(applyCompare(rows, { sort: "soonest" }).map((r) => r.slug)).toEqual(["b", "a", "c"]);
+  });
+  it("sorts by most sections", () => {
+    expect(applyCompare(rows, { sort: "sections" })[0].slug).toBe("b"); // 2 sections
+  });
+  it("filters open-only (drops the full college)", () => {
+    expect(applyCompare(rows, { sort: "name", openOnly: true }).map((r) => r.slug)).toEqual(["a", "b"]);
+  });
+  it("filters online-only", () => {
+    expect(applyCompare(rows, { sort: "name", onlineOnly: true }).map((r) => r.slug)).toEqual(["b"]);
+  });
+});

--- a/lib/compare-colleges.ts
+++ b/lib/compare-colleges.ts
@@ -1,0 +1,147 @@
+// Builds the "compare colleges" matrix rows for a single course — one row per
+// college that offers it, with honest, comparable, sortable fields. Pure (no
+// DOM / React) so it's unit-tested in isolation. Seats go through lib/seats so
+// negatives/sentinels/flag states never become fabricated counts.
+
+import type { CourseSection } from "@/lib/types";
+import { aggregateSeats } from "@/lib/seats";
+import { parseTimeToMinutes } from "@/lib/time-utils";
+
+// Day expansion matching the course page's detail table ("MW" → "Mon Wed"), so
+// the matrix and the per-college section list below it read the same.
+const DAY_MAP: Record<string, string> = {
+  M: "Mon", Tu: "Tue", W: "Wed", Th: "Thu", F: "Fri", Sa: "Sat", Su: "Sun",
+  TH: "Thu", SU: "Sun", TU: "Tue", SA: "Sat",
+};
+function expandDays(days: string): string {
+  if (!days || !days.trim()) return "";
+  const cleaned = days.replace(/[,\s]+/g, "").trim();
+  const out: string[] = [];
+  let i = 0;
+  while (i < cleaned.length) {
+    const two = cleaned.substring(i, i + 2);
+    if (i + 1 < cleaned.length && DAY_MAP[two]) { out.push(DAY_MAP[two]); i += 2; continue; }
+    const one = cleaned[i];
+    if (DAY_MAP[one]) out.push(DAY_MAP[one]);
+    i++;
+  }
+  return out.join(" ");
+}
+
+export interface CollegeOfferingInput {
+  slug: string;
+  name: string;
+  auditAllowed: boolean | null;
+  sections: CourseSection[];
+  modeBreakdown: Record<string, number>;
+}
+
+export interface CollegeCompareRow {
+  slug: string;
+  name: string;
+  auditAllowed: boolean | null;
+  sectionCount: number;
+  /** Honest seat label: "12 seats open" (real counts) | "3 of 5 sections open"
+   *  (flag states) | "—" (no data). */
+  seatLabel: string;
+  /** Sort key for availability: real open seats if known, else open sections. */
+  availability: number;
+  hasOpen: boolean;
+  modes: Record<string, number>;
+  /** Schedule of the earliest-starting section, e.g. "Mon Wed 9:00 AM–10:15 AM". */
+  soonest: string;
+  /** Sort key for "soonest" (ms epoch of earliest start date; Infinity if none). */
+  soonestKey: number;
+  hasOnline: boolean;
+  hasEvening: boolean;
+}
+
+const EVENING_MIN = 17 * 60; // 5:00 PM
+
+function isValidTime(t: string | null | undefined): boolean {
+  return !!t && t !== "TBA" && t !== "0:00 AM" && t !== "0:00 PM";
+}
+
+function formatSchedule(s: CourseSection): string {
+  const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
+  if (!s.days && !hasTime) return "Online / async";
+  const days = s.days ? expandDays(s.days) : "";
+  const time = hasTime ? `${s.start_time}–${s.end_time}` : "";
+  return (days && time ? `${days} ${time}` : days || time) || "Online / async";
+}
+
+function startEpoch(date: string | null | undefined): number {
+  if (!date) return Infinity;
+  const t = Date.parse(date);
+  return Number.isNaN(t) ? Infinity : t;
+}
+
+function isEvening(s: CourseSection): boolean {
+  if (!isValidTime(s.start_time)) return false;
+  const m = parseTimeToMinutes(s.start_time);
+  return m >= EVENING_MIN;
+}
+
+export function buildCollegeCompareRows(
+  colleges: CollegeOfferingInput[],
+): CollegeCompareRow[] {
+  return colleges.map((c) => {
+    const agg = aggregateSeats(c.sections);
+    const seatLabel =
+      agg.openSeats != null
+        ? `${agg.openSeats} ${agg.openSeats === 1 ? "seat" : "seats"} open`
+        : agg.anyData
+          ? `${agg.openSections} of ${agg.totalSections} ${agg.totalSections === 1 ? "section" : "sections"} open`
+          : "—";
+
+    // Earliest-starting section — prefer one with meeting days/times to show.
+    const byDate = [...c.sections].sort(
+      (a, b) => startEpoch(a.start_date) - startEpoch(b.start_date),
+    );
+    const earliest = byDate.find((s) => s.days) ?? byDate[0];
+
+    return {
+      slug: c.slug,
+      name: c.name,
+      auditAllowed: c.auditAllowed,
+      sectionCount: c.sections.length,
+      seatLabel,
+      availability: agg.openSeats ?? agg.openSections,
+      hasOpen: agg.openSections > 0,
+      modes: c.modeBreakdown,
+      soonest: earliest ? formatSchedule(earliest) : "—",
+      soonestKey: earliest ? startEpoch(earliest.start_date) : Infinity,
+      hasOnline: c.sections.some((s) => s.mode === "online" || s.mode === "zoom"),
+      hasEvening: c.sections.some(isEvening),
+    };
+  });
+}
+
+export type CompareSort = "availability" | "soonest" | "sections" | "name";
+
+/** Sort + filter rows for the matrix (pure; client applies on user input). */
+export function applyCompare(
+  rows: CollegeCompareRow[],
+  opts: { sort: CompareSort; openOnly?: boolean; onlineOnly?: boolean; eveningOnly?: boolean },
+): CollegeCompareRow[] {
+  let out = rows;
+  if (opts.openOnly) out = out.filter((r) => r.hasOpen);
+  if (opts.onlineOnly) out = out.filter((r) => r.hasOnline);
+  if (opts.eveningOnly) out = out.filter((r) => r.hasEvening);
+  const sorted = [...out];
+  switch (opts.sort) {
+    case "availability":
+      sorted.sort((a, b) => b.availability - a.availability || a.name.localeCompare(b.name));
+      break;
+    case "soonest":
+      sorted.sort((a, b) => a.soonestKey - b.soonestKey || a.name.localeCompare(b.name));
+      break;
+    case "sections":
+      sorted.sort((a, b) => b.sectionCount - a.sectionCount || a.name.localeCompare(b.name));
+      break;
+    case "name":
+      sorted.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+  }
+  return sorted;
+}


### PR DESCRIPTION
## What changes for someone using the site

Each course page gets a new **"Compare colleges"** section: every college that offers that course, side by side in one **sortable, filterable table** — soonest section, open seats, format mix, and section count, one row per college. So a student can answer "where should I take ENGL 1101?" at a glance instead of expanding 22 colleges one by one.

- **Sort:** most availability · soonest start · most sections · A–Z
- **Filter:** open seats · online · evening
- **"Not offered this term at N colleges"** footnote for the full picture.
- Sits **above** the existing per-college detail list (which stays for full per-section info); only shown when ≥2 colleges offer the course.

The **Seats column is honest** (built on #1087/#1088): real **"454 seats open"** in count states (GA/NC/TX), **"55 of 62 sections open"** in flag states (VA/MN/ND/NV), and **"—"** where there's no data. It never invents a number.

## What changes on the technical front

This is the Tier-B #3 feature, deliberately built *after* the seat-data honesty work so it stands on a trustworthy base.

- **`lib/compare-colleges.ts`** (pure, unit-tested): `buildCollegeCompareRows()` derives one honest row per college from the data the course page already loads (no new queries); `applyCompare()` does sort + filter. The Seats label routes through `lib/seats` (`aggregateSeats`); day formatting matches the page's detail table ("Mon Wed").
- **`components/CourseCollegeCompare.tsx`** (client): the interactive table, reusing `DataProvenanceNote` for the "confirm on the college's site" caveat.
- **`course/[code]` page**: computes rows + the not-offered list, renders the section.

### Honest deviations from the concept (`compare-colleges.html`)
The concept itself flagged these as illustrative, so they're **dropped**, not faked:
- **No "Est. cost" column** — institution cost is `null` for every college.
- **No per-row transfer column** — transfer is course-level (identical across colleges) and already shown in the page's Transfer Equivalencies table.

## Test plan
- **11 new tests** for the row-builder (count/flag/no-data seat labels, soonest, online/evening flags) + sort/filter. Full suite **568 pass / 0 fail**. tsc + eslint clean; `next build` OK.
- Live Playwright on real courses: GA `engl-1101` → real seat counts sorted by availability; VA `eng-111` → "N of M sections open"; "—" for no-data colleges. No fabricated numbers anywhere.

Depends on #1087 + #1088 (merged). Completes the Plan-to-Outcome audit's Tier-B #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)