### PR TITLE
nav: add "Find your program" link + group the menu into sections

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,20 +5,44 @@ import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 
-const NAV_ITEMS = [
-  { path: "", label: "Search" },
-  { path: "/courses", label: "Find a Course" },
-  { path: "/starting-soon", label: "Starting Soon" },
-  { path: "/schedule", label: "Schedule Builder" },
-  { path: "/transfer", label: "Transfer" },
-  { path: "/plan", label: "Semester Planner" },
-  { path: "/colleges", label: "All Colleges" },
-  // Programs index — every page in the site links here so the
-  // /[state]/program/[slug] comparison hubs (federal earnings data, awards
-  // counts) are one click away regardless of entry point. See #413.
-  { path: "/programs", label: "Programs" },
-  { path: "/about", label: "About" },
+// Task-based nav groups — single source of truth. The slide-down menu renders
+// these as labeled columns (a mega-menu); the desktop bar flattens them into a
+// single row. "Find your program" (the guided quiz) sits with Programs; it's
+// ungated like /programs (both notFound() when a state has no qualifying
+// programs). See #413 for why the Programs index is reachable from every page.
+const NAV_GROUPS = [
+  {
+    heading: "Explore classes",
+    items: [
+      { path: "", label: "Search" },
+      { path: "/courses", label: "Find a Course" },
+      { path: "/starting-soon", label: "Starting Soon" },
+      { path: "/colleges", label: "All Colleges" },
+    ],
+  },
+  {
+    heading: "Plan your path",
+    items: [
+      { path: "/schedule", label: "Schedule Builder" },
+      { path: "/plan", label: "Semester Planner" },
+      { path: "/transfer", label: "Transfer" },
+    ],
+  },
+  {
+    heading: "Programs & majors",
+    items: [
+      { path: "/choose", label: "Find your program" },
+      { path: "/programs", label: "Programs" },
+    ],
+  },
 ];
+
+// "More" utility links — kept out of the task groups (About is state-scoped;
+// All States is the global "/" home). Rendered last in the menu.
+const MORE_ITEMS = [{ path: "/about", label: "About" }];
+
+// Flat list (group order) for the desktop horizontal bar.
+const NAV_ITEMS = [...NAV_GROUPS.flatMap((g) => g.items), ...MORE_ITEMS];
 
 // Guides dropdown — exposes high-traffic blog clusters from sitewide nav.
 // Issue #374: senior waivers cluster pulled 600+ monthly impressions across
@@ -79,18 +103,60 @@ export default function Header({ state, stateName, transferSupported = true, pre
     return () => document.removeEventListener("keydown", handleEsc);
   }, [guidesOpen]);
 
-  const links = NAV_ITEMS
-    .filter((item) => item.path !== "/transfer" || transferSupported)
-    .filter((item) => item.path !== "/plan" || prereqsAvailable)
-    .map((item) => ({
-      href: `/${state}${item.path}`,
-      label: item.label,
-    }));
+  // Hide transfer/planner where the state lacks the data backing them.
+  const showItem = (path: string) =>
+    (path !== "/transfer" || transferSupported) &&
+    (path !== "/plan" || prereqsAvailable);
+  const toLink = (item: { path: string; label: string }) => ({
+    href: `/${state}${item.path}`,
+    label: item.label,
+  });
+
+  // Desktop horizontal bar — flat, in group order.
+  const links = NAV_ITEMS.filter((i) => showItem(i.path)).map(toLink);
+
+  // Slide-down mega-menu columns: task groups, then Guides, then a "More"
+  // column (About + the global All States link).
+  const menuColumns: { heading: string; links: { href: string; label: string }[] }[] = [
+    ...NAV_GROUPS.map((g) => ({
+      heading: g.heading,
+      links: g.items.filter((i) => showItem(i.path)).map(toLink),
+    })),
+    {
+      heading: "Guides",
+      links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })),
+    },
+    {
+      heading: "More",
+      links: [
+        ...MORE_ITEMS.filter((i) => showItem(i.path)).map(toLink),
+        { href: "/", label: "All States" },
+      ],
+    },
+  ];
 
   return (
     <header className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
+          {/* Hamburger (below xl) — top-left, before the logo. */}
+          <button
+            type="button"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            className="xl:hidden inline-flex items-center justify-center w-10 h-10 -ml-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
+            aria-label="Toggle menu"
+            aria-expanded={mobileOpen}
+          >
+            {mobileOpen ? (
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+              </svg>
+            )}
+          </button>
           <Link href="/" className="text-xs text-gray-400 dark:text-slate-500 hover:text-teal-600 transition-colors hidden sm:block" title="All States">
             <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
@@ -107,8 +173,10 @@ export default function Header({ state, stateName, transferSupported = true, pre
           </Link>
         </div>
 
-        {/* Desktop nav */}
-        <nav className="hidden sm:flex items-center gap-6 text-sm text-gray-600 dark:text-slate-400">
+        {/* Desktop nav — shown only at xl+ where all items fit. Below that the
+            hamburger menu (which lists every item, plus Sign In + theme) takes
+            over, so the dense nav never overflows / clips Sign In on tablets. */}
+        <nav className="hidden xl:flex items-center gap-6 text-sm text-gray-600 dark:text-slate-400">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -165,64 +233,36 @@ export default function Header({ state, stateName, transferSupported = true, pre
           <ThemeToggle />
         </nav>
 
-        {/* Mobile: user menu + theme toggle + hamburger */}
-        <div className="sm:hidden flex items-center gap-2">
+        {/* Below xl: just account + theme on the right; the hamburger lives
+            top-left (next to the logo). */}
+        <div className="xl:hidden flex items-center gap-2">
           <UserMenu />
           <ThemeToggle />
-        <button
-          type="button"
-          onClick={() => setMobileOpen(!mobileOpen)}
-          className="inline-flex items-center justify-center w-10 h-10 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
-          aria-label="Toggle menu"
-          aria-expanded={mobileOpen}
-        >
-          {mobileOpen ? (
-            <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          ) : (
-            <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-            </svg>
-          )}
-        </button>
         </div>
       </div>
 
-      {/* Mobile dropdown */}
+      {/* Slide-down mega-menu (below xl). Each task group is a labeled column;
+          columns flow into a responsive grid so the menu fills the width on
+          tablet/laptop and stacks to one column on phones. */}
       {mobileOpen && (
-        <nav className="sm:hidden border-t border-gray-100 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 pb-4 pt-2">
-          <Link
-            href="/"
-            onClick={() => setMobileOpen(false)}
-            className="block py-2.5 text-sm text-gray-500 dark:text-slate-400 hover:text-teal-600 transition-colors"
-          >
-            All States
-          </Link>
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              onClick={() => setMobileOpen(false)}
-              className="block py-2.5 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
-            >
-              {link.label}
-            </Link>
-          ))}
-          {/* Guides section (#374) — same destinations as the desktop dropdown */}
-          <div className="mt-3 pt-3 border-t border-gray-100 dark:border-slate-700">
-            <p className="text-[11px] uppercase tracking-wide font-medium text-gray-400 dark:text-slate-500 mb-1">
-              Guides
-            </p>
-            {GUIDES_ITEMS.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setMobileOpen(false)}
-                className="block py-2 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
-              >
-                {item.label}
-              </Link>
+        <nav className="xl:hidden border-t border-gray-100 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 sm:px-6 lg:px-8 pb-6 pt-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-6">
+            {menuColumns.map((col) => (
+              <div key={col.heading}>
+                <p className="text-[11px] uppercase tracking-wide font-semibold text-gray-400 dark:text-slate-500 mb-1.5">
+                  {col.heading}
+                </p>
+                {col.links.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={() => setMobileOpen(false)}
+                    className="block py-2 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
             ))}
           </div>
         </nav>


### PR DESCRIPTION
## What changes for someone using the site

- The top navigation now has a **"Find your program"** link (the guided quiz at `/{state}/choose`), so students can reach it from any page — not just the home-page card.
- On phones and tablets, the slide-down menu is now **grouped into labeled sections** instead of one long flat list: **Explore classes**, **Plan your path**, **Programs & majors**, **Guides**, and **More**. On tablets these lay out as columns that fill the width; on phones they stack.
- The **hamburger button moved to the top-left** (next to the logo); Sign In + theme toggle stay top-right.
- Fixes a pre-existing bug: the nav used to **overflow on tablets** (~640–1024px), pushing Sign In and the theme toggle off-screen. Now any width too narrow for the full horizontal bar uses the hamburger menu, so nothing is ever clipped.

## What changes on the technical front

`components/Header.tsx`:
- Replaced the flat `NAV_ITEMS` array with a task-based `NAV_GROUPS` structure as the single source of truth. The desktop bar flattens it (group order); the mobile/tablet menu renders each group as a labeled column in a responsive grid (`grid-cols-1 → sm:2 → md:3`).
- Raised the horizontal-nav breakpoint from `sm` to `xl`. Below 1280px the existing hamburger menu (which lists every item plus Sign In + theme) takes over, eliminating the overflow. The hamburger button now lives in the top-left group.
- Transfer/Planner gating (`transferSupported` / `prereqsAvailable`) is preserved via a shared `showItem` helper applied to both the desktop bar and the menu columns.

## Test plan
- `npm run build` — exit 0, compiled successfully.
- 595 tests pass; `tsc --noEmit` + eslint clean.
- Playwright against the worktree dev server: verified no header overflow at 768 / 1024 / 1100 / 1280 / 1440px; desktop shows the flat bar (≥1280), narrower widths show the grouped hamburger menu; "Find your program" present in both; Sign In + theme reachable at all widths.

Pure presentational change — no data or routing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)