### PR TITLE
fix(search): rescue natural-language course searches that returned 0 (e.g. "math courses without prerequisite")

### DIFF
--- a/lib/__tests__/courses-search.test.ts
+++ b/lib/__tests__/courses-search.test.ts
@@ -3,7 +3,26 @@ import {
   parseQuery,
   matchesTimeOfDay,
   sectionMatchesDays,
+  meaningfulKeywordTokens,
 } from "../courses-search";
+
+describe("meaningfulKeywordTokens (zero-result rescue)", () => {
+  it("strips course/qualifier filler, keeping the subject", () => {
+    expect(meaningfulKeywordTokens("math courses without prerequisite?")).toEqual(["math"]);
+    expect(meaningfulKeywordTokens("biology classes")).toEqual(["biology"]);
+  });
+  it("keeps multiple subject/descriptor tokens", () => {
+    expect(meaningfulKeywordTokens("online accounting courses")).toEqual(["online", "accounting"]);
+  });
+  it("drops tokens under 3 chars and punctuation", () => {
+    // "of" = filler, "ml" = under 3 chars → both dropped; "art" kept.
+    expect(meaningfulKeywordTokens("art of ml")).toEqual(["art"]);
+  });
+  it("returns [] when only filler remains, so the rescue is skipped (stays 0)", () => {
+    expect(meaningfulKeywordTokens("courses that have no prerequisites")).toEqual([]);
+    expect(meaningfulKeywordTokens("any courses with no prereqs")).toEqual([]);
+  });
+});
 
 describe("parseQuery", () => {
   it("parses an exact course code with space", () => {

--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -1,6 +1,7 @@
 import type { CourseSection, Institution } from "./types";
 import { getZipCoordinates, calculateDistance } from "./geo";
-import { searchSections } from "./courses";
+import { searchSections, getDistinctSubjects } from "./courses";
+import { subjectName } from "./subjects";
 
 // ---------------------------------------------------------------------------
 // Cross-college search
@@ -51,6 +52,31 @@ export function parseQuery(q: string): {
 
   // Otherwise treat as keyword search on title
   return { prefix: null, number: null, keyword: q.trim().toLowerCase() };
+}
+
+// Filler words dropped when rescuing a no-result natural-language keyword query
+// (e.g. "math courses without prerequisite" → "math"). Intentionally narrow:
+// generic course/qualifier words, not subject or descriptor words, so we never
+// strip the part that identifies what the student wants.
+const KEYWORD_FILLER = new Set([
+  "course", "courses", "class", "classes", "section", "sections",
+  "without", "with", "no", "not", "any", "all", "some", "that", "which",
+  "have", "having", "has", "the", "for", "and", "or", "to", "do", "does",
+  "prerequisite", "prerequisites", "prereq", "prereqs", "requisite", "requisites",
+  "requirement", "requirements", "require", "requires", "required", "need", "needs",
+]);
+
+/**
+ * Reduce a free-text keyword to its meaningful tokens for the zero-result
+ * rescue: lowercase, strip punctuation, drop filler words and tokens under 3
+ * chars. "math courses without prerequisite?" → ["math"].
+ */
+export function meaningfulKeywordTokens(keyword: string): string[] {
+  return keyword
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 3 && !KEYWORD_FILLER.has(t));
 }
 
 /** Check if a time string falls in a time-of-day bucket */
@@ -106,12 +132,60 @@ export async function searchCoursesAcrossColleges(
   totalSections: number;
   totalColleges: number;
 }> {
-  const { prefix, number, keyword } = parseQuery(query);
+  let { prefix, number, keyword } = parseQuery(query);
   // Push the query predicate into Postgres instead of loading every section
   // for the term and filtering in JS (which 504'd on large states like CA,
   // ~188k rows). The JS filters below still run on this already-narrowed set,
   // so output is unchanged — just over 10s–1000s of rows.
-  const allCourses = await searchSections(term, state, { prefix, number, keyword });
+  let allCourses = await searchSections(term, state, { prefix, number, keyword });
+
+  // Zero-result rescue for natural-language keyword phrases. A keyword like
+  // "math courses without prerequisite" matches no course TITLE verbatim, so the
+  // server-side search returns nothing (this also happens when the /ask
+  // classifier leaves `keyword` null and the client searches the raw sentence).
+  // Strip filler words and re-query on the remaining subject token(s). Because a
+  // short subject word re-parses as a PREFIX (e.g. "math" → MATH), this recovers
+  // the whole subject, not just title matches. Only runs when the normal search
+  // found nothing, so it can never change a query that already returns results.
+  if (allCourses.length === 0 && keyword) {
+    const tokens = meaningfulKeywordTokens(keyword);
+    if (tokens.length > 0) {
+      // Resolve each token to THIS state's actual subject prefixes via subject
+      // names — so "math" → MTH (VA) / MAT (NC) / MATH (CT,TX), not a literal
+      // "MATH" that only some states use. Query those prefixes, plus each token
+      // as a title keyword (to catch title-only words like "calculus" that
+      // aren't subject names). Union + dedupe.
+      const subjects = await getDistinctSubjects(term, state);
+      const matchPrefixes = subjects.filter((p) =>
+        tokens.some(
+          (t) => p.toLowerCase().includes(t) || subjectName(p).toLowerCase().includes(t),
+        ),
+      );
+      const seen = new Set<string>();
+      const union: CourseSection[] = [];
+      const add = (rows: CourseSection[]) => {
+        for (const r of rows) {
+          const k = `${r.course_prefix}-${r.course_number}-${r.college_code}-${r.crn}`;
+          if (!seen.has(k)) {
+            seen.add(k);
+            union.push(r);
+          }
+        }
+      };
+      for (const p of matchPrefixes) {
+        add(await searchSections(term, state, { prefix: p, number: null, keyword: null }));
+      }
+      for (const t of tokens) {
+        add(await searchSections(term, state, { prefix: null, number: null, keyword: t }));
+      }
+      if (union.length > 0) {
+        allCourses = union;
+        prefix = null;
+        number = null;
+        keyword = null; // already matched per-token above
+      }
+    }
+  }
 
   // Build institution lookup
   const instMap = new Map<string, Institution>();
@@ -126,20 +200,22 @@ export async function searchCoursesAcrossColleges(
     if (zipInfo) userCoords = { lat: zipInfo.lat, lng: zipInfo.lng };
   }
 
-  // Step 1: Filter sections
+  // Non-query filters (mode/days/time) — shared by the main pass and the
+  // zero-result keyword rescue below so they stay in sync.
+  const passesFilters = (s: CourseSection): boolean => {
+    if (filters.mode && s.mode !== filters.mode) return false;
+    if (filters.days && filters.days.length > 0 && !sectionMatchesDays(s.days, filters.days)) return false;
+    if (filters.timeOfDay && !matchesTimeOfDay(s.start_time, filters.timeOfDay)) return false;
+    return true;
+  };
+
+  // Step 1: Apply the remaining JS-side filters to the server-narrowed set
+  // (prefix/number/keyword reflect the rescue's effective parse when it ran).
   const matched = allCourses.filter((s) => {
-    // Query matching
     if (prefix && s.course_prefix !== prefix) return false;
     if (number && s.course_number !== number) return false;
     if (keyword && !s.course_title.toLowerCase().includes(keyword)) return false;
-
-    // Filters
-    if (filters.mode && s.mode !== filters.mode) return false;
-    if (filters.days && filters.days.length > 0 && !sectionMatchesDays(s.days, filters.days)) return false;
-    if (filters.timeOfDay && !matchesTimeOfDay(s.start_time, filters.timeOfDay))
-      return false;
-
-    return true;
+    return passesFilters(s);
   });
 
   // Step 2: Group by course (prefix+number), then by college


### PR DESCRIPTION
## What changes for someone using the site

Typing a course search as a sentence — like **"math courses without prerequisite"** — used to show **"No matching courses"** even though the state has dozens of math courses. Now it returns them. Verified live across states: that query returns **VA 26, NC 24, CT 32, TX 89** math courses (it resolves to each state's real prefix — MTH / MAT / MATH). It does *not* invent results when there's genuinely no subject in the query ("courses without prerequisites" → still empty, as it should be).

## Why it happened

The course search filters by a **literal title substring** (a server-side `ILIKE`, added to stop big states like CA from timing out on ~188k rows). So a full sentence matches no course title and returns nothing. This also triggers when the `/ask` classifier identifies the intent but leaves the structured `keyword` empty, so the client searches the raw sentence verbatim. (Root-caused from a CT screenshot where the answer card correctly said "math courses that have no prerequisites" but the grid showed 0.)

## The fix (`lib/courses-search.ts`)

A **zero-result rescue** — it runs *only* when the normal search finds nothing, so it can never change a query that already works:

1. Strip filler words ("courses", "class", "without", "prerequisite", …) to the meaningful subject token(s) — `"math courses without prerequisite?"` → `["math"]`.
2. Resolve each token to **this state's actual subject prefixes** via `subjectName()` (so "math" → `MTH` in VA, `MAT` in NC, `MATH` in CT/TX — not a literal "MATH"), and query those prefixes.
3. Also query each token as a **title keyword**, to catch title-only words like "calculus"/"algebra" that aren't subject names.
4. Union + dedupe.

If no subject token survives (e.g. "courses without prerequisites"), the rescue is skipped and the result stays empty — the answer card's clarification still shows.

### Test plan
- New unit tests for `meaningfulKeywordTokens` (filler stripping, <3-char drop, empty → skip). **26 search tests pass; typecheck + lint clean.**
- **Verified on the live dev route** against real Supabase data for VA/NC/CT/TX (numbers above), plus controls: "history" → 25 (unchanged normal path), code queries like "ENG 101" untouched, "courses without prerequisites" → 0.

Independent of the Groq/Cloudflare classifier work — this hardens the search itself so it's robust no matter what the classifier extracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)