### PR TITLE
nav: convert top nav to a pinnable left sidebar

### DIFF
--- a/app/tailwind.source.css
+++ b/app/tailwind.source.css
@@ -83,3 +83,19 @@ body {
     opacity: 1;
   }
 }
+
+/* Side navigation push (components/Header.tsx).
+   When the sidebar is open, the header sets data-nav-open on <html>. On
+   desktop (≥1024px) the body shifts right by the sidebar width (16rem = w-64)
+   so the fixed sidebar doesn't cover content; on smaller screens the sidebar
+   is an overlay, so no push. Only state pages render that header, so this
+   attribute is never set elsewhere. */
+body {
+  transition: padding-left 0.2s ease;
+}
+
+@media (min-width: 1024px) {
+  html[data-nav-open="1"] body {
+    padding-left: 16rem;
+  }
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 
-// Task-based nav groups — single source of truth. The slide-down menu renders
-// these as labeled columns (a mega-menu); the desktop bar flattens them into a
-// single row. "Find your program" (the guided quiz) sits with Programs; it's
-// ungated like /programs (both notFound() when a state has no qualifying
-// programs). See #413 for why the Programs index is reachable from every page.
+// Task-based nav groups — single source of truth for the sidebar. "Find your
+// program" (the guided quiz) sits with Programs; it's ungated like /programs
+// (both notFound() when a state has no qualifying programs). See #413 for why
+// the Programs index is reachable from every page.
 const NAV_GROUPS = [
   {
     heading: "Explore classes",
@@ -37,71 +36,119 @@ const NAV_GROUPS = [
   },
 ];
 
-// "More" utility links — kept out of the task groups (About is state-scoped;
-// All States is the global "/" home). Rendered last in the menu.
+// "More" utility links — About is state-scoped; All States is the global "/".
 const MORE_ITEMS = [{ path: "/about", label: "About" }];
 
-// Flat list (group order) for the desktop horizontal bar.
-const NAV_ITEMS = [...NAV_GROUPS.flatMap((g) => g.items), ...MORE_ITEMS];
-
-// Guides dropdown — exposes high-traffic blog clusters from sitewide nav.
-// Issue #374: senior waivers cluster pulled 600+ monthly impressions across
-// 13 spokes; transfer-credit cluster pulled 930+ on 2 hubs alone. Both were
-// previously only discoverable via direct organic search, not header.
+// Guides cluster (#374) — high-traffic blog hubs surfaced in the sidebar.
 const GUIDES_ITEMS = [
-  {
-    href: "/blog/free-community-college-classes-for-seniors",
-    label: "Senior Waivers",
-    description: "Free tuition for seniors by state",
-  },
-  {
-    href: "/blog/how-to-check-if-community-college-course-transfers",
-    label: "Transfer Guides",
-    description: "Direct match vs elective credit",
-  },
-  {
-    href: "/blog/what-does-audit-a-class-mean",
-    label: "Auditing a Class",
-    description: "Sit in without credit pressure",
-  },
-  {
-    href: "/blog/how-to-find-late-start-community-college-classes",
-    label: "Late-Start Classes",
-    description: "Enroll after the semester started",
-  },
-  {
-    href: "/blog",
-    label: "All Articles →",
-    description: "",
-  },
+  { href: "/blog/free-community-college-classes-for-seniors", label: "Senior Waivers" },
+  { href: "/blog/how-to-check-if-community-college-course-transfers", label: "Transfer Guides" },
+  { href: "/blog/what-does-audit-a-class-mean", label: "Auditing a Class" },
+  { href: "/blog/how-to-find-late-start-community-college-classes", label: "Late-Start Classes" },
+  { href: "/blog", label: "All Articles →" },
 ];
 
-export default function Header({ state, stateName, transferSupported = true, prereqsAvailable = false }: { state: string; stateName?: string; transferSupported?: boolean; prereqsAvailable?: boolean }) {
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [guidesOpen, setGuidesOpen] = useState(false);
-  const guidesRef = useRef<HTMLDivElement>(null);
+const PIN_KEY = "ccp-nav-pinned";
+const DESKTOP_MQ = "(min-width: 1024px)";
 
-  // Close guides dropdown on outside click (matches UserMenu pattern)
+export default function Header({
+  state,
+  stateName,
+  transferSupported = true,
+  prereqsAvailable = false,
+}: {
+  state: string;
+  stateName?: string;
+  transferSupported?: boolean;
+  prereqsAvailable?: boolean;
+}) {
+  // `open` is the transient show/hide; `pinned` (persisted) keeps the sidebar
+  // open across navigation on desktop. `isDesktop` gates pinning + push.
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  // On desktop the sidebar shows when opened OR pinned; on mobile only when
+  // explicitly opened (pin is a desktop-only convenience).
+  const effectiveOpen = isDesktop ? open || pinned : open;
+
+  // Track viewport so pin/push apply on desktop only.
   useEffect(() => {
-    if (!guidesOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (guidesRef.current && !guidesRef.current.contains(e.target as Node)) {
-        setGuidesOpen(false);
+    const mql = window.matchMedia(DESKTOP_MQ);
+    const sync = () => setIsDesktop(mql.matches);
+    sync();
+    mql.addEventListener("change", sync);
+    return () => mql.removeEventListener("change", sync);
+  }, []);
+
+  // Restore the persisted pin once on mount (client-only; can't read during
+  // SSR). Same hydration-safe pattern as ThemeToggle/UserMenu.
+  useEffect(() => {
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      if (localStorage.getItem(PIN_KEY) === "1") setPinned(true);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Reflect the open state onto <html> so a small CSS rule can push page
+  // content right on desktop (the fixed sidebar fills the gap). Removed on
+  // unmount so non-state pages (which don't render this header) never shift.
+  useEffect(() => {
+    const el = document.documentElement;
+    if (effectiveOpen) el.setAttribute("data-nav-open", "1");
+    else el.removeAttribute("data-nav-open");
+    return () => el.removeAttribute("data-nav-open");
+  }, [effectiveOpen]);
+
+  // Close on Escape (transient close; leaves pin state alone).
+  useEffect(() => {
+    if (!effectiveOpen) return;
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        setPinned(false);
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [guidesOpen]);
+    document.addEventListener("keydown", onEsc);
+    return () => document.removeEventListener("keydown", onEsc);
+  }, [effectiveOpen]);
 
-  // Close guides dropdown on Escape
-  useEffect(() => {
-    if (!guidesOpen) return;
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setGuidesOpen(false);
-    };
-    document.addEventListener("keydown", handleEsc);
-    return () => document.removeEventListener("keydown", handleEsc);
-  }, [guidesOpen]);
+  const persistPin = (next: boolean) => {
+    setPinned(next);
+    try {
+      localStorage.setItem(PIN_KEY, next ? "1" : "0");
+    } catch {
+      /* ignore */
+    }
+  };
+
+  // Hamburger: show if hidden; fully close (and unpin) if showing.
+  const toggle = useCallback(() => {
+    if (effectiveOpen) {
+      setOpen(false);
+      persistPin(false);
+    } else {
+      setOpen(true);
+    }
+  }, [effectiveOpen]);
+
+  const closeNav = () => {
+    setOpen(false);
+    persistPin(false);
+  };
+
+  // Clicking a link closes the menu unless it's pinned open on desktop.
+  const onNavigate = () => {
+    if (!(isDesktop && pinned)) setOpen(false);
+  };
+
+  const togglePin = () => {
+    const next = !pinned;
+    persistPin(next);
+    if (next) setOpen(true);
+  };
 
   // Hide transfer/planner where the state lacks the data backing them.
   const showItem = (path: string) =>
@@ -112,20 +159,12 @@ export default function Header({ state, stateName, transferSupported = true, pre
     label: item.label,
   });
 
-  // Desktop horizontal bar — flat, in group order.
-  const links = NAV_ITEMS.filter((i) => showItem(i.path)).map(toLink);
-
-  // Slide-down mega-menu columns: task groups, then Guides, then a "More"
-  // column (About + the global All States link).
-  const menuColumns: { heading: string; links: { href: string; label: string }[] }[] = [
+  const columns: { heading: string; links: { href: string; label: string }[] }[] = [
     ...NAV_GROUPS.map((g) => ({
       heading: g.heading,
       links: g.items.filter((i) => showItem(i.path)).map(toLink),
     })),
-    {
-      heading: "Guides",
-      links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })),
-    },
+    { heading: "Guides", links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })) },
     {
       heading: "More",
       links: [
@@ -136,137 +175,125 @@ export default function Header({ state, stateName, transferSupported = true, pre
   ];
 
   return (
-    <header className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          {/* Hamburger (below xl) — top-left, before the logo. */}
-          <button
-            type="button"
-            onClick={() => setMobileOpen(!mobileOpen)}
-            className="xl:hidden inline-flex items-center justify-center w-10 h-10 -ml-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
-            aria-label="Toggle menu"
-            aria-expanded={mobileOpen}
-          >
-            {mobileOpen ? (
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            ) : (
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-              </svg>
-            )}
-          </button>
-          <Link href="/" className="text-xs text-gray-400 dark:text-slate-500 hover:text-teal-600 transition-colors hidden sm:block" title="All States">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
-            </svg>
-          </Link>
-          <Link href={`/${state}`} className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-teal-600 rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-xs">CCP</span>
-            </div>
-            <span className="text-xl font-semibold text-gray-900 dark:text-slate-100">
-              Community College <span className="text-teal-600">Path</span>{" "}
-              <span className="text-gray-400 dark:text-slate-500 font-normal text-base hidden sm:inline">{stateName}</span>
-            </span>
-          </Link>
-        </div>
-
-        {/* Desktop nav — shown only at xl+ where all items fit. Below that the
-            hamburger menu (which lists every item, plus Sign In + theme) takes
-            over, so the dense nav never overflows / clips Sign In on tablets. */}
-        <nav className="hidden xl:flex items-center gap-6 text-sm text-gray-600 dark:text-slate-400">
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="hover:text-teal-600 transition-colors"
-            >
-              {link.label}
-            </Link>
-          ))}
-          {/* Guides dropdown — replaces the plain "Blog" link (#374) */}
-          <div className="relative" ref={guidesRef}>
+    <>
+      {/* Top bar */}
+      <header className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 sticky top-0 z-30">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
             <button
               type="button"
-              onClick={() => setGuidesOpen(!guidesOpen)}
-              className="inline-flex items-center gap-1 hover:text-teal-600 transition-colors"
-              aria-expanded={guidesOpen}
-              aria-haspopup="true"
+              onClick={toggle}
+              className="inline-flex items-center justify-center w-10 h-10 -ml-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
+              aria-label={effectiveOpen ? "Close menu" : "Open menu"}
+              aria-expanded={effectiveOpen}
+              aria-controls="site-sidebar"
             >
-              Guides
-              <svg
-                className={`w-3 h-3 transition-transform ${guidesOpen ? "rotate-180" : ""}`}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+              {effectiveOpen ? (
+                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                </svg>
+              )}
+            </button>
+            <Link href={`/${state}`} className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-teal-600 rounded-lg flex items-center justify-center">
+                <span className="text-white font-bold text-xs">CCP</span>
+              </div>
+              <span className="text-xl font-semibold text-gray-900 dark:text-slate-100">
+                Community College <span className="text-teal-600">Path</span>{" "}
+                <span className="text-gray-400 dark:text-slate-500 font-normal text-base hidden sm:inline">
+                  {stateName}
+                </span>
+              </span>
+            </Link>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <UserMenu />
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      {/* Backdrop — mobile only, when the overlay sidebar is open. */}
+      {effectiveOpen && !isDesktop && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 lg:hidden"
+          aria-hidden="true"
+          onClick={closeNav}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        id="site-sidebar"
+        aria-label="Site navigation"
+        className={`fixed top-0 left-0 z-50 flex h-dvh w-64 flex-col border-r border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg transition-transform duration-200 ease-out ${
+          effectiveOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        {/* Sidebar control row — aligns with the top bar height. */}
+        <div className="flex h-[65px] flex-shrink-0 items-center justify-between border-b border-gray-100 dark:border-slate-700 px-4">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-slate-500">
+            Menu
+          </span>
+          <div className="flex items-center gap-1">
+            {/* Pin (desktop only) — keep the sidebar open while navigating. */}
+            {isDesktop && (
+              <button
+                type="button"
+                onClick={togglePin}
+                aria-pressed={pinned}
+                title={pinned ? "Unpin menu" : "Keep menu open"}
+                className={`inline-flex h-8 w-8 items-center justify-center rounded-md transition ${
+                  pinned
+                    ? "bg-teal-50 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300"
+                    : "text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                }`}
               >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                {/* pin icon */}
+                <svg className="h-[18px] w-[18px]" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 4h6l-1 7 3 2v2H7v-2l3-2-1-7zM12 15v5" />
+                </svg>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={closeNav}
+              aria-label="Close menu"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-slate-200 transition"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
-            {guidesOpen && (
-              <div className="absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 py-1 z-50">
-                {GUIDES_ITEMS.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={() => setGuidesOpen(false)}
-                    className="block px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-                  >
-                    <div className="text-sm font-medium text-gray-900 dark:text-slate-100">
-                      {item.label}
-                    </div>
-                    {item.description && (
-                      <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
-                        {item.description}
-                      </div>
-                    )}
-                  </Link>
-                ))}
-              </div>
-            )}
           </div>
-          <UserMenu />
-          <ThemeToggle />
-        </nav>
-
-        {/* Below xl: just account + theme on the right; the hamburger lives
-            top-left (next to the logo). */}
-        <div className="xl:hidden flex items-center gap-2">
-          <UserMenu />
-          <ThemeToggle />
         </div>
-      </div>
 
-      {/* Slide-down mega-menu (below xl). Each task group is a labeled column;
-          columns flow into a responsive grid so the menu fills the width on
-          tablet/laptop and stacks to one column on phones. */}
-      {mobileOpen && (
-        <nav className="xl:hidden border-t border-gray-100 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 sm:px-6 lg:px-8 pb-6 pt-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-6">
-            {menuColumns.map((col) => (
-              <div key={col.heading}>
-                <p className="text-[11px] uppercase tracking-wide font-semibold text-gray-400 dark:text-slate-500 mb-1.5">
-                  {col.heading}
-                </p>
-                {col.links.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    onClick={() => setMobileOpen(false)}
-                    className="block py-2 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </div>
-            ))}
-          </div>
+        {/* Grouped nav (vertical) */}
+        <nav className="flex-1 overflow-y-auto px-3 py-4">
+          {columns.map((col) => (
+            <div key={col.heading} className="mb-5 last:mb-0">
+              <p className="px-2 mb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-slate-500">
+                {col.heading}
+              </p>
+              {col.links.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={onNavigate}
+                  className="block rounded-md px-2 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-50 hover:text-teal-700 dark:hover:bg-slate-800 dark:hover:text-teal-300 transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          ))}
         </nav>
-      )}
-    </header>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## What changes for someone using the site

The navigation on state pages (e.g. `/va`, `/mn`) is now a **left sidebar** opened by the hamburger button — at every screen size, not just narrow ones.

- **Always the hamburger.** No more horizontal nav bar; the hamburger (top-left) opens the menu everywhere.
- **Grouped, vertical menu:** Explore classes → Plan your path → Programs & majors → Guides → More.
- **Keep it open while you browse.** A pin button (desktop) keeps the sidebar open as you move between pages; it remembers your choice. When pinned/open on desktop, page content shifts right so nothing is hidden. On phones/tablets it's a temporary overlay with a dim backdrop that closes when you tap a link.
- The top bar still shows the logo, Sign In, and the light/dark toggle.

Try it: open `/va`, click the hamburger, click the pin, then click around — the menu stays put. Narrow the window and it becomes an overlay instead.

## What changes on the technical front

`components/Header.tsx` — rewritten from a top bar + dropdown into a top bar + fixed left sidebar:
- State model: `open` (transient) + `pinned` (persisted to `localStorage`) + `isDesktop` (matchMedia). The sidebar shows when `open || pinned` on desktop, or `open` on mobile.
- **Content push** is decoupled from the layout: the header sets `data-nav-open` on `<html>`, and a single rule in `app/tailwind.source.css` pads the `<body>` left by `16rem` at `≥1024px` (the fixed `w-64` sidebar fills the gap). Below that, no push — it's an overlay with a backdrop. Because only state pages render this header, the attribute (and the push) never apply to the landing/blog pages.
- Pin persists across client-side navigation for free (the `[state]` layout keeps the header mounted); `localStorage` covers hard reloads.

## Test plan
- Playwright (worktree dev server), **9/9 behaviors**: desktop open pushes content 256px; unpinned nav closes it; **pinned nav keeps it open across pages**; mobile open is overlay (no push) with backdrop and no pin button; mobile nav closes it. Plus: a pushed content page (`/va/colleges`) has **no horizontal overflow**.
- `next build` exit 0; 608 tests pass; `tsc --noEmit` + eslint clean (used the repo's `eslint-disable react-hooks/set-state-in-effect` idiom for the client-only localStorage restore, matching ThemeToggle/UserMenu).

## Known notes
- Scoped to **state pages** (landing/blog use a separate header — unchanged).
- On a **hard reload** of a pinned desktop page there's a brief content slide-in (client-side navigation has none). A no-flash inline script can be added later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)