### PR TITLE
perf(programs): targeted transfer query + ISR cache (fix CA 15s render)

### DIFF
--- a/lib/__tests__/transfer.test.ts
+++ b/lib/__tests__/transfer.test.ts
@@ -1,7 +1,58 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Supabase mock — installed before importing the subject so the module
+// picks up the mocked client. Tracks each call's filters so the tests can
+// assert the targeted-query shape (`.eq('state', …).or(<compound>)`).
+const { selectMock, eqMock, orMock, fromMock, supabaseClient } = vi.hoisted(() => {
+  // Queue of responses so a single test that triggers multiple chunks can
+  // return different rows per chunk. Default is an empty success result.
+  const state: { responses: Array<{ data: unknown[] | null; error: unknown }> } = {
+    responses: [],
+  };
+  const orMock = vi.fn(async (_filter: string) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+    return state.responses.length > 0
+      ? state.responses.shift()!
+      : { data: [], error: null };
+  });
+  const eqMock = vi.fn();
+  const selectMock = vi.fn();
+  type Chain = {
+    select: (cols: string) => Chain;
+    eq: (col: string, val: unknown) => Chain;
+    or: (filter: string) => ReturnType<typeof orMock>;
+  };
+  const chain: Chain = {
+    select: (cols: string) => {
+      selectMock(cols);
+      return chain;
+    },
+    eq: (col: string, val: unknown) => {
+      eqMock(col, val);
+      return chain;
+    },
+    or: (filter: string) => orMock(filter),
+  };
+  const fromMock = vi.fn(() => chain);
+  return {
+    selectMock,
+    eqMock,
+    orMock,
+    fromMock,
+    supabaseClient: {
+      from: fromMock,
+      _queueResponses: (rs: Array<{ data: unknown[] | null; error: unknown }>) => {
+        state.responses = rs;
+      },
+    },
+  };
+});
+
+vi.mock("../supabase", () => ({ supabase: supabaseClient }));
+
 import {
   capMappingsByRoundRobin,
   trimMappingsForClient,
+  loadTransferMappingsForCourses,
   TRANSFER_HUB_MAX_CLIENT_MAPPINGS,
 } from "../transfer";
 import type { TransferMapping } from "../types";
