### PR TITLE
choose: add "Help me choose" guided program-finder quiz

### DIFF
--- a/app/[state]/choose/page.tsx
+++ b/app/[state]/choose/page.tsx
@@ -1,0 +1,122 @@
+/**
+ * "Help me choose" guided flow — `/[state]/choose`.
+ *
+ * A short interest → goal → schedule quiz for students who don't yet know
+ * what to study. Matches against the REAL program catalog and links each
+ * result to the existing /[state]/program/[slug] comparison hub.
+ *
+ * Owner-approved concept (the `choose.html` prototype). Data is gathered
+ * server-side via `gatherChooseFacts` (live sections + BLS wages); the quiz
+ * itself is a small client component. Only programs that QUALIFY for a
+ * program page are ever surfaced, so a match can never dead-end on a 404.
+ *
+ * On-demand ISR (7 days) like the program/programs pages — no build-time
+ * fan-out. notFound() when the state has no qualifying programs at all
+ * (same gate as the /[state]/programs index).
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
+import { gatherChooseFacts } from "@/lib/programs/choose-data";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import ChooseQuiz from "@/components/ChooseQuiz";
+
+export const revalidate = 604800; // 7 days
+export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  return [];
+}
+
+type PageProps = {
+  params: Promise<{ state: string }>;
+};
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state } = await props.params;
+  if (!isValidState(state)) return { title: "Not Found" };
+  const config = requireStateConfig(state);
+  const title = `Not sure what to study? Find your program — ${config.name} Community Colleges`;
+  const description = `Answer three quick questions and we'll point you to community-college programs in ${config.name} that fit how you want to work — with real college counts, schedules, and earnings.`;
+  const canonical = `${siteUrl()}/${state}/choose`;
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function ChoosePage(props: PageProps) {
+  const { state } = await props.params;
+  if (!isValidState(state)) notFound();
+  const config = requireStateConfig(state);
+
+  const facts = await gatherChooseFacts(state);
+  // No qualifying programs at all → the tool has nothing to offer. Same gate
+  // as the /[state]/programs index, which notFound()s on an empty result.
+  if (facts.length === 0) notFound();
+
+  const url = siteUrl();
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-8">
+      <Breadcrumbs
+        siteUrl={url}
+        items={[
+          { name: config.branding.siteName, href: `/${state}` },
+          { name: "Find your program", href: `/${state}/choose` },
+        ]}
+      />
+
+      <header className="mt-2 text-center">
+        <span className="inline-flex items-center gap-2 rounded-full border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/30 px-3.5 py-1.5 text-[13px] font-semibold text-teal-700 dark:text-teal-300">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-3.5 w-3.5"
+            aria-hidden="true"
+          >
+            <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z" />
+          </svg>
+          No experience needed
+        </span>
+        <h1 className="mt-4 text-3xl sm:text-4xl font-extrabold tracking-tight text-slate-900 dark:text-slate-100">
+          Not sure what to study?{" "}
+          <span className="text-teal-600 dark:text-teal-400">Let&rsquo;s find it.</span>
+        </h1>
+        <p className="mx-auto mt-3 max-w-xl text-[15px] sm:text-base text-slate-500 dark:text-slate-400">
+          Three quick questions. We&rsquo;ll point you to {config.name} community
+          college programs that fit how you want to work — and what you want out
+          of it.
+        </p>
+      </header>
+
+      <div className="mt-2">
+        <ChooseQuiz
+          state={state}
+          stateName={config.name}
+          facts={facts}
+          transferSupported={config.transferSupported}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -152,6 +152,53 @@ export default async function HomePage({ params }: Props) {
           />
           <StartingSoonCallout state={state} />
         </div>
+
+        {/* "Help me choose" entry point — only when programs qualify (so the
+            quiz always has content; same gate as Browse by Program below). */}
+        {programSlugs.length > 0 && (
+          <div className="max-w-2xl mx-auto mt-8">
+            <Link
+              href={`/${state}/choose`}
+              className="group flex items-center gap-4 rounded-2xl border border-teal-200 dark:border-teal-800 bg-gradient-to-br from-teal-50 to-white dark:from-teal-900/30 dark:to-slate-900 px-5 py-4 transition-all hover:-translate-y-0.5 hover:shadow-md"
+            >
+              <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-teal-600 text-white">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-5 w-5"
+                  aria-hidden="true"
+                >
+                  <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z" />
+                </svg>
+              </span>
+              <span className="min-w-0 text-left">
+                <span className="block font-semibold text-gray-900 dark:text-slate-100">
+                  Not sure what to study?
+                </span>
+                <span className="block text-sm text-gray-600 dark:text-slate-400">
+                  Answer three quick questions and we&rsquo;ll point you to
+                  programs that fit.
+                </span>
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="ml-auto h-5 w-5 flex-shrink-0 text-teal-600 dark:text-teal-400 group-hover:translate-x-0.5 transition-transform"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14M13 6l6 6-6 6" />
+              </svg>
+            </Link>
+          </div>
+        )}
       </section>
 
       {/* How it works */}

