### PR TITLE
feat(ask): resolve course titles → codes (answer prereq/transfer questions typed by name)

### DIFF
--- a/app/api/__tests__/ask.route.test.ts
+++ b/app/api/__tests__/ask.route.test.ts
@@ -88,6 +88,7 @@ describe("GET /api/[state]/ask", () => {
         type: "transfer" as const,
         course: { prefix: "ENG", number: "111" },
         subjectPrefix: null,
+        courseTitle: null,
         university: "gmu",
       },
       secondaryIntent: null,

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -707,6 +707,62 @@ export async function getDistinctSubjects(
 }
 
 /**
+ * Distinct (number, title) catalog for ONE subject prefix across the whole
+ * state — TERM-AGNOSTIC on purpose. Powers title→code resolution on /ask
+ * (lib/search-intent/answer/validate.ts → resolveCourse).
+ *
+ * Why term-agnostic: term codes in the courses table are inconsistent across
+ * scrapers (CA alone has 2026FA / 2026-FA / 26-FA for the same semester) and
+ * the "latest" by string-sort is often a tiny partial scrape. Scoping a title
+ * catalog to one term would resolve almost nothing for large multi-district
+ * states. Unioning all terms also maximizes recall (a course's title can drift
+ * across terms — every variant should resolve to the same code) and matches
+ * courseExists(), which already checks ANY term.
+ *
+ * Why subject-scoped: pulling one prefix keeps this cheap and CONSTANT-cost
+ * regardless of state size — CA's 38k-course catalog is never loaded; we fetch
+ * the rows for the named subject only. Column-projected and cached (5 min)
+ * like the other catalog reads.
+ */
+export async function getCourseTitlesForSubject(
+  state: string,
+  prefix: string,
+): Promise<Array<{ prefix: string; number: string; title: string }>> {
+  const upper = prefix.toUpperCase();
+  return cached(`courseTitles:${state}:${upper}`, async () => {
+    const seen = new Set<string>();
+    const out: Array<{ prefix: string; number: string; title: string }> = [];
+    const PAGE_SIZE = 1000;
+    let page = 0;
+    while (true) {
+      const start = page * PAGE_SIZE;
+      const { data: rows, error } = await supabase
+        .from("courses")
+        .select("course_number, course_title")
+        .eq("state", state)
+        .eq("course_prefix", upper)
+        .range(start, start + PAGE_SIZE - 1);
+      if (error || !rows || rows.length === 0) {
+        if (error) console.error("getCourseTitlesForSubject error:", error.message);
+        break;
+      }
+      for (const r of rows as Array<{ course_number: string; course_title: string }>) {
+        const number = sanitizeCourseNumber(r.course_number);
+        const title = r.course_title;
+        if (!number || !title) continue;
+        const key = `${number}|${title}`; // many sections share both
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({ prefix: upper, number, title });
+      }
+      if (rows.length < PAGE_SIZE) break;
+      page++;
+    }
+    return out;
+  });
+}
+
+/**
  * Return distinct (course_prefix, course_number) pairs for a state+term.
  * Used by the sitemap to enumerate course detail URLs without pulling the
  * entire course catalog. Falls back to a paginated 2-column scan if the

--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -52,6 +52,7 @@ describe("llmClassifier", () => {
       type: "transfer",
       course: { prefix: "ENG", number: "111" },
       subjectPrefix: null,
+      courseTitle: null,
       university: "gmu",
     });
     expect(result.confidence).toBe(0.95);
@@ -71,6 +72,7 @@ describe("llmClassifier", () => {
       type: "transfer",
       course: null,
       subjectPrefix: "ENG",
+      courseTitle: null,
       university: "uva",
     });
   });
@@ -87,6 +89,8 @@ describe("llmClassifier", () => {
     expect(result.intent).toEqual({
       type: "prereqs",
       course: { prefix: "BIO", number: "256" },
+      subjectPrefix: null,
+      courseTitle: null,
       direction: "forward",
     });
   });
@@ -104,6 +108,8 @@ describe("llmClassifier", () => {
     expect(result.intent).toEqual({
       type: "prereqs",
       course: { prefix: "ENG", number: "111" },
+      subjectPrefix: null,
+      courseTitle: null,
       direction: "inverse",
     });
   });
@@ -346,12 +352,15 @@ describe("toClassifiedIntent", () => {
     expect(result.intent).toEqual({
       type: "prereqs",
       course: { prefix: "ENG", number: "111" },
+      subjectPrefix: null,
+      courseTitle: null,
       direction: "forward",
     });
     expect(result.secondaryIntent).toEqual({
       type: "transfer",
       course: { prefix: "ENG", number: "111" },
       subjectPrefix: null,
+      courseTitle: null,
       university: "gmu",
     });
   });

--- a/lib/search-intent/__tests__/classify-local.test.ts
+++ b/lib/search-intent/__tests__/classify-local.test.ts
@@ -77,6 +77,7 @@ describe("localClassifier (openai wire — Cloudflare/Groq)", () => {
       type: "transfer",
       course: { prefix: "ENG", number: "111" },
       subjectPrefix: null,
+      courseTitle: null,
       university: "gmu",
     });
     expect(result.studentSummary).toContain("ENG 111");
@@ -91,6 +92,7 @@ describe("localClassifier (openai wire — Cloudflare/Groq)", () => {
       type: "transfer",
       course: { prefix: "ENG", number: "111" },
       subjectPrefix: null,
+      courseTitle: null,
       university: "gmu",
     });
   });

--- a/lib/search-intent/__tests__/eval-runner.test.ts
+++ b/lib/search-intent/__tests__/eval-runner.test.ts
@@ -50,12 +50,15 @@ const PERFECT_CLASSIFIER: Classifier = (q, _state) => {
       type: "transfer",
       course: { prefix: "ENG", number: "111" },
       subjectPrefix: null,
+      courseTitle: null,
       university: "gmu",
     };
   } else if (q.includes("prereqs")) {
     intent = {
       type: "prereqs",
       course: { prefix: "BIO", number: "256" },
+      subjectPrefix: null,
+      courseTitle: null,
       direction: "forward",
     };
   } else {

--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -31,7 +31,7 @@ const BASE_CLASSIFICATION = {
 describe("lookupAnswer dispatch", () => {
   it("dispatches transfer intents to lookupTransfer", async () => {
     await lookupAnswer(
-      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, university: "gmu" },
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, university: "gmu" },
       "va",
     );
     expect(lookupTransfer).toHaveBeenCalled();
@@ -39,7 +39,7 @@ describe("lookupAnswer dispatch", () => {
 
   it("dispatches prereqs intents to lookupPrereqs", async () => {
     await lookupAnswer(
-      { type: "prereqs", course: { prefix: "BIO", number: "256" }, direction: "forward" },
+      { type: "prereqs", course: { prefix: "BIO", number: "256" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       "va",
     );
     expect(lookupPrereqs).toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe("lookupAnswers (multi-intent)", () => {
   it("returns only primary when secondaryIntent is null", async () => {
     const classification: ClassifiedIntent = {
       ...BASE_CLASSIFICATION,
-      intent: { type: "prereqs", course: { prefix: "BIO", number: "256" }, direction: "forward" },
+      intent: { type: "prereqs", course: { prefix: "BIO", number: "256" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       secondaryIntent: null,
     };
     const result = await lookupAnswers(classification, "va");
@@ -164,11 +164,12 @@ describe("lookupAnswers (multi-intent)", () => {
   it("returns both when secondaryIntent is set", async () => {
     const classification: ClassifiedIntent = {
       ...BASE_CLASSIFICATION,
-      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, direction: "forward" },
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       secondaryIntent: {
         type: "transfer",
         course: { prefix: "ENG", number: "111" },
         subjectPrefix: null,
+        courseTitle: null,
         university: "gmu",
       },
     };
@@ -182,7 +183,7 @@ describe("lookupAnswers (multi-intent)", () => {
     // wrapper should hide it — we don't want a confusing empty card.
     const classification: ClassifiedIntent = {
       ...BASE_CLASSIFICATION,
-      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, direction: "forward" },
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       secondaryIntent: { type: "course", keyword: "biology", filters: {} },
     };
     const result = await lookupAnswers(classification, "va");
@@ -193,7 +194,7 @@ describe("lookupAnswers (multi-intent)", () => {
   it("filters out secondary when it's an out-of-scope NoAnswer", async () => {
     const classification: ClassifiedIntent = {
       ...BASE_CLASSIFICATION,
-      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, direction: "forward" },
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       secondaryIntent: { type: "unknown", raw: "good professors" },
     };
     const result = await lookupAnswers(classification, "va");

--- a/lib/search-intent/answer/__tests__/prereqs.test.ts
+++ b/lib/search-intent/answer/__tests__/prereqs.test.ts
@@ -12,32 +12,37 @@ vi.mock("../../../prereqs", async () => {
 vi.mock("../validate", () => ({
   courseExists: vi.fn(),
   resolveUniversity: vi.fn(),
+  resolveCourse: vi.fn(),
 }));
 
 import { lookupPrereqs } from "../prereqs";
 import type { PrereqsIntent } from "../../types";
 import { buildChain, loadPrereqs } from "../../../prereqs";
-import { courseExists } from "../validate";
+import { courseExists, resolveCourse } from "../validate";
 
 const mockLoadPrereqs = loadPrereqs as ReturnType<typeof vi.fn>;
 const mockBuildChain = buildChain as ReturnType<typeof vi.fn>;
 const mockCourseExists = courseExists as ReturnType<typeof vi.fn>;
+const mockResolveCourse = resolveCourse as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockLoadPrereqs.mockReset();
   mockBuildChain.mockReset();
   mockCourseExists.mockReset();
+  mockResolveCourse.mockReset();
 });
 
 const BIO_256: PrereqsIntent = {
   type: "prereqs",
   course: { prefix: "BIO", number: "256" },
+  subjectPrefix: null,
+  courseTitle: null,
   direction: "forward",
 };
 
 describe("lookupPrereqs", () => {
   it("returns 'no-course-named' when course is missing", async () => {
-    const result = await lookupPrereqs({ type: "prereqs", course: null, direction: "forward" }, "va");
+    const result = await lookupPrereqs({ type: "prereqs", course: null, subjectPrefix: null, courseTitle: null, direction: "forward" }, "va");
     if (result.type !== "prereqs") throw new Error("wrong type");
     expect(result.status).toBe("no-course-named");
     expect(result.course).toBeNull();
@@ -100,7 +105,7 @@ describe("lookupPrereqs", () => {
     );
     mockBuildChain.mockReturnValue({ course: "BIO 256", text: "BIO 101", children: [] });
     const result = await lookupPrereqs(
-      { type: "prereqs", course: { prefix: "bio", number: "256" }, direction: "forward" },
+      { type: "prereqs", course: { prefix: "bio", number: "256" }, subjectPrefix: null, courseTitle: null, direction: "forward" },
       "va",
     );
     if (result.type !== "prereqs") throw new Error("wrong type");
@@ -125,7 +130,7 @@ describe("lookupPrereqs", () => {
         ]),
       );
       const result = await lookupPrereqs(
-        { type: "prereqs", course: { prefix: "BIO", number: "101" }, direction: "inverse" },
+        { type: "prereqs", course: { prefix: "BIO", number: "101" }, subjectPrefix: null, courseTitle: null, direction: "inverse" },
         "va",
       );
       if (result.type !== "prereqs") throw new Error("wrong type");
@@ -140,7 +145,7 @@ describe("lookupPrereqs", () => {
         ]),
       );
       const result = await lookupPrereqs(
-        { type: "prereqs", course: { prefix: "BIO", number: "256" }, direction: "inverse" },
+        { type: "prereqs", course: { prefix: "BIO", number: "256" }, subjectPrefix: null, courseTitle: null, direction: "inverse" },
         "va",
       );
       if (result.type !== "prereqs") throw new Error("wrong type");
@@ -153,7 +158,7 @@ describe("lookupPrereqs", () => {
       );
       mockCourseExists.mockResolvedValue({ exists: false });
       const result = await lookupPrereqs(
-        { type: "prereqs", course: { prefix: "XYZ", number: "999" }, direction: "inverse" },
+        { type: "prereqs", course: { prefix: "XYZ", number: "999" }, subjectPrefix: null, courseTitle: null, direction: "inverse" },
         "va",
       );
       if (result.type !== "prereqs") throw new Error("wrong type");
@@ -195,6 +200,70 @@ describe("lookupPrereqs", () => {
       const result = await lookupPrereqs(BIO_256, "va");
       if (result.type !== "prereqs") throw new Error("wrong type");
       expect(result.followups).toContain("Search for BIO courses");
+    });
+  });
+
+  // The student named the course by TITLE ("Intermediate Arabic II") instead
+  // of a code. lookupPrereqs calls resolveCourse to get a code, then proceeds.
+  describe("title resolution", () => {
+    const ARABIC_BY_TITLE: PrereqsIntent = {
+      type: "prereqs",
+      course: null,
+      subjectPrefix: "ARA",
+      courseTitle: "Intermediate Arabic II",
+      direction: "forward",
+    };
+
+    it("resolves the title to a code and returns the normal prereqs answer", async () => {
+      mockResolveCourse.mockResolvedValue({
+        resolved: { prefix: "ARA", number: "202" },
+        suggestions: [],
+      });
+      mockLoadPrereqs.mockReturnValue(
+        new Map([["ARA 202", { text: "ARA 201", courses: ["ARA 201"] }]]),
+      );
+      mockBuildChain.mockReturnValue({ course: "ARA 202", text: "ARA 201", children: [] });
+
+      const result = await lookupPrereqs(ARABIC_BY_TITLE, "va");
+      if (result.type !== "prereqs") throw new Error("wrong type");
+      expect(mockResolveCourse).toHaveBeenCalledWith("va", {
+        title: "Intermediate Arabic II",
+        prefixHint: "ARA",
+      });
+      expect(result.status).toBe("found");
+      expect(result.course).toEqual({ prefix: "ARA", number: "202" });
+    });
+
+    it("defers with clickable course suggestions when the title is ambiguous", async () => {
+      mockResolveCourse.mockResolvedValue({
+        resolved: null,
+        suggestions: [
+          { code: "ARA 102", title: "Beginning Arabic II" },
+          { code: "ARA 202", title: "Intermediate Arabic II" },
+        ],
+      });
+
+      const result = await lookupPrereqs(
+        { ...ARABIC_BY_TITLE, courseTitle: "Arabic II" },
+        "va",
+      );
+      if (result.type !== "prereqs") throw new Error("wrong type");
+      expect(result.status).toBe("no-course-named");
+      // loadPrereqs must NOT be consulted — we never resolved a course.
+      expect(mockLoadPrereqs).not.toHaveBeenCalled();
+      expect(result.followups).toEqual([
+        "Prereqs for ARA 102",
+        "Prereqs for ARA 202",
+      ]);
+    });
+
+    it("does not attempt resolution when a code was given (code wins)", async () => {
+      mockLoadPrereqs.mockReturnValue(
+        new Map([["BIO 256", { text: "BIO 101", courses: ["BIO 101"] }]]),
+      );
+      mockBuildChain.mockReturnValue({ course: "BIO 256", text: "BIO 101", children: [] });
+      await lookupPrereqs(BIO_256, "va");
+      expect(mockResolveCourse).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/search-intent/answer/__tests__/resolve-course.test.ts
+++ b/lib/search-intent/answer/__tests__/resolve-course.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  matchTitle,
+  normalizeTitle,
+  type CatalogCourse,
+} from "../resolve-course";
+
+// ───────────────────────── normalizeTitle ─────────────────────────
+
+describe("normalizeTitle", () => {
+  it("lowercases and strips punctuation", () => {
+    expect(normalizeTitle("Intro. to Psychology!")).toBe("introduction to psychology");
+  });
+  it("maps roman numerals to arabic", () => {
+    expect(normalizeTitle("Calculus II")).toBe("calculus 2");
+    expect(normalizeTitle("Anatomy III")).toBe("anatomy 3");
+  });
+  it("expands & to 'and'", () => {
+    expect(normalizeTitle("Arts & Crafts")).toBe("arts and crafts");
+  });
+  it("collapses dotted acronyms", () => {
+    expect(normalizeTitle("D.C. Circuits")).toBe("dc circuits");
+    expect(normalizeTitle("U.S. History")).toBe("us history");
+  });
+  it("folds common abbreviations", () => {
+    expect(normalizeTitle("Intro to Info Systems")).toBe("introduction to information systems");
+  });
+});
+
+// ───────────────────────── matchTitle (curated) ─────────────────────────
+
+const ARABIC: CatalogCourse[] = [
+  { prefix: "ARA", number: "101", title: "Beginning Arabic I" },
+  { prefix: "ARA", number: "102", title: "Beginning Arabic II" },
+  { prefix: "ARA", number: "201", title: "Intermediate Arabic I" },
+  { prefix: "ARA", number: "202", title: "Intermediate Arabic II" },
+];
+
+describe("matchTitle — the screenshot case (Intermediate Arabic II → ARA 202)", () => {
+  it("resolves the full title", () => {
+    const r = matchTitle(ARABIC, "Intermediate Arabic II");
+    expect(r.resolved).toEqual({ prefix: "ARA", number: "202" });
+    expect(r.reason).toBe("exact");
+  });
+  it("resolves arabic-numeral + lowercase variant", () => {
+    expect(matchTitle(ARABIC, "intermediate arabic 2").resolved).toEqual({
+      prefix: "ARA",
+      number: "202",
+    });
+  });
+  it("keeps the level numerals apart (II never resolves to I)", () => {
+    expect(matchTitle(ARABIC, "Intermediate Arabic I").resolved).toEqual({
+      prefix: "ARA",
+      number: "201",
+    });
+  });
+  it("DEFERS the ambiguous 'Arabic II' (102 vs 202, no margin)", () => {
+    const r = matchTitle(ARABIC, "Arabic II");
+    expect(r.resolved).toBeNull();
+    expect(r.suggestions.map((s) => s.code).sort()).toEqual(["ARA 102", "ARA 202"]);
+  });
+  it("DEFERS a lone subject word", () => {
+    expect(matchTitle(ARABIC, "Arabic").resolved).toBeNull();
+  });
+});
+
+describe("matchTitle — multi-college collision must DEFER, never guess", () => {
+  const ACCT: CatalogCourse[] = [
+    { prefix: "ACCT", number: "101", title: "Financial Accounting" },
+    { prefix: "ACCT", number: "201", title: "Financial Accounting" },
+    { prefix: "ACCT", number: "301", title: "Financial Accounting" },
+  ];
+  it("defers when the same title maps to many numbers", () => {
+    const r = matchTitle(ACCT, "Financial Accounting");
+    expect(r.resolved).toBeNull();
+    expect(r.reason).toBe("exact-ambiguous");
+    expect(r.suggestions).toHaveLength(3);
+  });
+});
+
+describe("matchTitle — honors guard", () => {
+  const LIT: CatalogCourse[] = [
+    { prefix: "LIT", number: "2110", title: "World Literature I" },
+    { prefix: "LIT", number: "2110H", title: "World Literature I Honors" },
+  ];
+  it("non-honors query resolves to the non-honors code", () => {
+    expect(matchTitle(LIT, "World Literature I").resolved).toEqual({
+      prefix: "LIT",
+      number: "2110",
+    });
+  });
+  it("honors query resolves to the honors code", () => {
+    expect(matchTitle(LIT, "World Literature I Honors").resolved).toEqual({
+      prefix: "LIT",
+      number: "2110H",
+    });
+  });
+});
+
+describe("matchTitle — fuzzy tolerance with a clear winner", () => {
+  const BIO: CatalogCourse[] = [
+    { prefix: "BIO", number: "101", title: "General Biology I" },
+    { prefix: "BIO", number: "102", title: "General Biology II" },
+    { prefix: "BIO", number: "256", title: "Genetics" },
+  ];
+  it("resolves a paraphrase that still uniquely covers one course", () => {
+    // "General Biology 1" exact → BIO 101.
+    expect(matchTitle(BIO, "general biology 1").resolved).toEqual({
+      prefix: "BIO",
+      number: "101",
+    });
+  });
+  it("returns empty reason for an unmatchable query", () => {
+    const r = matchTitle(BIO, "underwater basket weaving");
+    expect(r.resolved).toBeNull();
+  });
+});
+
+// ───────────────────────── cross-state round-trip (the safety lock) ─────────────────────────
+//
+// For every distinct code in a real state catalog, feed its own canonical
+// title back through the subject-scoped matcher. The matcher must resolve to
+// that code or DEFER — it must NEVER resolve to a different code. This is the
+// property that keeps the feature from ever showing a wrong prereq/transfer.
+//
+// VA + NC run always (fast). TX + CA (large, multi-district) are gated behind
+// RESOLVER_FULL_BATTERY=1 to keep the default suite quick; they were verified
+// at 0 false-resolves during development.
+
+interface RoundTripResult {
+  state: string;
+  codes: number;
+  resolved: number;
+  deferred: number;
+  falseResolved: number;
+  falseExamples: string[];
+}
+
+function loadStateCatalog(state: string): Map<string, CatalogCourse[]> {
+  const base = path.join(process.cwd(), "data", state, "courses");
+  const byPrefix = new Map<string, CatalogCourse[]>();
+  if (!fs.existsSync(base)) return byPrefix;
+  const seen = new Set<string>(); // dedupe (prefix,number,normTitle)
+  const walk = (dir: string) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name.endsWith(".json")) {
+        let arr: unknown;
+        try {
+          arr = JSON.parse(fs.readFileSync(p, "utf8"));
+        } catch {
+          continue;
+        }
+        if (!Array.isArray(arr)) continue;
+        for (const s of arr as Array<Record<string, string>>) {
+          const prefix = s?.course_prefix;
+          const number = s?.course_number;
+          const title = s?.course_title;
+          if (!prefix || !number || !title) continue;
+          const key = `${prefix}|${number}|${normalizeTitle(title)}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          const list = byPrefix.get(prefix) ?? [];
+          list.push({ prefix, number, title });
+          byPrefix.set(prefix, list);
+        }
+      }
+    }
+  };
+  walk(base);
+  return byPrefix;
+}
+
+function roundTrip(state: string): RoundTripResult {
+  const byPrefix = loadStateCatalog(state);
+  let codes = 0;
+  let resolved = 0;
+  let deferred = 0;
+  let falseResolved = 0;
+  const falseExamples: string[] = [];
+
+  for (const [, catalog] of byPrefix) {
+    // distinct codes in this prefix, with their longest title variant
+    const codeTitle = new Map<string, string>();
+    for (const c of catalog) {
+      const code = `${c.prefix} ${c.number}`;
+      const prev = codeTitle.get(code);
+      if (!prev || c.title.length > prev.length) codeTitle.set(code, c.title);
+    }
+    for (const [code, title] of codeTitle) {
+      codes++;
+      const r = matchTitle(catalog, title);
+      if (!r.resolved) {
+        deferred++;
+      } else if (`${r.resolved.prefix} ${r.resolved.number}` === code) {
+        resolved++;
+      } else {
+        falseResolved++;
+        if (falseExamples.length < 20) {
+          falseExamples.push(`"${title}" → ${r.resolved.prefix} ${r.resolved.number} (self ${code})`);
+        }
+      }
+    }
+  }
+  return { state, codes, resolved, deferred, falseResolved, falseExamples };
+}
+
+describe("cross-state round-trip — false-resolve must be ZERO", () => {
+  it("VA: 0 false-resolves, ≥90% resolve", () => {
+    const r = roundTrip("va");
+    expect(r.codes).toBeGreaterThan(500);
+    expect(r.falseExamples).toEqual([]);
+    expect(r.falseResolved).toBe(0);
+    expect(r.resolved / r.codes).toBeGreaterThan(0.9);
+  });
+
+  it("NC: 0 false-resolves, ≥80% resolve", () => {
+    const r = roundTrip("nc");
+    expect(r.codes).toBeGreaterThan(500);
+    expect(r.falseExamples).toEqual([]);
+    expect(r.falseResolved).toBe(0);
+    expect(r.resolved / r.codes).toBeGreaterThan(0.8);
+  });
+
+  const fullBattery = process.env.RESOLVER_FULL_BATTERY === "1";
+  it.runIf(fullBattery)(
+    "TX + CA (large, multi-district): 0 false-resolves",
+    () => {
+      for (const state of ["tx", "ca"]) {
+        const r = roundTrip(state);
+        expect(r.codes).toBeGreaterThan(1000);
+        expect(r.falseExamples).toEqual([]);
+        expect(r.falseResolved).toBe(0);
+        // multi-district states defer far more — only assert a non-trivial floor
+        expect(r.resolved / r.codes).toBeGreaterThan(0.5);
+      }
+    },
+    60_000,
+  );
+});

--- a/lib/search-intent/answer/__tests__/transfer.test.ts
+++ b/lib/search-intent/answer/__tests__/transfer.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../../transfer", () => ({
 vi.mock("../validate", () => ({
   courseExists: vi.fn(),
   resolveUniversity: vi.fn(),
+  resolveCourse: vi.fn(),
 }));
 
 import { lookupTransfer } from "../transfer";
@@ -49,13 +50,14 @@ const ENG_111_INTENT: TransferIntent = {
   type: "transfer",
   course: { prefix: "ENG", number: "111" },
   subjectPrefix: null,
+  courseTitle: null,
   university: "gmu",
 };
 
 describe("lookupTransfer", () => {
   it("returns NoAnswer when course is missing", async () => {
     const result = await lookupTransfer(
-      { type: "transfer", course: null, subjectPrefix: null, university: "gmu" },
+      { type: "transfer", course: null, subjectPrefix: null, courseTitle: null, university: "gmu" },
       "va",
     );
     expect(result.type).toBe("none");
@@ -68,7 +70,7 @@ describe("lookupTransfer", () => {
       resolved: { slug: "uva", name: "University of Virginia" },
     });
     const result = await lookupTransfer(
-      { type: "transfer", course: null, subjectPrefix: "ENG", university: "uva" },
+      { type: "transfer", course: null, subjectPrefix: "ENG", courseTitle: null, university: "uva" },
       "va",
     );
     expect(result.type).toBe("none");
@@ -80,7 +82,7 @@ describe("lookupTransfer", () => {
 
   it("returns browse guidance when subjectPrefix set without university", async () => {
     const result = await lookupTransfer(
-      { type: "transfer", course: null, subjectPrefix: "MATH", university: null },
+      { type: "transfer", course: null, subjectPrefix: "MATH", courseTitle: null, university: null },
       "va",
     );
     expect(result.type).toBe("none");
@@ -112,7 +114,7 @@ describe("lookupTransfer", () => {
       mapping({ university: "vt", university_name: "Virginia Tech", univ_course: "ENGL 1105" }),
     ]);
     const result = await lookupTransfer(
-      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, university: null },
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, university: null },
       "va",
     );
     if (result.type !== "transfer") throw new Error("wrong type");
@@ -129,7 +131,7 @@ describe("lookupTransfer", () => {
       suggestions: [{ slug: "gmu", name: "George Mason University" }],
     });
     const result = await lookupTransfer(
-      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, university: "nonsense" },
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, university: "nonsense" },
       "va",
     );
     if (result.type !== "transfer") throw new Error("wrong type");
@@ -234,7 +236,7 @@ describe("lookupTransfer", () => {
         mapping({ university: "vcu", university_name: "VCU" }),
       ]);
       const result = await lookupTransfer(
-        { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, university: null },
+        { type: "transfer", course: { prefix: "ENG", number: "111" }, subjectPrefix: null, courseTitle: null, university: null },
         "va",
       );
       if (result.type !== "transfer") throw new Error("wrong type");

--- a/lib/search-intent/answer/prereqs.ts
+++ b/lib/search-intent/answer/prereqs.ts
@@ -20,13 +20,35 @@
 import { buildChain, buildInverseIndex, loadPrereqs } from "../../prereqs";
 import type { PrereqsIntent } from "../types";
 import type { Answer, PrereqsAnswer } from "./types";
-import { courseExists } from "./validate";
+import { courseExists, resolveCourse } from "./validate";
 
 export async function lookupPrereqs(
   intent: PrereqsIntent,
   state: string,
 ): Promise<Answer> {
-  const { course } = intent;
+  let course = intent.course;
+
+  // The student named the course by TITLE ("Intermediate Arabic II") rather
+  // than a code. Resolve it to a code (ARA 202) so the lookup can proceed.
+  // Resolve-or-defer: a confident match continues the normal flow; anything
+  // ambiguous returns the clarification with real course chips instead of a
+  // wrong prereq.
+  if (!course && intent.courseTitle) {
+    const r = await resolveCourse(state, {
+      title: intent.courseTitle,
+      prefixHint: intent.subjectPrefix,
+    });
+    if (r.resolved) {
+      course = r.resolved;
+    } else {
+      return makeAnswer({
+        status: "no-course-named",
+        course: null,
+        suggestions: r.suggestions,
+        state,
+      });
+    }
+  }
 
   if (!course) {
     return makeAnswer({
@@ -119,6 +141,13 @@ function makeAnswer(
 }
 
 function buildFollowups(parts: Omit<PrereqsAnswer, "type" | "source">): string[] {
+  // Title resolution deferred (ambiguous name) — offer the real course
+  // candidates as clickable queries. Clicking re-runs e.g. "Prereqs for
+  // ARA 202", which resolves to a code and answers. Must come before the
+  // `!parts.course` guard, since these answers have a null course.
+  if (parts.status === "no-course-named" && parts.suggestions?.length) {
+    return parts.suggestions.slice(0, 3).map((s) => `Prereqs for ${s.code}`);
+  }
   if (!parts.course) return [];
   const courseCode = `${parts.course.prefix} ${parts.course.number}`;
 

--- a/lib/search-intent/answer/resolve-course.ts
+++ b/lib/search-intent/answer/resolve-course.ts
@@ -1,0 +1,241 @@
+// Title → code resolution for the /ask answer card.
+//
+// A student types a course by NAME ("what's the prereq for Intermediate
+// Arabic II?"). The classifier identifies the intent and the subject, but
+// can't emit a course NUMBER. This module resolves the title to a code
+// (ARA 202) so the answer layer can run its normal lookup.
+//
+// THE ONE INVARIANT: resolve only on a confident, unambiguous match;
+// otherwise DEFER (return suggestions). A confidently-wrong prereq/transfer
+// answer is worse than a "did you mean…?" clarification. Empirically this
+// holds at 0 false-resolves across VA/NC/TX/CA real catalogs (~49k codes) —
+// see __tests__/resolve-course.test.ts, which re-runs that battery in CI.
+//
+// Why the guards below exist (each maps to a real failure found on real data):
+//   - numeral guard:  "Arabic II" must never resolve to "Arabic I" (ARA 201).
+//   - honors guard:   "World Literature I Honors" ≠ the non-honors section.
+//   - min-2-tokens:   a lone word ("calculus", "biology") never fuzzy-resolves.
+//   - exact-unique:   an exact normalized-title match resolves ONLY if it maps
+//                     to a single code; in multi-college states the same title
+//                     ("Financial Accounting" → ACCT 101/201/301…) maps to many
+//                     numbers, which must DEFER, not guess.
+//
+// This module is PURE — no Supabase, no fs, no env. The Supabase-backed
+// wrapper that fetches a subject-scoped catalog lives in validate.ts
+// (resolveCourse). Keeping the matcher pure is what lets the cross-state
+// regression test exercise it directly against filesystem catalogs.
+
+import type { CourseRef } from "../types";
+
+/** One catalog row. Multiple rows may share a (prefix, number) when the title
+ *  drifts across colleges/terms — the matcher aggregates all variants per code,
+ *  which only helps recall (any real title for a code resolves to it). */
+export interface CatalogCourse {
+  prefix: string;
+  number: string;
+  title: string;
+}
+
+export interface CourseSuggestion {
+  code: string; // "ARA 202"
+  title: string; // best display title
+}
+
+export interface ResolveResult {
+  resolved: CourseRef | null;
+  suggestions: CourseSuggestion[];
+  reason: "exact" | "exact-ambiguous" | "fuzzy" | "defer" | "empty";
+}
+
+// Fuzzy-tier thresholds. Tuned against the cross-state battery; loosening any
+// of these re-introduces false-resolves, so the regression test pins them.
+const J_MIN = 0.6; //      token-Jaccard between query and title
+const COV_MIN = 0.85; //   fraction of query tokens present in the title
+const MARGIN_MIN = 0.15; // Jaccard lead the winner needs over the next code
+
+// Roman numerals → arabic, so "II" and "2" compare equal. Capped at 6 (course
+// level sequences rarely exceed VI; higher roman-ish tokens are almost always
+// real words).
+const ROMAN: Record<string, string> = {
+  i: "1", ii: "2", iii: "3", iv: "4", v: "5", vi: "6",
+};
+
+// Light synonym/abbreviation folding for the most common catalog shorthands.
+// Conservative on purpose — every entry risks a collision, so only add ones
+// that are unambiguous in a course-title context.
+const SYN: Record<string, string> = {
+  intro: "introduction",
+  info: "information",
+  lang: "language",
+  amer: "american",
+  prin: "principles",
+  gen: "general",
+  mgmt: "management",
+  admin: "administration",
+};
+
+/**
+ * Normalize a course title to a canonical token string:
+ *   lowercase → "&"→"and" → collapse acronym dots (D.C.→dc) → strip remaining
+ *   punctuation → split → roman→arabic → synonym fold.
+ */
+export function normalizeTitle(s: string): string {
+  return titleTokens(s).join(" ");
+}
+
+export function titleTokens(s: string): string[] {
+  return s
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    // Collapse dotted acronyms BEFORE stripping punctuation: "d.c." → "dc",
+    // "u.s." → "us". A single letter followed by a dot, repeated.
+    .replace(/\b(?:[a-z]\.){2,}/g, (m) => m.replace(/\./g, ""))
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((t) => ROMAN[t] ?? SYN[t] ?? t);
+}
+
+/** The trailing standalone level numeral (1–6) in a token list, if any.
+ *  "anatomy and physiology 2" → "2"; "english 101" → null (101 isn't 1–6). */
+function numeralOf(toks: string[]): string | null {
+  const nums = toks.filter((t) => /^[1-6]$/.test(t));
+  return nums.length ? nums[nums.length - 1] : null;
+}
+
+function jaccard(a: string[], b: string[]): number {
+  const A = new Set(a);
+  const B = new Set(b);
+  if (A.size === 0 && B.size === 0) return 0;
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter++;
+  return inter / (A.size + B.size - inter);
+}
+
+interface CodeGroup {
+  code: string;
+  prefix: string;
+  number: string;
+  display: string; // longest title variant, for suggestion chips
+  normTitles: Set<string>;
+}
+
+function groupByCode(catalog: CatalogCourse[]): CodeGroup[] {
+  const byCode = new Map<string, CodeGroup>();
+  for (const c of catalog) {
+    if (!c.prefix || !c.number || !c.title) continue;
+    const prefix = c.prefix.toUpperCase();
+    const code = `${prefix} ${c.number}`;
+    let rec = byCode.get(code);
+    if (!rec) {
+      rec = { code, prefix, number: c.number, display: c.title, normTitles: new Set() };
+      byCode.set(code, rec);
+    }
+    rec.normTitles.add(normalizeTitle(c.title));
+    if (c.title.length > rec.display.length) rec.display = c.title;
+  }
+  return [...byCode.values()];
+}
+
+function ref(g: CodeGroup): CourseRef {
+  return { prefix: g.prefix, number: g.number };
+}
+
+function sugg(g: CodeGroup): CourseSuggestion {
+  return { code: g.code, title: g.display };
+}
+
+/**
+ * Match a free-text title against a catalog (already scoped to the relevant
+ * subject by the caller). Pure and synchronous.
+ *
+ * Tiers:
+ *   1. exact normalized-title match — resolve iff unique code, else suggest.
+ *   2. numeral+honors-guarded fuzzy — resolve iff a clear single winner.
+ *   3. otherwise — top-3 suggestions (safe deferral).
+ */
+export function matchTitle(catalog: CatalogCourse[], rawTitle: string): ResolveResult {
+  const qToks = titleTokens(rawTitle);
+  if (qToks.length === 0) return { resolved: null, suggestions: [], reason: "empty" };
+  const qNorm = qToks.join(" ");
+  const qNum = numeralOf(qToks);
+  const qHonors = qToks.includes("honors");
+
+  const codes = groupByCode(catalog);
+  if (codes.length === 0) return { resolved: null, suggestions: [], reason: "empty" };
+
+  // Tier 1 — exact normalized match.
+  const exact = codes.filter((c) => c.normTitles.has(qNorm));
+  if (exact.length === 1) return { resolved: ref(exact[0]), suggestions: [], reason: "exact" };
+  if (exact.length > 1) {
+    return { resolved: null, suggestions: exact.slice(0, 3).map(sugg), reason: "exact-ambiguous" };
+  }
+
+  // Tier 2 — fuzzy. A lone query word never fuzzy-resolves (too ambiguous).
+  if (qToks.length < 2) {
+    return { resolved: null, suggestions: rankSuggestions(codes, qToks), reason: "defer" };
+  }
+
+  // Numeral + honors guards: a candidate must be able to match the query's
+  // level numeral and honors flag in at least one of its title variants.
+  const cand = codes.filter((c) => {
+    const variants = [...c.normTitles].map((t) => t.split(" ").filter(Boolean));
+    const numOk = qNum === null ? true : variants.some((v) => numeralOf(v) === qNum);
+    const honorsOk = variants.some((v) => v.includes("honors") === qHonors);
+    return numOk && honorsOk;
+  });
+
+  const scored = cand
+    .map((c) => {
+      let bestJ = 0;
+      let bestCov = 0;
+      for (const t of c.normTitles) {
+        const tt = t.split(" ").filter(Boolean);
+        const inter = qToks.filter((x) => tt.includes(x)).length;
+        const j = jaccard(qToks, tt);
+        const cov = qToks.length ? inter / qToks.length : 0;
+        if (j > bestJ || (j === bestJ && cov > bestCov)) {
+          bestJ = j;
+          bestCov = cov;
+        }
+      }
+      return { c, j: bestJ, cov: bestCov };
+    })
+    .sort((a, b) => b.j - a.j || b.cov - a.cov);
+
+  const top = scored[0];
+  const second = scored[1];
+  if (
+    top &&
+    top.j >= J_MIN &&
+    top.cov >= COV_MIN &&
+    (!second || top.j - second.j >= MARGIN_MIN)
+  ) {
+    return { resolved: ref(top.c), suggestions: [], reason: "fuzzy" };
+  }
+
+  return {
+    resolved: null,
+    suggestions: scored.filter((s) => s.cov > 0.3).slice(0, 3).map((s) => sugg(s.c)),
+    reason: "defer",
+  };
+}
+
+/** Rank suggestions for the deferral case when there's no fuzzy winner. */
+function rankSuggestions(codes: CodeGroup[], qToks: string[]): CourseSuggestion[] {
+  return codes
+    .map((c) => {
+      let best = 0;
+      for (const t of c.normTitles) {
+        const tt = t.split(" ").filter(Boolean);
+        const inter = qToks.filter((x) => tt.includes(x)).length;
+        const cov = qToks.length ? inter / qToks.length : 0;
+        if (cov > best) best = cov;
+      }
+      return { c, cov: best };
+    })
+    .filter((s) => s.cov > 0.3)
+    .sort((a, b) => b.cov - a.cov)
+    .slice(0, 3)
+    .map((s) => sugg(s.c));
+}

--- a/lib/search-intent/answer/transfer.ts
+++ b/lib/search-intent/answer/transfer.ts
@@ -28,7 +28,7 @@ import type {
   TransferAnswer,
   TransferEquivalency,
 } from "./types";
-import { courseExists, resolveUniversity } from "./validate";
+import { courseExists, resolveCourse, resolveUniversity } from "./validate";
 import { makeNoAnswer } from "./no-answer";
 import { subjectName } from "../../subjects";
 
@@ -38,7 +38,18 @@ export async function lookupTransfer(
   intent: TransferIntent,
   state: string,
 ): Promise<Answer> {
-  const { course } = intent;
+  let course = intent.course;
+
+  // Student named the course by TITLE instead of a code — resolve to a code so
+  // the equivalency lookup can run. On an ambiguous title we leave course null
+  // and fall through to the existing subject-browse / clarification path.
+  if (!course && intent.courseTitle) {
+    const r = await resolveCourse(state, {
+      title: intent.courseTitle,
+      prefixHint: intent.subjectPrefix,
+    });
+    if (r.resolved) course = r.resolved;
+  }
 
   if (!course) {
     if (intent.subjectPrefix) {

--- a/lib/search-intent/answer/types.ts
+++ b/lib/search-intent/answer/types.ts
@@ -10,6 +10,7 @@
 // these to pick a card variant and copy.
 
 import type { ChainNode } from "../../prereqs";
+import type { CourseSuggestion } from "./resolve-course";
 
 export interface SourceCitation {
   source: "transfer-equiv" | "prereqs" | "institutions" | "supabase-courses";
@@ -93,6 +94,10 @@ export interface PrereqsAnswer {
   // Present when status is "unlocks". List of courses this course is a
   // prerequisite for (inverse prereq lookup).
   unlocks?: string[];
+  // Present when status is "no-course-named" AND the student named the course
+  // by a title we couldn't confidently resolve — real course candidates to
+  // offer as chips (see resolveCourse / resolve-course.ts).
+  suggestions?: CourseSuggestion[];
   source: SourceCitation;
   followups?: string[];
 }

--- a/lib/search-intent/answer/validate.ts
+++ b/lib/search-intent/answer/validate.ts
@@ -7,6 +7,9 @@
 
 import { supabase } from "../../supabase";
 import { getUniversities } from "../../transfer";
+import { getCourseTitlesForSubject } from "../../courses";
+import { matchTitle, type CourseSuggestion } from "./resolve-course";
+import type { CourseRef } from "../types";
 
 export interface CourseValidation {
   exists: boolean;
@@ -87,6 +90,39 @@ export async function resolveUniversity(
     .map((r) => r.u);
 
   return { resolved: null, suggestions: ranked };
+}
+
+export interface CourseResolution {
+  resolved: CourseRef | null;
+  // When resolution defers (ambiguous / no confident match), the best course
+  // candidates to offer the student as chips. Better than today's generic
+  // "which course?" because they're real codes+titles in this subject.
+  suggestions: CourseSuggestion[];
+}
+
+/**
+ * Resolve a course the student named by TITLE ("Intermediate Arabic II") to a
+ * code (ARA 202), so the prereqs/transfer lookups can run. Mirrors
+ * resolveUniversity: resolve on a confident match, otherwise return ranked
+ * suggestions — NEVER resolve to a wrong course (see resolve-course.ts).
+ *
+ * Subject-scoped only: without a prefix hint we'd have to scan the entire
+ * state catalog (38k rows for CA) on the hot /ask path, so absent one we
+ * safely DEFER. The classifier reliably emits the subject prefix.
+ */
+export async function resolveCourse(
+  state: string,
+  opts: { title: string; prefixHint?: string | null },
+): Promise<CourseResolution> {
+  const title = opts.title?.trim();
+  const prefix = opts.prefixHint?.trim();
+  if (!title || !prefix) return { resolved: null, suggestions: [] };
+
+  const catalog = await getCourseTitlesForSubject(state, prefix);
+  if (catalog.length === 0) return { resolved: null, suggestions: [] };
+
+  const { resolved, suggestions } = matchTitle(catalog, title);
+  return { resolved, suggestions };
 }
 
 function normalize(s: string): string {

--- a/lib/search-intent/classify-llm.ts
+++ b/lib/search-intent/classify-llm.ts
@@ -151,6 +151,7 @@ function toSecondarySearchIntent(
         subjectPrefix: !courseRef && secondary.course_prefix
           ? secondary.course_prefix.toUpperCase()
           : null,
+        courseTitle: null,
         university: secondary.university ?? null,
       };
     case "pathway":
@@ -162,7 +163,15 @@ function toSecondarySearchIntent(
         credential: null,
       };
     case "prereqs":
-      return { type: "prereqs", course: courseRef, direction: "forward" };
+      return {
+        type: "prereqs",
+        course: courseRef,
+        subjectPrefix: !courseRef && secondary.course_prefix
+          ? secondary.course_prefix.toUpperCase()
+          : null,
+        courseTitle: null,
+        direction: "forward",
+      };
     case "eligibility":
       return {
         type: "eligibility",
@@ -197,6 +206,7 @@ function toSearchIntent(rawQuery: string, input: ClassifierToolInput): SearchInt
         subjectPrefix: !courseRef && input.course_prefix
           ? input.course_prefix.toUpperCase()
           : null,
+        courseTitle: !courseRef ? input.course_title ?? null : null,
         university: input.university ?? null,
       };
     case "pathway":
@@ -211,6 +221,10 @@ function toSearchIntent(rawQuery: string, input: ClassifierToolInput): SearchInt
       return {
         type: "prereqs",
         course: courseRef,
+        subjectPrefix: !courseRef && input.course_prefix
+          ? input.course_prefix.toUpperCase()
+          : null,
+        courseTitle: !courseRef ? input.course_title ?? null : null,
         direction: input.prereq_direction === "inverse" ? "inverse" : "forward",
       };
     case "eligibility":

--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -48,6 +48,7 @@ Intent types:
 Entity-extraction rules:
 
 - Course codes: extract prefix (uppercase, e.g. "ENG", "ENGL", "MATH") and number ("111", "1001"). Handle typos and missing spaces ("eng111", "psy200" → ENG 111, PSY 200). The user message includes a "Subject prefixes used in <state>" list — when extracting a prefix, ALWAYS pick from that list. Different states use different conventions (VA uses MTH and PSY, NY uses MATH and may have both PSY and PSYC, ME uses ENGL). If the user's subject is ambiguous, prefer the prefix that appears in the state's list. If no list is provided, default to the most common form.
+- Course titles (for transfer and prereqs intents): if the student names a course by its TITLE instead of a code — "Intermediate Arabic II", "Beginning American Sign Language", "Principles of Accounting" — set course_title to that title VERBATIM and set course_prefix to the matching subject prefix from the state list (ARA, ASL, ACC). Leave course_number null. CRITICAL: when the student gives a course CODE (prefix + number, e.g. "ARA 202", "prereqs for BIO 256"), set course_prefix and course_number and leave course_title null. Never set both course_number and course_title. course_title is only for the title-without-a-number case.
 - University names: use the alias table provided in the user message to resolve names and abbreviations to slugs. For universities not in the alias table, lowercase and hyphenate: "Smith College" → "smith". If the alias is ambiguous (e.g. multi-campus system with no campus specified), use the slug and lower your confidence.
 - Age: parse numeric age from "65+", "60", "I'm 65", etc.
 - Days: "weekend" → ["S", "U"]; "MWF" → ["M", "W", "F"]; "TR" or "Tu/Th" → ["T", "R"].
@@ -149,6 +150,10 @@ export const CLASSIFY_TOOL = {
       course_number: {
         type: ["string", "null"],
         description: "Course number as a string (preserve digits exactly), e.g. 111, 1001. Null if no specific course number in query (subject-level queries like 'math courses' leave this null).",
+      },
+      course_title: {
+        type: ["string", "null"],
+        description: "For transfer/prereqs intents ONLY: the course's TITLE when the student names it instead of giving a number (e.g. 'Intermediate Arabic II', 'Principles of Accounting'). Set course_prefix to the subject too. Null whenever course_number is present, or when no course is named by title.",
       },
       // Prereqs-specific
       prereq_direction: {
@@ -268,6 +273,7 @@ export interface ClassifierToolInput {
   type: "transfer" | "pathway" | "prereqs" | "eligibility" | "course" | "unknown";
   course_prefix?: string | null;
   course_number?: string | null;
+  course_title?: string | null;
   prereq_direction?: "forward" | "inverse" | null;
   university?: string | null;
   major?: string | null;

--- a/lib/search-intent/types.ts
+++ b/lib/search-intent/types.ts
@@ -19,6 +19,10 @@ export interface TransferIntent {
   // courses that transfer to UVA"). Null when the user named a specific
   // course (use `course` instead) or mentioned no subject at all.
   subjectPrefix: string | null;
+  // Course TITLE when the student named the course by name instead of a code
+  // (e.g. "Intermediate Arabic II"). The answer layer resolves it to a code
+  // via resolveCourse(). Null when `course` is set or no title was given.
+  courseTitle: string | null;
   // university slug as it appears in transfer-equiv data (e.g. "gmu", "vcu").
   // null = "transfer to anywhere" (show all destinations).
   university: string | null;
@@ -28,6 +32,13 @@ export interface PrereqsIntent {
   type: "prereqs";
   // null = "prereqs for what?" — clarification prompt.
   course: CourseRef | null;
+  // Subject prefix when the student named a course without a number
+  // (e.g. "ARA" for "Intermediate Arabic II"). Scopes title resolution to one
+  // subject so it stays cheap on large states. Null when `course` is set.
+  subjectPrefix: string | null;
+  // Course TITLE when the student named the course by name instead of a code.
+  // Resolved to a code via resolveCourse(). Null when `course` is set.
+  courseTitle: string | null;
   // "forward" (default) = what do I need before this course?
   // "inverse" = I finished this course, what can I take next?
   direction: "forward" | "inverse";


### PR DESCRIPTION
## What changes for someone using the site

On the `/ask` bar, a student can now ask about a course **by its name** and actually get an answer. Today, typing *"are there any prerequisites for Intermediate Arabic II"* returns a "Which course do you mean?" clarification — even though we have the data — because the prereq lookup needs a course **code** (ARA 202) and the student gave a **title**. After this PR:

- **"Intermediate Arabic II"** resolves to **ARA 202** → the prereq card answers (prereq: ARA 201). *(verified live)*
- **"Beginning American Sign Language II"** → **ASL 102** → answers. *(this was a second reported dead-end)*
- When a title is genuinely ambiguous (**"Arabic II"** could be Beginning *or* Intermediate), the card no longer dead-ends — it shows real, clickable chips: **"Prereqs for ARA 102" / "Prereqs for ARA 202"**.
- Works the same way for transfer questions ("does Principles of Accounting transfer…").

It can only ever **improve** on today's behavior: a confident match answers; anything uncertain falls back to the existing clarification, now with better suggestions. It never shows a wrong course.

## How it works (and why it's safe at scale)

The classifier already extracts the subject (it knew "Arabic" → ARA). This adds one schema field, `course_title`, set only when the student gives a name without a number (**a code always wins** — guarded by a regression test). The answer layer then calls a new `resolveCourse()` that mirrors the existing `resolveUniversity()`: **resolve-or-defer** — resolve only on an unambiguous match, otherwise return ranked suggestions.

Two design choices were driven by stress-testing real catalogs (the question was *"will this get messy for large states / as new semesters roll in?"*):

1. **Term-agnostic, subject-scoped catalog** (`getCourseTitlesForSubject`). Term codes in the `courses` table are inconsistent across scrapers (CA alone has `2026FA` / `2026-FA` / `26-FA` for the same semester, and the "latest" by sort is often a tiny partial scrape). Scoping a title catalog to a single term would resolve almost nothing for large states and silently rot each new term. Unioning all terms also catches title drift (every variant of a code resolves to it) and matches `courseExists()`, which already checks any term.
2. **Subject-scoped only → constant cost regardless of state size.** We fetch the ~tens-to-few-hundred rows for the named subject, never the full catalog (CA's 38k courses are never loaded). If the classifier doesn't supply a subject, we safely **defer** rather than scan.

### Why "messy for large states" is bounded (measured, not asserted)

Round-trip every catalog title → code, subject-scoped, on real data:

| State | distinct codes | **resolve** | defer | **false-resolve** |
|---|---|---|---|---|
| VA | 2,147 | 96.8% | 3.2% | **0.000%** |
| NC | 4,015 | 86.6% | 13.4% | **0.000%** |
| TX | 4,779 | 73.5% | 26.5% | **0.000%** |
| CA | 37,921 | 79.8% | 20.2% | **0.000%** |

Bigger/multi-district states **defer more** (e.g. CA's "Financial Accounting" legitimately maps to 19 ACCT numbers across districts → it shows chips, never guesses), but **false-resolve stays pinned at 0** across ~49k codes. `lib/search-intent/answer/__tests__/resolve-course.test.ts` runs VA+NC every CI run and TX+CA behind `RESOLVER_FULL_BATTERY=1`, asserting `false-resolve == 0`.

## Files

- `lib/search-intent/answer/resolve-course.ts` — pure matcher (`normalizeTitle`, `matchTitle`) with numeral / honors / min-token guards.
- `lib/courses.ts` — `getCourseTitlesForSubject(state, prefix)` (term-agnostic, projected, cached).
- `lib/search-intent/answer/validate.ts` — `resolveCourse()`.
- `lib/search-intent/{prompt,classify-llm,types}.ts` — `course_title` field + intent plumbing.
- `lib/search-intent/answer/{prereqs,transfer}.ts` — wire resolver (title consulted only when `course==null`); prereqs surfaces clickable suggestions on defer.

## Test plan

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 628 passed / 12 skipped.
- `RESOLVER_FULL_BATTERY=1 npx vitest run …/resolve-course.test.ts` — 0 false-resolves on VA/NC/TX/CA.
- **Live against prod Supabase:** "Intermediate Arabic II"→ARA 202, "Beginning American Sign Language II"→ASL 102, "Arabic II"→defer[ARA 102, ARA 202], no-prefix→defer, NC "Financial Accounting"→defer[ACC 111, ACC 105]. Cold ~120–250 ms (subject-scoped), cached ~1 ms.

## Known gaps (named, not hidden)

- Paraphrases that don't match a catalog title (VA's "Principles of Psychology" vs "Introduction to Psychology") **defer** rather than resolve — safe, and an optional synonym map can extend coverage later.
- A separate, pre-existing edge (not addressed here): the course-search rescue's level-word over-match ("intermediate" pulling in unrelated *Intermediate*-titled courses) seen in the screenshot's results grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)