### PR TITLE
fix(search): stop the results grid pulling in unrelated 'Intermediate'/'Intro' courses

### DIFF
--- a/lib/__tests__/courses-search.test.ts
+++ b/lib/__tests__/courses-search.test.ts
@@ -11,8 +11,29 @@ describe("meaningfulKeywordTokens (zero-result rescue)", () => {
     expect(meaningfulKeywordTokens("math courses without prerequisite?")).toEqual(["math"]);
     expect(meaningfulKeywordTokens("biology classes")).toEqual(["biology"]);
   });
-  it("keeps multiple subject/descriptor tokens", () => {
+  it("keeps multiple subject tokens", () => {
     expect(meaningfulKeywordTokens("online accounting courses")).toEqual(["online", "accounting"]);
+  });
+  it("drops level/scope descriptors so the rescue stays on-subject (not cross-subject)", () => {
+    // The bug: "intermediate" re-queried as a title substring and pulled in
+    // Intermediate Algebra / Accounting / etc. into an Arabic search's grid.
+    expect(meaningfulKeywordTokens("Intermediate Arabic II")).toEqual(["arabic"]);
+    expect(meaningfulKeywordTokens("intro to psychology")).toEqual(["psychology"]);
+    expect(meaningfulKeywordTokens("principles of accounting")).toEqual(["accounting"]);
+    expect(meaningfulKeywordTokens("beginning spanish")).toEqual(["spanish"]);
+    expect(meaningfulKeywordTokens("general biology")).toEqual(["biology"]);
+    // a query that is ONLY descriptors → no tokens → rescue skipped (stays 0)
+    expect(meaningfulKeywordTokens("introduction")).toEqual([]);
+    expect(meaningfulKeywordTokens("advanced intermediate")).toEqual([]);
+  });
+  it("strips question/stop words from raw NL sentences (the /ask grid case)", () => {
+    // The screenshot query: the whole sentence reaches the grid. Without
+    // stop-word stripping, "are"/"there" substring-match across all subjects.
+    expect(
+      meaningfulKeywordTokens("are there any prerequisite for Intermediate Arabic II"),
+    ).toEqual(["arabic"]);
+    expect(meaningfulKeywordTokens("what biology classes are available")).toEqual(["biology"]);
+    expect(meaningfulKeywordTokens("show me online nursing courses")).toEqual(["online", "nursing"]);
   });
   it("drops tokens under 3 chars and punctuation", () => {
     // "of" = filler, "ml" = under 3 chars → both dropped; "art" kept.

--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -55,15 +55,40 @@ export function parseQuery(q: string): {
 }
 
 // Filler words dropped when rescuing a no-result natural-language keyword query
-// (e.g. "math courses without prerequisite" → "math"). Intentionally narrow:
-// generic course/qualifier words, not subject or descriptor words, so we never
-// strip the part that identifies what the student wants.
+// (e.g. "math courses without prerequisite" → "math"). Two groups:
+//   1. Generic course / qualifier words.
+//   2. Level / scope descriptors (intro, intermediate, advanced, principles…).
+// Descriptors are dropped because in the 0-result rescue a bare descriptor token
+// re-queries as a title substring and matches EVERY same-level course across all
+// subjects — e.g. "Intermediate Arabic" pulled in "Intermediate Algebra",
+// "Intermediate Accounting", etc. into the results grid. The SUBJECT token
+// ("arabic") identifies the course and survives; a level word never names a
+// subject, so dropping it only ever narrows cross-subject noise. A query that is
+// ONLY descriptors yields no tokens → no rescue (acceptable; too vague to
+// recover precisely).
 const KEYWORD_FILLER = new Set([
+  // generic course / qualifier words
   "course", "courses", "class", "classes", "section", "sections",
   "without", "with", "no", "not", "any", "all", "some", "that", "which",
   "have", "having", "has", "the", "for", "and", "or", "to", "do", "does",
   "prerequisite", "prerequisites", "prereq", "prereqs", "requisite", "requisites",
   "requirement", "requirements", "require", "requires", "required", "need", "needs",
+  // level / scope descriptors (identify a LEVEL, not a subject)
+  "intro", "introduction", "introductory", "beginning", "beginner", "beginners",
+  "elementary", "intermediate", "advanced", "general", "principles",
+  "fundamental", "fundamentals", "basic", "basics", "foundation", "foundations",
+  "survey",
+  // common English question / stop / intent words. Raw NL sentences reach the
+  // rescue when the /ask page searches the whole question (e.g. "are there any
+  // prerequisites for Intermediate Arabic II") — without these, "are" and
+  // "there" substring-match "softwARE", "THEREapy", etc. across every subject.
+  // None of these ever names a subject.
+  "are", "was", "were", "what", "whats", "when", "where", "how", "why", "who",
+  "whose", "whom", "can", "could", "will", "would", "should", "shall", "may",
+  "might", "must", "did", "there", "here", "this", "these", "those", "you",
+  "your", "yours", "our", "their", "them", "they", "its", "about", "from",
+  "than", "then", "also", "only", "just", "into", "want", "wants", "looking",
+  "show", "find", "take", "get", "available", "offered",
 ]);
 
 /**


### PR DESCRIPTION
## What changes for someone using the site

When you ask a natural-language question on a state's course page, the **results grid** below the answer card no longer fills up with unrelated courses that merely share a *level* word.

Concretely, the reported case — *"are there any prerequisite for Intermediate Arabic II"* on VA — previously showed a grid of **61 courses / 217 sections** spanning Algebra (MDE), Accounting, French, German, etc. (everything titled "Intermediate …"). It now shows **2 courses / 7 sections — Arabic only** (Beginning Arabic I, Intermediate Arabic II). Same fix cleans up "intro to psychology" (→ Psychology), "principles of accounting" (→ Accounting), and similar.

This only ever affects the **0-result fallback** path, so it can't change a query that already returns matches.

## The mechanism (and why there were two causes)

`searchCoursesAcrossColleges` has a zero-result rescue (PR #1092): if a keyword phrase matches no course title verbatim, it splits the phrase into tokens and re-queries each as (a) a subject prefix and (b) a **title substring**. The substring step is where weak tokens leak across subjects. Two kinds were getting through:

1. **Level / scope words** — "intermediate", "intro", "beginning", "principles"… "intermediate" alone matched **83 sections across 7 subjects**. The *subject* token ("arabic") is the real identifier; the level word never names a subject.
2. **Question / stop words** — the `/ask` page feeds the *whole NL sentence* to the grid, so "are there any prerequisites for…" left **"are"** and **"there"** as tokens, which substring-match "softwARE", "THEREapy", childcARE, etc.

Both groups are now added to `KEYWORD_FILLER` in `lib/courses-search.ts`, so only subject tokens survive the rescue. A query that is *only* descriptors/stop-words yields no tokens → the rescue is skipped (result stays 0) rather than producing a wrong-subject grid.

## Files
- `lib/courses-search.ts` — extend `KEYWORD_FILLER` with level-descriptor and question/stop-word groups (with rationale comments).
- `lib/__tests__/courses-search.test.ts` — add cases for descriptor stripping, the raw-NL-sentence case, and descriptor-only → `[]`.

## Test plan
- `npx vitest run` — 630 passed / 12 skipped (28 in `courses-search.test.ts`).
- `npx tsc --noEmit` + `eslint` — clean.
- **Live against prod Supabase (VA):** "are there any prerequisite for Intermediate Arabic II" → `tokens:[arabic]` → 2 courses / 7 sections, ARA only (was 61 / 217). "principles of accounting" → ACC only; "intro to psychology" → PSY (+1 legit Human-Services title containing "psychology").

## Note
This is the follow-up flagged in PR #1096 ("level-word over-match in the results grid"). The title→code resolver (#1096) fixed the **answer card**; this fixes the **results grid** underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)