--- a/components/ChooseQuiz.tsx
+++ b/components/ChooseQuiz.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+/**
+ * "Help me choose" guided quiz (client). Three questions — interest field,
+ * goal, schedule — then real program matches that link to the existing
+ * /[state]/program/[slug] comparison pages.
+ *
+ * All data arrives as props from the server page (`facts`); this component
+ * imports ONLY the client-safe taxonomy + pure `recommend` from
+ * `lib/programs/choose` (never the Supabase/fs gatherer). Every number shown
+ * is a measured value passed in — nothing is fabricated here.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  FIELDS,
+  GOALS,
+  TIMES,
+  recommend,
+  availableFieldIds,
+  type ChooseProgramFact,
+  type FieldId,
+  type GoalId,
+  type TimeId,
+} from "@/lib/programs/choose";
+
+type Props = {
+  state: string;
+  stateName: string;
+  facts: ChooseProgramFact[];
+  transferSupported: boolean;
+};
+
+/** Render one of our trusted inline-SVG path strings as a stroked icon. */
+function Icon({ path, className }: { path: string; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: path }}
+    />
+  );
+}
+
+const GOAL_LABEL: Record<GoalId, string> = {
+  job: "start working soon",
+  transfer: "transfer to a four-year",
+  pay: "earn the most",
+};
+
+/** One question card with a grid of selectable options. Module-level so it
+ *  isn't recreated on every render (which would remount and lose state). */
+function OptionGrid<T extends string>(props: {
+  qn: string;
+  title: string;
+  options: { id: T; label: string; desc: string; iconPath: string }[];
+  selected: T | null;
+  onPick: (id: T) => void;
+  canBack: boolean;
+  onBack: () => void;
+  two?: boolean;
+}) {
+  return (
+    <div className="rounded-3xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-sm p-6 sm:p-8">
+      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-teal-700 dark:text-teal-300">
+        {props.qn}
+      </p>
+      <h2 className="mt-1.5 text-xl sm:text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+        {props.title}
+      </h2>
+      <div
+        className={`mt-5 grid gap-3 ${
+          props.two ? "sm:grid-cols-2" : "grid-cols-1"
+        }`}
+      >
+        {props.options.map((o) => {
+          const on = props.selected === o.id;
+          return (
+            <button
+              key={o.id}
+              type="button"
+              onClick={() => props.onPick(o.id)}
+              aria-pressed={on}
+              className={`flex items-center gap-3.5 rounded-2xl border-[1.5px] px-4 py-3.5 text-left transition-all hover:-translate-y-0.5 ${
+                on
+                  ? "border-teal-600 bg-teal-50 dark:bg-teal-900/30"
+                  : "border-gray-200 dark:border-slate-700 hover:border-teal-600 bg-white dark:bg-slate-900"
+              }`}
+            >
+              <span
+                className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${
+                  on
+                    ? "bg-teal-600 text-white"
+                    : "bg-teal-50 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300"
+                }`}
+              >
+                <Icon path={o.iconPath} className="h-5 w-5" />
+              </span>
+              <span className="min-w-0">
+                <span className="block font-semibold text-slate-900 dark:text-slate-100">
+                  {o.label}
+                </span>
+                <span className="block text-[13px] text-slate-500 dark:text-slate-400">
+                  {o.desc}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-5 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={props.onBack}
+          disabled={!props.canBack}
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 hover:text-slate-900 dark:hover:text-slate-200 disabled:opacity-40 disabled:hover:text-slate-500"
+        >
+          <Icon path='<path d="M19 12H5M11 6l-6 6 6 6"/>' className="h-4 w-4" />
+          Back
+        </button>
+        <span className="text-[13px] text-slate-400">
+          Tap an answer to continue
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function ChooseQuiz({
+  state,
+  stateName,
+  facts,
+  transferSupported,
+}: Props) {
+  const [step, setStep] = useState(0); // 0=field, 1=goal, 2=time, 3=results
+  const [field, setField] = useState<FieldId | null>(null);
+  const [goal, setGoal] = useState<GoalId | null>(null);
+  const [time, setTime] = useState<TimeId | null>(null);
+
+  const available = availableFieldIds(facts);
+  const fieldOptions = FIELDS.filter((f) => available.has(f.id));
+  const someFieldsHidden = fieldOptions.length < FIELDS.length;
+
+  function reset() {
+    setStep(0);
+    setField(null);
+    setGoal(null);
+    setTime(null);
+  }
+
+  const progress = (
+    <div className="flex items-center justify-center gap-2 my-7">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className={`h-1.5 w-9 rounded-full transition-colors ${
+            i <= step ? "bg-teal-600" : "bg-gray-200 dark:bg-slate-700"
+          }`}
+        />
+      ))}
+    </div>
+  );
+
+  const goBack = () => setStep((s) => Math.max(0, s - 1));
+
+  // ---- Questions ----
+  if (step === 0) {
+    return (
+      <>
+        {progress}
+        <OptionGrid
+          qn="Question 1 of 3"
+          title="What kind of work sounds good to you?"
+          options={fieldOptions}
+          selected={field}
+          two
+          canBack={false}
+          onBack={goBack}
+          onPick={(id) => {
+            setField(id);
+            setStep(1);
+          }}
+        />
+        {someFieldsHidden && (
+          <p className="mt-4 text-center text-[13px] text-slate-500 dark:text-slate-400">
+            Some career &amp; trades programs aren&rsquo;t offered in {stateName}{" "}
+            yet.{" "}
+            <Link
+              href={`/${state}/programs`}
+              className="text-teal-700 dark:text-teal-300 underline underline-offset-2"
+            >
+              Browse every program
+            </Link>
+            .
+          </p>
+        )}
+      </>
+    );
+  }
+
+  if (step === 1) {
+    return (
+      <>
+        {progress}
+        <OptionGrid
+          qn="Question 2 of 3"
+          title="What matters most right now?"
+          options={GOALS}
+          selected={goal}
+          canBack
+          onBack={goBack}
+          onPick={(id) => {
+            setGoal(id);
+            setStep(2);
+          }}
+        />
+      </>
+    );
+  }
+
+  if (step === 2) {
+    return (
+      <>
+        {progress}
+        <OptionGrid
+          qn="Question 3 of 3"
+          title="How much time do you have for school?"
+          options={TIMES}
+          selected={time}
+          two
+          canBack
+          onBack={goBack}
+          onPick={(id) => {
+            setTime(id);
+            setStep(3);
+          }}
+        />
+      </>
+    );
+  }
+
+  // ---- Results ----
+  const answers =
+    field && goal && time ? { field, goal, time } : null;
+  const matches = answers ? recommend(facts, answers) : [];
+
+  return (
+    <>
+      {progress}
+      <div className="text-center">
+        <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+          {matches.length > 0
+            ? `Your best matches in ${stateName}`
+            : "Let's widen the search"}
+        </h2>
+        {answers && matches.length > 0 && (
+          <p className="mt-2 text-[15px] text-slate-500 dark:text-slate-400">
+            Because you want to {GOAL_LABEL[answers.goal]}, here are real
+            programs you can compare college by college.
+          </p>
+        )}
+      </div>
+
+      {matches.length === 0 ? (
+        <div className="mt-6 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 text-center">
+          <p className="text-slate-600 dark:text-slate-300">
+            We don&rsquo;t have programs in that area for {stateName} yet.
+          </p>
+          <Link
+            href={`/${state}/programs`}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-xl bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition-colors"
+          >
+            See all programs in {stateName}
+            <Icon path='<path d="M5 12h14M13 6l6 6-6 6"/>' className="h-4 w-4" />
+          </Link>
+        </div>
+      ) : (
+        <ul className="mt-6 space-y-3">
+          {matches.map((m, i) => (
+            <li key={m.slug}>
+              <Link
+                href={`/${state}/program/${m.slug}`}
+                className={`group flex items-center gap-4 rounded-2xl border p-4 sm:p-5 transition-all hover:-translate-y-0.5 hover:shadow-md ${
+                  i === 0
+                    ? "border-teal-300 dark:border-teal-700 bg-gradient-to-b from-white to-teal-50/60 dark:from-slate-900 dark:to-teal-900/20"
+                    : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900"
+                }`}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-lg font-semibold text-teal-800 dark:text-teal-200">
+                      {m.name}
+                    </h3>
+                    {i === 0 && (
+                      <span className="rounded-full bg-teal-600 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+                        Best match
+                      </span>
+                    )}
+                    <span className="rounded-full border border-gray-200 dark:border-slate-700 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {m.careerOriented ? "Career-focused" : "Transfer-focused"}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400 line-clamp-2">
+                    {m.blurb}
+                  </p>
+                  <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1 text-[13px] text-slate-600 dark:text-slate-300">
+                    <span>
+                      <b className="font-semibold text-slate-900 dark:text-slate-100">
+                        {m.collegeCount}
+                      </b>{" "}
+                      {m.collegeCount === 1 ? "college" : "colleges"}
+                    </span>
+                    <span>
+                      <b className="font-semibold text-slate-900 dark:text-slate-100">
+                        {m.sectionCount}
+                      </b>{" "}
+                      sections this term
+                    </span>
+                    {m.medianWage != null && (
+                      <span title="State median annual wage for the program's primary career (U.S. Bureau of Labor Statistics)">
+                        <b className="font-semibold text-slate-900 dark:text-slate-100">
+                          ${m.medianWage.toLocaleString()}
+                        </b>{" "}
+                        median pay · BLS
+                      </span>
+                    )}
+                    {answers?.time === "online" &&
+                      m.onlinePct != null &&
+                      m.onlinePct > 0 && (
+                        <span>
+                          <b className="font-semibold text-slate-900 dark:text-slate-100">
+                            {m.onlinePct}%
+                          </b>{" "}
+                          online
+                        </span>
+                      )}
+                    {answers?.time === "evening" && m.eveningAvailable && (
+                      <span className="text-teal-700 dark:text-teal-300">
+                        Evening sections available
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <Icon
+                  path='<path d="M5 12h14M13 6l6 6-6 6"/>'
+                  className="h-5 w-5 flex-shrink-0 text-slate-400 group-hover:text-teal-600 transition-colors"
+                />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Honesty note */}
+      {matches.length > 0 && (
+        <p className="mt-5 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+          Pay figures are state medians for a typical career from the U.S.
+          Bureau of Labor Statistics — a guide, not a guarantee. College and
+          section counts reflect the current term. Transfer-focused programs are
+          built to continue toward a bachelor&rsquo;s
+          {transferSupported ? (
+            <>
+              {" "}
+              —{" "}
+              <Link
+                href={`/${state}/transfer`}
+                className="text-teal-700 dark:text-teal-300 underline underline-offset-2"
+              >
+                check transfer equivalencies
+              </Link>
+              .
+            </>
+          ) : (
+            "."
+          )}
+        </p>
+      )}
+
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 dark:border-slate-700 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 hover:border-teal-600 transition-colors"
+        >
+          <Icon
+            path='<path d="M3 12a9 9 0 1 0 9-9 9 9 0 0 0-6.4 2.6L3 8"/><path d="M3 3v5h5"/>'
+            className="h-4 w-4"
+          />
+          Start over
+        </button>
+        <Link
+          href={`/${state}/programs`}
+          className="text-sm font-medium text-teal-700 dark:text-teal-300 underline underline-offset-2"
+        >
+          See all programs in {stateName}
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/lib/programs/__tests__/choose.test.ts
+++ b/lib/programs/__tests__/choose.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  recommend,
+  matchesTime,
+  availableFieldIds,
+  FIELDS,
+  GOALS,
+  TIMES,
+  type ChooseProgramFact,
+  type QuizAnswers,
+} from "../choose";
+
+// --- fixtures -------------------------------------------------------------
+
+function fact(p: Partial<ChooseProgramFact> & { slug: string }): ChooseProgramFact {
+  return {
+    name: p.slug,
+    blurb: "",
+    collegeCount: 5,
+    sectionCount: 50,
+    onlinePct: 0,
+    eveningAvailable: false,
+    medianWage: null,
+    careerOriented: false,
+    ...p,
+  };
+}
+
+// Business field = business-administration (career) + accounting (career).
+const bizAdmin = fact({
+  slug: "business-administration",
+  careerOriented: true,
+  medianWage: 80000,
+  sectionCount: 300,
+  collegeCount: 20,
+});
+const accounting = fact({
+  slug: "accounting",
+  careerOriented: true,
+  medianWage: 60000,
+  sectionCount: 100,
+  collegeCount: 15,
+});
+// Health field mixes career (nursing) + transfer (psychology, biology).
+const nursing = fact({
+  slug: "nursing",
+  careerOriented: true,
+  medianWage: 85000,
+  sectionCount: 90,
+  collegeCount: 12,
+  eveningAvailable: true,
+});
+const psychology = fact({
+  slug: "psychology",
+  careerOriented: false,
+  medianWage: null,
+  sectionCount: 200,
+  collegeCount: 18,
+  onlinePct: 40,
+});
+const biology = fact({
+  slug: "biology",
+  careerOriented: false,
+  medianWage: null,
+  sectionCount: 150,
+  collegeCount: 16,
+});
+
+const ALL = [bizAdmin, accounting, nursing, psychology, biology];
+
+const ans = (o: Partial<QuizAnswers>): QuizAnswers => ({
+  field: "business",
+  goal: "job",
+  time: "fulltime",
+  ...o,
+});
+
+// --- field filtering ------------------------------------------------------
+
+describe("recommend — field filtering", () => {
+  it("returns only programs in the chosen field", () => {
+    const r = recommend(ALL, ans({ field: "business" }));
+    expect(r.map((f) => f.slug).sort()).toEqual(["accounting", "business-administration"]);
+  });
+
+  it("returns [] for an unknown field id", () => {
+    // @ts-expect-error — testing defensive runtime behavior
+    expect(recommend(ALL, ans({ field: "nope" }))).toEqual([]);
+  });
+
+  it("returns [] when no facts are in the field", () => {
+    expect(recommend([psychology, biology], ans({ field: "business" }))).toEqual([]);
+  });
+
+  it("includes a slug that belongs to multiple fields under each", () => {
+    // biology is in both health and stem
+    const health = recommend(ALL, ans({ field: "health" })).map((f) => f.slug);
+    const stem = recommend(ALL, ans({ field: "stem" })).map((f) => f.slug);
+    expect(health).toContain("biology");
+    expect(stem).toContain("biology");
+  });
+});
+
+// --- goal ordering --------------------------------------------------------
+
+describe("recommend — goal: job", () => {
+  it("orders career-oriented programs before transfer-oriented", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "job" }));
+    // nursing (career) should come before psychology/biology (transfer)
+    const idxNursing = r.findIndex((f) => f.slug === "nursing");
+    const idxPsych = r.findIndex((f) => f.slug === "psychology");
+    expect(idxNursing).toBeLessThan(idxPsych);
+  });
+
+  it("within career programs, higher wage first", () => {
+    const r = recommend(ALL, ans({ field: "business", goal: "job" }));
+    expect(r[0].slug).toBe("business-administration"); // 80k > 60k
+  });
+});
+
+describe("recommend — goal: transfer", () => {
+  it("orders transfer-oriented programs before career programs", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "transfer" }));
+    const idxPsych = r.findIndex((f) => f.slug === "psychology");
+    const idxNursing = r.findIndex((f) => f.slug === "nursing");
+    expect(idxPsych).toBeLessThan(idxNursing);
+  });
+
+  it("within transfer programs, more colleges first", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "transfer" }));
+    // psychology (18 colleges) before biology (16)
+    const transferOnly = r.filter((f) => !f.careerOriented).map((f) => f.slug);
+    expect(transferOnly).toEqual(["psychology", "biology"]);
+  });
+});
+
+describe("recommend — goal: pay", () => {
+  it("orders by highest known wage, unknown-wage last", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "pay" }));
+    // nursing (85k) first; psychology & biology (null wage) last
+    expect(r[0].slug).toBe("nursing");
+    expect(r[r.length - 1].careerOriented).toBe(false); // a null-wage program trails
+  });
+
+  it("never floats a null-wage program above a real wage", () => {
+    const r = recommend(ALL, ans({ field: "business", goal: "pay" }));
+    expect(r.map((f) => f.slug)).toEqual(["business-administration", "accounting"]);
+  });
+
+  // Regression: two null-wage programs must not produce a NaN comparator
+  // (Infinity - Infinity). They must fall through to the section tiebreak.
+  it("orders two unknown-wage programs by sections (no NaN corruption)", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "pay" }));
+    const transferOnly = r.filter((f) => !f.careerOriented).map((f) => f.slug);
+    // psychology (200 sections) before biology (150), both null wage
+    expect(transferOnly).toEqual(["psychology", "biology"]);
+  });
+});
+
+describe("recommend — goal: job with unknown-wage pairs (NaN regression)", () => {
+  it("orders two unknown-wage transfer programs by sections under job goal", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "job" }));
+    const transferOnly = r.filter((f) => !f.careerOriented).map((f) => f.slug);
+    // psychology (200) before biology (150) — would be unstable if NaN leaked
+    expect(transferOnly).toEqual(["psychology", "biology"]);
+  });
+
+  // Strong form: reverse the input order. A NaN comparator (Infinity-Infinity)
+  // makes V8 keep input order, so this would yield [biology, psychology] and
+  // fail. The finite comparator sorts by sections regardless of input order.
+  it("sorts unknown-wage pairs by the comparator, not input order", () => {
+    const reversed = [biology, psychology]; // bio first on input
+    const r = recommend(reversed, ans({ field: "health", goal: "pay" }));
+    expect(r.map((f) => f.slug)).toEqual(["psychology", "biology"]); // 200 > 150
+  });
+});
+
+// --- time annotation ------------------------------------------------------
+
+describe("matchesTime", () => {
+  it("evening matches only programs with evening sections", () => {
+    expect(matchesTime(nursing, "evening")).toBe(true);
+    expect(matchesTime(biology, "evening")).toBe(false);
+  });
+  it("online matches only programs with >0 online share", () => {
+    expect(matchesTime(psychology, "online")).toBe(true);
+    expect(matchesTime(biology, "online")).toBe(false);
+  });
+  it("fulltime and parttime match everything", () => {
+    expect(matchesTime(biology, "fulltime")).toBe(true);
+    expect(matchesTime(biology, "parttime")).toBe(true);
+  });
+});
+
+describe("recommend — time floats matches up without dropping", () => {
+  it("evening preference floats evening programs first but keeps the rest", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "transfer", time: "evening" }));
+    // nursing is the only evening-available one → it floats to the front
+    expect(r[0].slug).toBe("nursing");
+    // but psychology and biology are still present (not dropped)
+    expect(r.map((f) => f.slug).sort()).toEqual(["biology", "nursing", "psychology"]);
+  });
+
+  it("online preference floats online programs first", () => {
+    const r = recommend(ALL, ans({ field: "health", goal: "transfer", time: "online" }));
+    expect(r[0].slug).toBe("psychology"); // only one with onlinePct > 0
+    expect(r).toHaveLength(3);
+  });
+
+  it("fulltime does not reorder beyond the goal ordering", () => {
+    const full = recommend(ALL, ans({ field: "health", goal: "transfer", time: "fulltime" }));
+    const part = recommend(ALL, ans({ field: "health", goal: "transfer", time: "parttime" }));
+    expect(full.map((f) => f.slug)).toEqual(part.map((f) => f.slug));
+  });
+});
+
+// --- determinism ----------------------------------------------------------
+
+describe("recommend — determinism", () => {
+  it("is stable across calls (slug tie-break)", () => {
+    const tied = [
+      fact({ slug: "english", careerOriented: false, collegeCount: 10, sectionCount: 100 }),
+      fact({ slug: "art", careerOriented: false, collegeCount: 10, sectionCount: 100 }),
+      fact({ slug: "history", careerOriented: false, collegeCount: 10, sectionCount: 100 }),
+    ];
+    const a = recommend(tied, ans({ field: "arts", goal: "transfer" })).map((f) => f.slug);
+    const b = recommend(tied, ans({ field: "arts", goal: "transfer" })).map((f) => f.slug);
+    expect(a).toEqual(b);
+    expect(a).toEqual(["art", "english", "history"]); // alphabetical on full tie
+  });
+});
+
+// --- availableFieldIds ----------------------------------------------------
+
+describe("availableFieldIds", () => {
+  it("marks a field available when any of its slugs has a fact", () => {
+    const avail = availableFieldIds([accounting]);
+    expect(avail.has("business")).toBe(true);
+    expect(avail.has("trades")).toBe(false);
+  });
+
+  it("returns an empty set when no facts", () => {
+    expect(availableFieldIds([]).size).toBe(0);
+  });
+
+  it("a multi-field slug marks all its fields available", () => {
+    const avail = availableFieldIds([biology]); // health + stem
+    expect(avail.has("health")).toBe(true);
+    expect(avail.has("stem")).toBe(true);
+    expect(avail.has("business")).toBe(false);
+  });
+});
+
+// --- taxonomy sanity ------------------------------------------------------
+
+describe("taxonomy", () => {
+  it("every field has at least 2 slugs and valid metadata", () => {
+    for (const f of FIELDS) {
+      expect(f.slugs.length).toBeGreaterThanOrEqual(2);
+      expect(f.label.length).toBeGreaterThan(0);
+      expect(f.iconPath).toContain("<path");
+    }
+  });
+  it("has 3 goals and 4 time options", () => {
+    expect(GOALS).toHaveLength(3);
+    expect(TIMES).toHaveLength(4);
+  });
+});

--- a/lib/programs/__tests__/choose.test.ts
+++ b/lib/programs/__tests__/choose.test.ts
@@ -3,12 +3,14 @@ import {
   recommend,
   matchesTime,
   availableFieldIds,
+  relevantSlugs,
   FIELDS,
   GOALS,
   TIMES,
   type ChooseProgramFact,
   type QuizAnswers,
 } from "../choose";
+import { PROGRAMS } from "../registry";
 
 // --- fixtures -------------------------------------------------------------
 
@@ -264,5 +266,31 @@ describe("taxonomy", () => {
   it("has 3 goals and 4 time options", () => {
     expect(GOALS).toHaveLength(3);
     expect(TIMES).toHaveLength(4);
+  });
+
+  it("every field slug exists in the program registry", () => {
+    const valid = new Set(PROGRAMS.map((p) => p.slug));
+    for (const f of FIELDS) {
+      for (const s of f.slugs) {
+        expect(valid.has(s), `${s} (field ${f.id}) is not a registry slug`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  // INVARIANT that guarantees the home-page CTA never links to an empty quiz:
+  // the home page shows the CTA when getQualifyingProgramSlugs(state) is
+  // non-empty (a subset of all registry slugs), and /[state]/choose has
+  // content when any relevantSlug qualifies. Those are equivalent ONLY if
+  // relevantSlugs() covers every registry slug. If a future program is added
+  // to the registry without being placed in a field, this fails — assign it
+  // to a FIELD (or change the CTA gate) so the CTA can't dead-end on a 404.
+  it("relevantSlugs() covers every registry program slug (CTA-no-404 invariant)", () => {
+    const relevant = new Set(relevantSlugs());
+    const missing = PROGRAMS.map((p) => p.slug).filter((s) => !relevant.has(s));
+    expect(missing, `registry slugs missing from any field: ${missing.join(", ")}`).toEqual(
+      [],
+    );
   });
 });

--- a/lib/programs/choose-data.ts
+++ b/lib/programs/choose-data.ts
@@ -1,0 +1,63 @@
+/**
+ * Server-only fact gatherer for the "Help me choose" flow.
+ *
+ * Kept separate from `choose.ts` (the client-safe taxonomy + pure logic) so
+ * that importing the quiz UI never drags Supabase / `node:fs` into the client
+ * bundle. Reads ONLY runtime-available sources:
+ *   - live sections via `loadProgramData` (Supabase — same path the
+ *     /[state]/programs index uses, cached + ISR)
+ *   - BLS wages from the bundled `data/bls/wages.json` (fs)
+ *
+ * Emits a fact ONLY for slugs that clear `qualifies()`, so a recommendation
+ * can never link to a program page that soft-404s. Never fabricates a number:
+ * every field is a measured value or null.
+ */
+
+import { loadProgramData, qualifies } from "./index";
+import { getProgramBySlug } from "./registry";
+import { relevantSlugs, type ChooseProgramFact } from "./choose";
+import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
+import { getStateSocStats } from "@/lib/bls";
+
+/**
+ * Gather honest facts for every quiz-relevant program that QUALIFIES in the
+ * state this term. Cost profile mirrors the /[state]/programs index
+ * (loadProgramData per slug, cached). Returns only qualifying slugs.
+ */
+export async function gatherChooseFacts(
+  state: string,
+): Promise<ChooseProgramFact[]> {
+  const results = await Promise.all(
+    relevantSlugs().map(async (slug) => {
+      const def = getProgramBySlug(slug);
+      if (!def) return null;
+      const data = await loadProgramData(state, slug).catch(() => null);
+      if (!data || !qualifies(data)) return null;
+
+      const profile = computeCourseAvailabilityProfile(data.flatSections);
+      const onlinePct = profile
+        ? Math.round(
+            (profile.modes.pcts.online ?? 0) + (profile.modes.pcts.zoom ?? 0),
+          )
+        : null;
+      const eveningAvailable = profile ? profile.timeOfDay.evening > 0 : false;
+      const medianWage = def.primarySoc
+        ? getStateSocStats(state, def.primarySoc)?.medianAnnualWage ?? null
+        : null;
+
+      return {
+        slug,
+        name: def.name,
+        blurb: def.description,
+        collegeCount: data.totalColleges,
+        sectionCount: data.totalSections,
+        onlinePct,
+        eveningAvailable,
+        medianWage,
+        careerOriented: def.primarySoc != null,
+      } satisfies ChooseProgramFact;
+    }),
+  );
+
+  return results.filter((r): r is ChooseProgramFact => r !== null);
+}

--- a/lib/programs/choose.ts
+++ b/lib/programs/choose.ts
@@ -1,0 +1,358 @@
+/**
+ * "Help me choose" guided-flow data layer + pure recommendation logic.
+ *
+ * Powers `/[state]/choose`: a short interest → goal → schedule quiz that
+ * points an undecided student at real program comparison pages. Owner-
+ * approved concept (the `choose.html` prototype); this is the production
+ * wiring against the REAL catalog.
+ *
+ * Two halves, deliberately separated:
+ *
+ *  1. PURE LOGIC (`recommend`, the FIELDS/GOALS/TIMES taxonomy) — no I/O,
+ *     fully unit-tested. Given a set of program facts and the student's
+ *     three answers, returns the ordered matches.
+ *
+ *  2. SERVER GATHERER (`gatherChooseFacts`) — reads only data sources proven
+ *     available at runtime: live sections via `loadProgramData` (Supabase,
+ *     same path the /[state]/programs index uses) + BLS wages (bundled
+ *     file). It NEVER fabricates a number; every field is a measured value
+ *     or null. Slugs are emitted ONLY when they clear `qualifies()`, so a
+ *     recommendation can never link to a program page that soft-404s.
+ *
+ * Design decisions worth keeping (verified against real data 2026-06-02):
+ *  - Field taxonomy maps onto slugs that actually qualify. Each non-trades
+ *    field has at least one near-universally-qualifying anchor (psychology,
+ *    biology, mathematics, liberal-arts) so results are rarely empty. Trades
+ *    is genuinely state-limited by data; the UI says so and offers an escape.
+ *  - Job-vs-transfer orientation comes from the registry `primarySoc`
+ *    (non-null = a direct CC career path; null = transfer-oriented), NOT from
+ *    scraped `total_credits`/credentials, which are only 3–18% populated in
+ *    some states.
+ *  - No transfer-coverage % is computed here: `transfer-equiv.json` is
+ *    excluded from runtime bundles, and career programs legitimately have
+ *    ~0 transfer rows. The UI links to the existing transfer views instead.
+ */
+
+import { loadProgramData, qualifies } from "./index";
+import { getProgramBySlug } from "./registry";
+import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
+import { getStateSocStats } from "@/lib/bls";
+
+// ---------------------------------------------------------------------------
+// Quiz taxonomy (config-driven — tune the field→slug map in one place)
+// ---------------------------------------------------------------------------
+
+export type FieldId = "business" | "health" | "stem" | "arts" | "trades";
+export type GoalId = "job" | "transfer" | "pay";
+export type TimeId = "fulltime" | "parttime" | "evening" | "online";
+
+export type FieldDef = {
+  id: FieldId;
+  /** Card title shown in the quiz. */
+  label: string;
+  /** One-line plain-language hint under the title. */
+  desc: string;
+  /**
+   * Registry program slugs this interest maps to. A slug may appear under
+   * more than one field (e.g. biology under both health and stem) — that's
+   * intentional; goal/time ordering surfaces the most relevant first.
+   */
+  slugs: string[];
+  /** Inline SVG path(s) for the card icon (no <svg> wrapper). */
+  iconPath: string;
+};
+
+/**
+ * Order matters — this is the on-screen order of Q1. Every field except
+ * `trades` includes at least one slug that qualifies in nearly every state
+ * with program data, so a student rarely hits an empty result.
+ */
+export const FIELDS: FieldDef[] = [
+  {
+    id: "business",
+    label: "Business & money",
+    desc: "Accounting, management, marketing",
+    slugs: ["business-administration", "accounting"],
+    iconPath: '<path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/>',
+  },
+  {
+    id: "health",
+    label: "Health & helping people",
+    desc: "Nursing, child care, psychology",
+    slugs: ["nursing", "early-childhood-education", "psychology", "biology"],
+    iconPath:
+      '<path d="M12 21s-7-4.5-7-10a4 4 0 0 1 7-2 4 4 0 0 1 7 2c0 5.5-7 10-7 10z"/>',
+  },
+  {
+    id: "stem",
+    label: "Science, tech & math",
+    desc: "Computers, engineering, math",
+    slugs: ["computer-science", "engineering", "mathematics", "biology"],
+    iconPath:
+      '<path d="M9 3h6M10 3v6l-5 9a2 2 0 0 0 2 3h10a2 2 0 0 0 2-3l-5-9V3"/>',
+  },
+  {
+    id: "arts",
+    label: "Arts & humanities",
+    desc: "English, history, art, liberal arts",
+    slugs: ["english", "history", "art", "liberal-arts"],
+    iconPath:
+      '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>',
+  },
+  {
+    id: "trades",
+    label: "Hands-on & trades",
+    desc: "Welding, automotive, criminal justice",
+    slugs: ["welding", "automotive-technology", "criminal-justice"],
+    iconPath:
+      '<path d="M14.7 6.3a4 4 0 0 0-5.6 5.6L3 18l3 3 6.1-6.1a4 4 0 0 0 5.6-5.6l-2.9 2.9-2-2 2.9-2.9z"/>',
+  },
+];
+
+export type GoalDef = {
+  id: GoalId;
+  label: string;
+  desc: string;
+  iconPath: string;
+};
+
+export const GOALS: GoalDef[] = [
+  {
+    id: "job",
+    label: "A job, soon",
+    desc: "Start working as fast as I can",
+    iconPath:
+      '<rect x="3" y="7" width="18" height="13" rx="2"/><path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>',
+  },
+  {
+    id: "transfer",
+    label: "Transfer to a 4-year",
+    desc: "A bachelor's degree is the goal",
+    iconPath: '<path d="M4 7h12M12 3l4 4-4 4"/><path d="M20 17H8M12 21l-4-4 4-4"/>',
+  },
+  {
+    id: "pay",
+    label: "The highest pay",
+    desc: "Earnings matter most to me",
+    iconPath: '<path d="M3 17l6-6 4 4 7-8"/><path d="M21 7v5h-5"/>',
+  },
+];
+
+export type TimeDef = {
+  id: TimeId;
+  label: string;
+  desc: string;
+  iconPath: string;
+};
+
+export const TIMES: TimeDef[] = [
+  {
+    id: "fulltime",
+    label: "Full-time",
+    desc: "I can take a full load",
+    iconPath: '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+  },
+  {
+    id: "parttime",
+    label: "Part-time",
+    desc: "A class or two at a time",
+    iconPath: '<circle cx="12" cy="12" r="9"/><path d="M12 12V8M12 12h4"/>',
+  },
+  {
+    id: "evening",
+    label: "Evenings & weekends",
+    desc: "I work during the day",
+    iconPath: '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>',
+  },
+  {
+    id: "online",
+    label: "Online",
+    desc: "I'd rather study from home",
+    iconPath:
+      '<rect x="3" y="4" width="18" height="13" rx="2"/><path d="M8 21h8M12 17v4"/>',
+  },
+];
+
+export const FIELD_IDS = FIELDS.map((f) => f.id);
+export const GOAL_IDS = GOALS.map((g) => g.id);
+export const TIME_IDS = TIMES.map((t) => t.id);
+
+// ---------------------------------------------------------------------------
+// Facts (gathered server-side, serialized to the client). All values are
+// measured or null — never estimated.
+// ---------------------------------------------------------------------------
+
+export type ChooseProgramFact = {
+  slug: string;
+  name: string;
+  /** Registry description; the UI line-clamps it. */
+  blurb: string;
+  /** Colleges in the state offering coursework in this program (live term). */
+  collegeCount: number;
+  /** Total sections this term across those colleges. */
+  sectionCount: number;
+  /** % of sections that are online/remote, rounded; null if unknown. */
+  onlinePct: number | null;
+  /** Whether any section meets in the evening (start ≥ 17:00). */
+  eveningAvailable: boolean;
+  /** State median annual wage for the program's primary career (BLS); null if
+   *  transfer-oriented or no BLS data for this state/occupation. */
+  medianWage: number | null;
+  /** True when the program maps to a direct CC career (registry primarySoc);
+   *  false for transfer-oriented majors. Drives job-vs-transfer ordering. */
+  careerOriented: boolean;
+};
+
+export type QuizAnswers = {
+  field: FieldId;
+  goal: GoalId;
+  time: TimeId;
+};
+
+// ---------------------------------------------------------------------------
+// Pure recommendation logic (no I/O — unit-tested)
+// ---------------------------------------------------------------------------
+
+/** Does a fact match the schedule preference? full/part-time never filter. */
+export function matchesTime(fact: ChooseProgramFact, time: TimeId): boolean {
+  if (time === "evening") return fact.eveningAvailable;
+  if (time === "online") return (fact.onlinePct ?? 0) > 0;
+  return true; // fulltime / parttime — every program allows these
+}
+
+/**
+ * Comparator key for a fact under a goal. Lower sorts first. Returned as a
+ * tuple compared lexicographically by `byKey`. Wage-unknown always sorts
+ * after wage-known (via the `wageKnown` flag) so we never push a "no data"
+ * card above a real one.
+ *
+ * All components are FINITE — never use ±Infinity here: two unknown-wage
+ * facts would otherwise yield `Infinity - Infinity = NaN` in `byKey`, and a
+ * NaN from a sort comparator silently corrupts ordering. The `wageKnown`
+ * flag separates known/unknown, and `wageDesc` is 0 for unknowns (only ever
+ * compared against other unknowns, where it ties and falls through to the
+ * next component).
+ */
+function goalKey(fact: ChooseProgramFact, goal: GoalId): number[] {
+  const wage = fact.medianWage;
+  const wageKnown = wage == null ? 1 : 0; // 0 (known) sorts before 1 (unknown)
+  const wageDesc = wage == null ? 0 : -wage; // higher wage first among known
+  const sections = -fact.sectionCount;
+  const colleges = -fact.collegeCount;
+  switch (goal) {
+    case "job":
+      // Career-path first, then known pay, then higher pay, then sections.
+      return [fact.careerOriented ? 0 : 1, wageKnown, wageDesc, sections];
+    case "transfer":
+      // Transfer-oriented majors first, then breadth (more colleges), sections.
+      return [fact.careerOriented ? 1 : 0, colleges, sections];
+    case "pay":
+      // Known wage first, then highest wage, then sections.
+      return [wageKnown, wageDesc, sections];
+  }
+}
+
+/** Lexicographic compare of two equal-length numeric tuples. */
+function byKey(a: number[], b: number[]): number {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Core recommendation: filter to the chosen field's qualifying programs,
+ * order by goal, then float schedule-matching programs to the top WITHOUT
+ * dropping the rest (avoids empty results). Deterministic: ties break on
+ * slug so the output is stable for tests and ISR.
+ */
+export function recommend(
+  facts: ChooseProgramFact[],
+  answers: QuizAnswers,
+): ChooseProgramFact[] {
+  const field = FIELDS.find((f) => f.id === answers.field);
+  if (!field) return [];
+  const allowed = new Set(field.slugs);
+
+  const inField = facts.filter((f) => allowed.has(f.slug));
+
+  // Stable ordering by goal, slug as the final tie-breaker.
+  const ordered = [...inField].sort((a, b) => {
+    const k = byKey(goalKey(a, answers.goal), goalKey(b, answers.goal));
+    return k !== 0 ? k : a.slug.localeCompare(b.slug);
+  });
+
+  // Float schedule matches up while preserving goal order within each group.
+  if (answers.time === "evening" || answers.time === "online") {
+    const match = ordered.filter((f) => matchesTime(f, answers.time));
+    const rest = ordered.filter((f) => !matchesTime(f, answers.time));
+    return [...match, ...rest];
+  }
+  return ordered;
+}
+
+// ---------------------------------------------------------------------------
+// Server-side fact gathering (Supabase live sections + bundled BLS file)
+// ---------------------------------------------------------------------------
+
+/** Every slug referenced by any field (deduped) — the universe to evaluate. */
+function relevantSlugs(): string[] {
+  return [...new Set(FIELDS.flatMap((f) => f.slugs))];
+}
+
+/**
+ * Gather honest facts for every quiz-relevant program that QUALIFIES in the
+ * state this term. Mirrors the /[state]/programs index cost profile
+ * (loadProgramData per slug, cached + ISR). Returns only qualifying slugs,
+ * so the client can never recommend a soft-404 page.
+ */
+export async function gatherChooseFacts(
+  state: string,
+): Promise<ChooseProgramFact[]> {
+  const slugs = relevantSlugs();
+  const results = await Promise.all(
+    slugs.map(async (slug) => {
+      const def = getProgramBySlug(slug);
+      if (!def) return null;
+      const data = await loadProgramData(state, slug).catch(() => null);
+      if (!data || !qualifies(data)) return null;
+
+      const profile = computeCourseAvailabilityProfile(data.flatSections);
+      const onlinePct = profile
+        ? Math.round((profile.modes.pcts.online ?? 0) + (profile.modes.pcts.zoom ?? 0))
+        : null;
+      const eveningAvailable = profile ? profile.timeOfDay.evening > 0 : false;
+      const medianWage = def.primarySoc
+        ? getStateSocStats(state, def.primarySoc)?.medianAnnualWage ?? null
+        : null;
+
+      return {
+        slug,
+        name: def.name,
+        blurb: def.description,
+        collegeCount: data.totalColleges,
+        sectionCount: data.totalSections,
+        onlinePct,
+        eveningAvailable,
+        medianWage,
+        careerOriented: def.primarySoc != null,
+      } satisfies ChooseProgramFact;
+    }),
+  );
+
+  return results.filter((r): r is ChooseProgramFact => r !== null);
+}
+
+/**
+ * Which fields will actually yield ≥1 result given the qualifying facts.
+ * Lets the page disable/annotate dead fields up front rather than letting a
+ * student pick one and hit an empty screen.
+ */
+export function availableFieldIds(facts: ChooseProgramFact[]): Set<FieldId> {
+  const present = new Set(facts.map((f) => f.slug));
+  const out = new Set<FieldId>();
+  for (const field of FIELDS) {
+    if (field.slugs.some((s) => present.has(s))) out.add(field.id);
+  }
+  return out;
+}

--- a/lib/programs/choose.ts
+++ b/lib/programs/choose.ts
@@ -1,23 +1,18 @@
 /**
- * "Help me choose" guided-flow data layer + pure recommendation logic.
+ * "Help me choose" guided-flow taxonomy + PURE recommendation logic.
  *
  * Powers `/[state]/choose`: a short interest → goal → schedule quiz that
  * points an undecided student at real program comparison pages. Owner-
  * approved concept (the `choose.html` prototype); this is the production
  * wiring against the REAL catalog.
  *
- * Two halves, deliberately separated:
+ * This module is CLIENT-SAFE: no I/O, no server-only imports. It is imported
+ * by both the server page and the `ChooseQuiz` client component. The async
+ * fact gatherer (which reads Supabase + the BLS file) lives separately in
+ * `choose-data.ts` so server-only code never leaks into the client bundle.
  *
- *  1. PURE LOGIC (`recommend`, the FIELDS/GOALS/TIMES taxonomy) — no I/O,
- *     fully unit-tested. Given a set of program facts and the student's
- *     three answers, returns the ordered matches.
- *
- *  2. SERVER GATHERER (`gatherChooseFacts`) — reads only data sources proven
- *     available at runtime: live sections via `loadProgramData` (Supabase,
- *     same path the /[state]/programs index uses) + BLS wages (bundled
- *     file). It NEVER fabricates a number; every field is a measured value
- *     or null. Slugs are emitted ONLY when they clear `qualifies()`, so a
- *     recommendation can never link to a program page that soft-404s.
+ * Given a set of program facts and the student's three answers, `recommend`
+ * returns the ordered matches — fully unit-tested.
  *
  * Design decisions worth keeping (verified against real data 2026-06-02):
  *  - Field taxonomy maps onto slugs that actually qualify. Each non-trades
@@ -27,16 +22,11 @@
  *  - Job-vs-transfer orientation comes from the registry `primarySoc`
  *    (non-null = a direct CC career path; null = transfer-oriented), NOT from
  *    scraped `total_credits`/credentials, which are only 3–18% populated in
- *    some states.
- *  - No transfer-coverage % is computed here: `transfer-equiv.json` is
- *    excluded from runtime bundles, and career programs legitimately have
- *    ~0 transfer rows. The UI links to the existing transfer views instead.
+ *    some states. (Applied in `choose-data.ts` when building facts.)
+ *  - No transfer-coverage % is computed: `transfer-equiv.json` is excluded
+ *    from runtime bundles, and career programs legitimately have ~0 transfer
+ *    rows. The UI links to the existing transfer views instead.
  */
-
-import { loadProgramData, qualifies } from "./index";
-import { getProgramBySlug } from "./registry";
-import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
-import { getStateSocStats } from "@/lib/bls";
 
 // ---------------------------------------------------------------------------
 // Quiz taxonomy (config-driven — tune the field→slug map in one place)
@@ -291,62 +281,10 @@ export function recommend(
   return ordered;
 }
 
-// ---------------------------------------------------------------------------
-// Server-side fact gathering (Supabase live sections + bundled BLS file)
-// ---------------------------------------------------------------------------
-
-/** Every slug referenced by any field (deduped) — the universe to evaluate. */
-function relevantSlugs(): string[] {
-  return [...new Set(FIELDS.flatMap((f) => f.slugs))];
-}
-
-/**
- * Gather honest facts for every quiz-relevant program that QUALIFIES in the
- * state this term. Mirrors the /[state]/programs index cost profile
- * (loadProgramData per slug, cached + ISR). Returns only qualifying slugs,
- * so the client can never recommend a soft-404 page.
- */
-export async function gatherChooseFacts(
-  state: string,
-): Promise<ChooseProgramFact[]> {
-  const slugs = relevantSlugs();
-  const results = await Promise.all(
-    slugs.map(async (slug) => {
-      const def = getProgramBySlug(slug);
-      if (!def) return null;
-      const data = await loadProgramData(state, slug).catch(() => null);
-      if (!data || !qualifies(data)) return null;
-
-      const profile = computeCourseAvailabilityProfile(data.flatSections);
-      const onlinePct = profile
-        ? Math.round((profile.modes.pcts.online ?? 0) + (profile.modes.pcts.zoom ?? 0))
-        : null;
-      const eveningAvailable = profile ? profile.timeOfDay.evening > 0 : false;
-      const medianWage = def.primarySoc
-        ? getStateSocStats(state, def.primarySoc)?.medianAnnualWage ?? null
-        : null;
-
-      return {
-        slug,
-        name: def.name,
-        blurb: def.description,
-        collegeCount: data.totalColleges,
-        sectionCount: data.totalSections,
-        onlinePct,
-        eveningAvailable,
-        medianWage,
-        careerOriented: def.primarySoc != null,
-      } satisfies ChooseProgramFact;
-    }),
-  );
-
-  return results.filter((r): r is ChooseProgramFact => r !== null);
-}
-
 /**
  * Which fields will actually yield ≥1 result given the qualifying facts.
- * Lets the page disable/annotate dead fields up front rather than letting a
- * student pick one and hit an empty screen.
+ * Lets the UI disable/annotate dead fields up front rather than letting a
+ * student pick one and hit an empty screen. Pure — runs on the client.
  */
 export function availableFieldIds(facts: ChooseProgramFact[]): Set<FieldId> {
   const present = new Set(facts.map((f) => f.slug));
@@ -355,4 +293,10 @@ export function availableFieldIds(facts: ChooseProgramFact[]): Set<FieldId> {
     if (field.slugs.some((s) => present.has(s))) out.add(field.id);
   }
   return out;
+}
+
+/** Every slug referenced by any field (deduped) — the universe to evaluate
+ *  server-side. Pure; lives here so the taxonomy stays the single source. */
+export function relevantSlugs(): string[] {
+  return [...new Set(FIELDS.flatMap((f) => f.slugs))];
 }


### PR DESCRIPTION
## What changes for someone using the site

A student who doesn't know what to study can now answer three quick questions — what kind of work appeals to them, what they want out of it (a job, transfer, or pay), and how much time they have — and get a short list of **real** community-college programs that fit, each linking straight to that program's comparison page.

- New page: **`/{state}/choose`** ("Not sure what to study? Let's find it.").
- New entry point: a **"Not sure what to study?"** card on the state home page (e.g. `/va`), right under the search box.
- Results are honest: each card shows only measured, sourced numbers — how many colleges offer it, sections this term, **BLS median pay** for the career (when we have it), and online%/evening availability when the student asked about schedule. No made-up "fit %" scores.
- Every recommended program links to a page that's **guaranteed to exist** — the quiz only ever surfaces programs that already qualify for their own comparison page, so a match can never dead-end on a 404.

Try it: `/va/choose` (rich state, all 5 interest areas), `/ga/choose` or `/tn/choose` (trades correctly hidden — those programs aren't in our data there yet, and the UI says so with a link to browse everything).

## What changes on the technical front

- **`lib/programs/choose.ts`** — client-safe taxonomy (interest fields → registry slugs) + pure `recommend()` (filter by field, order by goal, float schedule matches). 27 unit tests.
- **`lib/programs/choose-data.ts`** — server-only fact gatherer. Reads only runtime-available sources: live sections via `loadProgramData` (same Supabase path as `/{state}/programs`, cached + ISR) and bundled BLS wages. Split from the taxonomy so Supabase/`fs` never enter the client bundle.
- **`app/[state]/choose/page.tsx`** — server page; `notFound()` when a state has no qualifying programs; on-demand ISR (7d), 0 pages prerendered at build (no build-time fan-out).
- **`components/ChooseQuiz.tsx`** — the client quiz.
- **`app/[state]/page.tsx`** — the home CTA, gated on the existing `programSlugs` signal (locked by a test to the same set the quiz uses, so the CTA can't link to an empty quiz).

### Design decisions (verified against live VA/GA/TN data)
- Interest fields map onto slugs that actually qualify; each non-trades field has a near-universal anchor (psychology/biology/mathematics/liberal-arts) so results are rarely empty. Trades is genuinely state-limited by data — surfaced honestly, not faked. (The prototype's literal 4 fields would have returned empty in many states — e.g. TN had 3 of 4 empty.)
- Job-vs-transfer ordering comes from the registry `primarySoc`, **not** the scraped `total_credits` (only 3–18% populated in some states).
- No transfer-coverage % is computed (`transfer-equiv.json` is bundle-excluded; career programs legitimately have ~0 transfer rows). Transfer-focused results link to the existing transfer views instead.

## Test plan
- `npx vitest run` — 582 pass (27 new, incl. a NaN sort-comparator regression and the CTA-no-404 invariant).
- `npm run build` — exit 0; `/[state]/choose` present as on-demand ISR (0 prerendered).
- `tsc --noEmit` clean; eslint clean.
- Playwright against the worktree dev server: full quiz flow on `/va/choose` (interest → goal → schedule → results), result links resolve to `/va/program/{slug}`, mobile (390px) and dark mode render correctly, invalid state → 404.

No new data pipeline or cron — reuses existing Supabase + BLS sources, so nothing to schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)