@@ -104,5 +155,141 @@ describe("trimMappingsForClient", () => {
 describe("TRANSFER_HUB_MAX_CLIENT_MAPPINGS", () => {
   it("matches the documented Vercel-payload-safe ceiling", () => {
     expect(TRANSFER_HUB_MAX_CLIENT_MAPPINGS).toBe(2500);
+  });
+});
+
+describe("loadTransferMappingsForCourses", () => {
+  beforeEach(() => {
+    fromMock.mockClear();
+    selectMock.mockClear();
+    eqMock.mockClear();
+    orMock.mockClear();
+    supabaseClient._queueResponses([]);
+  });
+
+  it("returns [] immediately when courses is empty (no Supabase call)", async () => {
+    const result = await loadTransferMappingsForCourses("ca", []);
+    expect(result).toEqual([]);
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("queries the transfers table with state filter and a compound .or() of (prefix, number) tuples", async () => {
+    supabaseClient._queueResponses([{ data: [], error: null }]);
+
+    await loadTransferMappingsForCourses("ca", [
+      { prefix: "CS", number: "110" },
+      { prefix: "MATH", number: "280" },
+    ]);
+
+    expect(fromMock).toHaveBeenCalledWith("transfers");
+    expect(eqMock).toHaveBeenCalledWith("state", "ca");
+    expect(orMock).toHaveBeenCalledTimes(1);
+    const filter = orMock.mock.calls[0][0];
+    // PostgREST compound: and(cc_prefix.eq.X,cc_number.eq.Y),and(...)
+    expect(filter).toContain("and(cc_prefix.eq.CS,cc_number.eq.110)");
+    expect(filter).toContain("and(cc_prefix.eq.MATH,cc_number.eq.280)");
+  });
+
+  it("deduplicates repeated (prefix, number) pairs before querying", async () => {
+    supabaseClient._queueResponses([{ data: [], error: null }]);
+
+    await loadTransferMappingsForCourses("ca", [
+      { prefix: "CS", number: "110" },
+      { prefix: "CS", number: "110" }, // duplicate
+      { prefix: "MATH", number: "280" },
+      { prefix: "CS", number: "110" }, // duplicate again
+    ]);
+
+    const filter = orMock.mock.calls[0][0];
+    const csOccurrences = filter.match(/cc_prefix\.eq\.CS,cc_number\.eq\.110/g) ?? [];
+    expect(csOccurrences).toHaveLength(1);
+    // MATH still present.
+    expect(filter).toContain("cc_prefix.eq.MATH,cc_number.eq.280");
+  });
+
+  it("chunks queries at 100 distinct courses (101 → two Supabase calls)", async () => {
+    supabaseClient._queueResponses([
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    const courses: Array<{ prefix: string; number: string }> = [];
+    for (let i = 0; i < 101; i++) courses.push({ prefix: "X", number: String(i) });
+
+    await loadTransferMappingsForCourses("ca", courses);
+
+    expect(orMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("concatenates rows from every chunk into a single result array", async () => {
+    const chunk1Rows = [makeMapping("X", "1"), makeMapping("X", "2")];
+    const chunk2Rows = [makeMapping("Y", "3")];
+    supabaseClient._queueResponses([
+      { data: chunk1Rows, error: null },
+      { data: chunk2Rows, error: null },
+    ]);
+
+    const courses: Array<{ prefix: string; number: string }> = [];
+    for (let i = 0; i < 101; i++) courses.push({ prefix: "X", number: String(i) });
+
+    const result = await loadTransferMappingsForCourses("ca", courses);
+    expect(result).toHaveLength(3);
+    expect(result.map((m) => `${m.cc_prefix}${m.cc_number}`)).toEqual(["X1", "X2", "Y3"]);
+  });
+
+  it("returns rows when a course has matches", async () => {
+    const rows = [makeMapping("CS", "110"), makeMapping("CS", "110")];
+    supabaseClient._queueResponses([{ data: rows, error: null }]);
+
+    const result = await loadTransferMappingsForCourses("ca", [
+      { prefix: "CS", number: "110" },
+    ]);
+    expect(result).toEqual(rows);
+  });
+
+  it("returns [] (not throw) when a course has no matching transfers", async () => {
+    supabaseClient._queueResponses([{ data: [], error: null }]);
+
+    const result = await loadTransferMappingsForCourses("ca", [
+      { prefix: "XXX", number: "999" },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("propagates Supabase errors instead of silently returning []", async () => {
+    supabaseClient._queueResponses([
+      { data: null, error: { message: "PostgREST barfed" } },
+    ]);
+
+    await expect(
+      loadTransferMappingsForCourses("ca", [{ prefix: "CS", number: "110" }]),
+    ).rejects.toBeTruthy();
+  });
+
+  it("selects the same column set as the existing loaders so callers get a consistent TransferMapping shape", async () => {
+    supabaseClient._queueResponses([{ data: [], error: null }]);
+
+    await loadTransferMappingsForCourses("ca", [{ prefix: "CS", number: "110" }]);
+
+    // Columns the existing loaders fetch. Order may differ; just assert the set.
+    const expected = [
+      "cc_prefix",
+      "cc_number",
+      "cc_course",
+      "cc_title",
+      "cc_credits",
+      "university",
+      "university_name",
+      "univ_course",
+      "univ_title",
+      "univ_credits",
+      "notes",
+      "no_credit",
+      "is_elective",
+    ];
+    const selectArg = selectMock.mock.calls[0][0] as string;
+    for (const col of expected) {
+      expect(selectArg).toContain(col);
+    }
   });
 });

--- a/lib/programs/__tests__/planner.test.ts
+++ b/lib/programs/__tests__/planner.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { TransferMapping } from "@/lib/types";
+
+// All loaders that buildMajorPlan depends on are mocked. The point of these
+// tests is the integration contract — that the planner calls the new
+// targeted loader with the deduped (prefix, number) list pulled from the
+// program's requirement_groups, and that the returned mappings flow into a
+// correctly-shaped MajorPlan.
+const {
+  loadInstitutionsMock,
+  loadCollegeProgramsMock,
+  loadTransferMappingsForCoursesMock,
+  loadPrereqsMock,
+  getCurrentTermMock,
+} = vi.hoisted(() => ({
+  loadInstitutionsMock: vi.fn(),
+  loadCollegeProgramsMock: vi.fn(),
+  loadTransferMappingsForCoursesMock: vi.fn(),
+  loadPrereqsMock: vi.fn(() => new Map()),
+  getCurrentTermMock: vi.fn(async () => "2026SP"),
+}));
+
+// next/cache's unstable_cache throws "Invariant: incrementalCache missing"
+// when called outside the Next.js request runtime. For unit tests we want it
+// to be a transparent passthrough so we exercise the actual planner logic
+// rather than the cache layer. Production behavior is verified separately
+// via the post-deploy `x-vercel-cache: HIT` curl in the PR's test plan.
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+  revalidateTag: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/institutions", () => ({
+  loadInstitutions: loadInstitutionsMock,
+}));
+vi.mock("@/lib/programs/requirements", () => ({
+  loadCollegePrograms: loadCollegeProgramsMock,
+}));
+vi.mock("@/lib/transfer", () => ({
+  loadTransferMappingsForCourses: loadTransferMappingsForCoursesMock,
+}));
+vi.mock("@/lib/prereqs", () => ({ loadPrereqs: loadPrereqsMock }));
+vi.mock("@/lib/terms", () => ({ getCurrentTerm: getCurrentTermMock }));
+
+import { buildMajorPlan, programSlug } from "../planner";
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+const FAKE_INSTITUTION = {
+  id: "cuyamaca",
+  name: "Cuyamaca College",
+  college_slug: "cuyamaca-college",
+};
+
+// 6 distinct real courses (above PLAN_MIN_COURSES = 5) plus an XXX
+// placeholder and a deliberate CS 110 duplicate across groups — exercises
+// both the placeholder-filter and the dedup behavior the planner relies on.
+const FAKE_PROGRAM = {
+  title: "Computer Science for Transfer (AS-T)",
+  credential: "AS",
+  catalog_url: "https://example/cs",
+  total_credits: 60,
+  gpa_minimum: 2.0,
+  requirement_groups: [
+    {
+      name: "Core",
+      credits_required: null,
+      choose_n: null,
+      courses: [
+        { prefix: "CS", number: "110", title: "Intro to CS", credits: "4", or_alternatives: [] },
+        { prefix: "CS", number: "120", title: "Data Structures", credits: "4", or_alternatives: [] },
+        { prefix: "CS", number: "210", title: "Systems", credits: "4", or_alternatives: [] },
+      ],
+    },
+    {
+      name: "Math",
+      credits_required: null,
+      choose_n: null,
+      courses: [
+        { prefix: "MATH", number: "280", title: "Calc I", credits: "5", or_alternatives: [] },
+        { prefix: "MATH", number: "281", title: "Calc II", credits: "5", or_alternatives: [] },
+        // CS 110 duplicated across a different group → loader must dedup.
+        { prefix: "CS", number: "110", title: "Intro to CS", credits: "4", or_alternatives: [] },
+        // Placeholder that should NOT be sent to the loader.
+        { prefix: "XXX", number: "Elective", title: "Placeholder", credits: null, or_alternatives: [] },
+      ],
+    },
+    {
+      name: "Science",
+      credits_required: null,
+      choose_n: null,
+      courses: [
+        { prefix: "PHYS", number: "200", title: "Physics I", credits: "4", or_alternatives: [] },
+      ],
+    },
+  ],
+};
+
+function makeMapping(
+  prefix: string,
+  number: string,
+  uni: string,
+  opts: Partial<TransferMapping> = {},
+): TransferMapping {
+  return {
+    cc_prefix: prefix,
+    cc_number: number,
+    cc_course: `${prefix} ${number}`,
+    cc_title: `${prefix} ${number}`,
+    cc_credits: "3",
+    university: uni,
+    university_name: uni.toUpperCase(),
+    univ_course: `U${prefix} ${number}`,
+    univ_title: "Univ Title",
+    univ_credits: "3",
+    notes: "",
+    no_credit: false,
+    is_elective: false,
+    ...opts,
+  };
+}
+
+beforeEach(() => {
+  loadInstitutionsMock.mockReset();
+  loadCollegeProgramsMock.mockReset();
+  loadTransferMappingsForCoursesMock.mockReset();
+  loadPrereqsMock.mockReset();
+  getCurrentTermMock.mockReset();
+
+  loadInstitutionsMock.mockReturnValue([FAKE_INSTITUTION]);
+  loadCollegeProgramsMock.mockResolvedValue([FAKE_PROGRAM]);
+  loadPrereqsMock.mockReturnValue(new Map());
+  getCurrentTermMock.mockResolvedValue("2026SP");
+  loadTransferMappingsForCoursesMock.mockResolvedValue([]);
+});
+
+describe("buildMajorPlan — targeted transfer loader integration", () => {
+  it("calls loadTransferMappingsForCourses with the program's REAL courses (XXX placeholders dropped before the query)", async () => {
+    await buildMajorPlan("ca", "cuyamaca", programSlug(FAKE_PROGRAM));
+
+    expect(loadTransferMappingsForCoursesMock).toHaveBeenCalledTimes(1);
+    const [state, courses] = loadTransferMappingsForCoursesMock.mock.calls[0];
+
+    expect(state).toBe("ca");
+    // XXX placeholder is dropped by isRealCourse before reaching the loader.
+    // CS 110 still appears twice — the planner passes the raw per-group list;
+    // dedup is the loader's responsibility (covered in transfer.test.ts).
+    const tuples = (courses as Array<{ prefix: string; number: string }>)
+      .map((c) => `${c.prefix} ${c.number}`)
+      .sort();
+    expect(tuples).toEqual([
+      "CS 110",
+      "CS 110", // duplicated across Core + Math groups
+      "CS 120",
+      "CS 210",
+      "MATH 280",
+      "MATH 281",
+      "PHYS 200",
+    ]);
+    // Placeholder must NOT be in the list.
+    expect(tuples).not.toContain("XXX Elective");
+  });
+
+  it("builds the per-university coverage map from the returned mappings", async () => {
+    loadTransferMappingsForCoursesMock.mockResolvedValue([
+      makeMapping("CS", "110", "ucsd"),
+      makeMapping("CS", "120", "ucsd"),
+      makeMapping("MATH", "280", "ucsd"),
+      makeMapping("CS", "110", "sdsu"),
+    ]);
+
+    const plan = await buildMajorPlan("ca", "cuyamaca", programSlug(FAKE_PROGRAM));
+    expect(plan).not.toBeNull();
+
+    // Pre-existing planner behavior: a course duplicated across requirement
+    // groups counts toward `accepts` per group-occurrence. CS 110 appears
+    // in both Core and Math, so UCSD's CS 110 mapping increments twice.
+    // UCSD: CS 110 (×2 groups) + CS 120 + MATH 280 = 4.
+    // SDSU: CS 110 (×2 groups) = 2.
+    const ucsd = plan!.universities.find((u) => u.slug === "ucsd");
+    const sdsu = plan!.universities.find((u) => u.slug === "sdsu");
+    expect(ucsd?.accepts).toBe(4);
+    expect(sdsu?.accepts).toBe(2);
+    // Sorted by coverage desc.
+    expect(plan!.universities[0].slug).toBe("ucsd");
+  });
+
+  it("collapses multiple mappings for the same (course, university) to the best verdict (direct > elective > no-credit)", async () => {
+    loadTransferMappingsForCoursesMock.mockResolvedValue([
+      makeMapping("CS", "110", "ucsd", { is_elective: true }), // elective
+      makeMapping("CS", "110", "ucsd", { is_elective: false }), // direct — should win
+      makeMapping("CS", "110", "ucsd", { no_credit: true }), // no-credit — should lose
+    ]);
+
+    const plan = await buildMajorPlan("ca", "cuyamaca", programSlug(FAKE_PROGRAM));
+    const cs110 = plan!.groups.flatMap((g) => g.courses).find((c) => c.code === "CS 110")!;
+
+    expect(cs110.transfers.ucsd.status).toBe("direct");
+    // Counted ONCE toward acceptingCount, not 3×.
+    expect(cs110.acceptingCount).toBe(1);
+  });
+
+  it("returns null when the program slug doesn't match (does not call the transfer loader)", async () => {
+    const plan = await buildMajorPlan("ca", "cuyamaca", "does-not-exist");
+    expect(plan).toBeNull();
+    expect(loadTransferMappingsForCoursesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the institution doesn't exist (does not call the transfer loader)", async () => {
+    const plan = await buildMajorPlan("ca", "no-such-college", programSlug(FAKE_PROGRAM));
+    expect(plan).toBeNull();
+    expect(loadTransferMappingsForCoursesMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/programs/planner.ts
+++ b/lib/programs/planner.ts
@@ -20,8 +20,9 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { unstable_cache } from "next/cache";
 import { loadCollegePrograms } from "@/lib/programs/requirements";
-import { loadTransferMappings } from "@/lib/transfer";
+import { loadTransferMappingsForCourses } from "@/lib/transfer";
 import { loadInstitutions } from "@/lib/institutions";
 import { loadPrereqs } from "@/lib/prereqs";
 import { getCurrentTerm } from "@/lib/terms";
@@ -229,7 +230,7 @@ export async function listPlannableProgramsForCollege(
  * the college, program, or program's real-course list can't be resolved
  * (callers should `notFound()`).
  */
-export async function buildMajorPlan(
+async function buildMajorPlanInner(
   state: string,
   collegeId: string,
   slug: string,
@@ -250,8 +251,13 @@ export async function buildMajorPlan(
   const term = resolveTerm(state, collegeSlug, preferredTerm) ?? preferredTerm;
   const sectionCounts = term ? sectionCountsFromFiles(state, collegeSlug, term) : new Map();
 
-  // Index transfer mappings by join key for fast per-course lookup.
-  const mappings = await loadTransferMappings(state);
+  // Targeted fetch: only the courses this program requires, not the entire
+  // state's transfer table. For CA (~162k state rows) this is the difference
+  // between a 15s cold render and <1s. Backed by idx_transfers_state_course.
+  const programCourses = program.requirement_groups.flatMap((g) =>
+    g.courses.filter(isRealCourse).map((c) => ({ prefix: c.prefix, number: c.number })),
+  );
+  const mappings = await loadTransferMappingsForCourses(state, programCourses);
   const transferIndex = new Map<string, CourseTransfer[]>();
   for (const m of mappings) {
     const key = joinKey(m.cc_prefix, m.cc_number);
@@ -350,6 +356,31 @@ export async function buildMajorPlan(
     totals: { listedCourses, offeredThisTerm },
     sequence,
   };
+}
+
+// Cross-instance plan cache. The route already declares `revalidate = 86400`,
+// but until this wrap landed every Supabase fetch inside `buildMajorPlanInner`
+// (loadCollegePrograms, loadTransferMappingsForCourses, getCurrentTerm)
+// counted as uncached fetch under Next 16's defaults — which marks the whole
+// route dynamic and ships `cache-control: no-store`. Wrapping the full plan
+// in unstable_cache restores Vercel-Data-Cache-backed ISR: first visitor pays
+// the assembly cost, everyone else gets an edge HIT for 24h.
+//
+// Key parts are the function arguments; the "program-plan-v1" string is just
+// a namespace. Bump the suffix when the MajorPlan shape changes so stale
+// cached objects don't deserialize wrong.
+const _cachedBuildMajorPlan = unstable_cache(
+  (state: string, collegeId: string, slug: string) => buildMajorPlanInner(state, collegeId, slug),
+  ["program-plan-v1"],
+  { revalidate: 86400, tags: ["transfers", "programs"] },
+);
+
+export async function buildMajorPlan(
+  state: string,
+  collegeId: string,
+  slug: string,
+): Promise<MajorPlan | null> {
+  return _cachedBuildMajorPlan(state, collegeId, slug);
 }
 
 /** direct beats elective beats no-credit when a course maps multiple ways. */

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -205,6 +205,63 @@ async function _loadTransferMappingsByUniversity(
   return result;
 }
 
+// Shared column list — kept identical across loaders so callers get a
+// uniform TransferMapping shape.
+const TRANSFER_COLUMNS =
+  "cc_prefix, cc_number, cc_course, cc_title, cc_credits, university, university_name, univ_course, univ_title, univ_credits, notes, no_credit, is_elective";
+
+// Chunk size for the compound .or() filter. Each tuple encodes to ~40 chars
+// (`and(cc_prefix.eq.XX,cc_number.eq.NNN)`); 100 stays comfortably under
+// PostgREST's ~8KB practical URL ceiling.
+const COURSE_FILTER_CHUNK = 100;
+
+/**
+ * Load transfer mappings for a specific set of CC courses in a single
+ * (or few) targeted Supabase queries — instead of pulling the entire
+ * state's mappings and filtering in memory.
+ *
+ * Replaces `loadTransferMappings(state)` for callers that already know
+ * which `(cc_prefix, cc_number)` pairs they need. Critical for CA, where
+ * the state-wide loader pages through ~162k rows (~15s) just to use ~30.
+ *
+ * Backed by `idx_transfers_state_course` on `(state, cc_prefix, cc_number)`
+ * — see `EXPLAIN ANALYZE` in PR #N description (~5ms server-side for ~10
+ * courses on the CA dataset).
+ */
+export async function loadTransferMappingsForCourses(
+  state: string,
+  courses: ReadonlyArray<{ prefix: string; number: string }>,
+): Promise<TransferMapping[]> {
+  if (courses.length === 0) return [];
+
+  // Dedupe — programs often list the same course in multiple requirement
+  // groups, and a duplicate filter clause is wasted DB work.
+  const seen = new Set<string>();
+  const unique: Array<{ prefix: string; number: string }> = [];
+  for (const c of courses) {
+    const key = `${c.prefix}|${c.number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(c);
+  }
+
+  const out: TransferMapping[] = [];
+  for (let i = 0; i < unique.length; i += COURSE_FILTER_CHUNK) {
+    const batch = unique.slice(i, i + COURSE_FILTER_CHUNK);
+    const orFilter = batch
+      .map((c) => `and(cc_prefix.eq.${c.prefix},cc_number.eq.${c.number})`)
+      .join(",");
+    const { data, error } = await supabase
+      .from("transfers")
+      .select(TRANSFER_COLUMNS)
+      .eq("state", state)
+      .or(orFilter);
+    if (error) throw error;
+    if (data) out.push(...(data as TransferMapping[]));
+  }
+  return out;
+}
+
 /**
  * Load all transfer mappings from Supabase (with local JSON fallback).
  * Cached after first load.


### PR DESCRIPTION
## What changes for users
The Computer-Science-for-Transfer program page at Cuyamaca College (and every other California program page) now loads in under a second instead of stalling out for 15 seconds and triggering Safari's "This page couldn't load" error. Reported symptom: black error screen on https://communitycollegepath.com/ca/college/cuyamaca-college/program/computer-science-for-transfer-as-t-associate-in-science-as . Root cause: the planner was pulling every California transfer mapping (~162,000 rows) on every request just to use the ~10 that the program needed.

No visible change on other states' program pages (they were already fast — this just keeps them fast as their transfer datasets grow).

## What changes technically
Two changes:

1. **Targeted Supabase query.** New `loadTransferMappingsForCourses(state, courses[])` in [lib/transfer.ts](lib/transfer.ts) builds a single compound `.or()` filter — `and(cc_prefix.eq.X,cc_number.eq.Y),and(...)` — over only the `(cc_prefix, cc_number)` pairs the program lists. Backed by the existing `idx_transfers_state_course` index; `EXPLAIN ANALYZE` shows ~5ms server-side for a 10-course query on CA's 162k-row table, down from ~15s of sequential 1k-row pagination. `buildMajorPlan` in [lib/programs/planner.ts](lib/programs/planner.ts) now calls this instead of `loadTransferMappings(state)`.
2. **ISR cache restored.** The route already declared `revalidate = 86400` but ISR was never engaging because the Supabase fetches inside `buildMajorPlan` are uncached under Next 16's defaults — that marked the whole route dynamic and shipped `cache-control: no-store` on every response. Wrapping `buildMajorPlan` in `unstable_cache` (24h revalidate, `transfers`/`programs` tags) restores Vercel-Data-Cache-backed ISR: the first visitor pays a few hundred ms, everyone else gets edge-cached.

No schema changes — the index this depends on (`transfers(state, cc_prefix, cc_number)`) was already present. Other callers of the older state-wide `loadTransferMappings` are unaffected and unchanged (they're API routes, scoped separately; left for a follow-up).

## Files changed
| File | Delta |
|---|---|
| [lib/transfer.ts](lib/transfer.ts) | +57 — new targeted loader + shared `TRANSFER_COLUMNS` |
| [lib/programs/planner.ts](lib/programs/planner.ts) | +35/-5 — switch to targeted loader + `unstable_cache` wrap |
| [lib/__tests__/transfer.test.ts](lib/__tests__/transfer.test.ts) | +188 — 9 new test cases (Supabase mock pattern) |
| [lib/programs/__tests__/planner.test.ts](lib/programs/__tests__/planner.test.ts) | +215 — new file, 5 integration tests |

## Test plan
Local (done):
- [x] `npm run test:run` — 642 passed (added 14 new cases, 0 regressions)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings from these files
- [x] `npm run build` — compiles successfully
- [x] Pre-flight verified `idx_transfers_state_course` index exists; `EXPLAIN ANALYZE` shows 4.7ms for the targeted query

Preview (will append results to this PR body once Vercel deploy is live):
- [ ] Cold-cache CA page render < 1s
- [ ] Second request returns `x-vercel-cache: HIT`
- [ ] VA program page (`/va/college/nvcc/program/general-studies-as`) still < 0.5s
- [ ] GA program page still < 0.5s
- [ ] Safari load on preview — page renders without "couldn't load" error
- [ ] Rendered page actually shows transfer verdicts (not empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)