### PR TITLE
nav: fix double close-X + active-page highlight in sidebar

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 
@@ -67,6 +68,7 @@ export default function Header({
   const [open, setOpen] = useState(false);
   const [pinned, setPinned] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
+  const pathname = usePathname();
 
   // On desktop the sidebar shows when opened OR pinned; on mobile only when
   // explicitly opened (pin is a desktop-only convenience).
@@ -124,16 +126,6 @@ export default function Header({
     }
   };
 
-  // Hamburger: show if hidden; fully close (and unpin) if showing.
-  const toggle = useCallback(() => {
-    if (effectiveOpen) {
-      setOpen(false);
-      persistPin(false);
-    } else {
-      setOpen(true);
-    }
-  }, [effectiveOpen]);
-
   const closeNav = () => {
     setOpen(false);
     persistPin(false);
@@ -174,30 +166,37 @@ export default function Header({
     },
   ];
 
+  // Highlight the current page. State home (/{state}) matches exactly so it
+  // doesn't light up on every sub-route; others match the page or its children.
+  const stateHome = `/${state}`;
+  const isActive = (href: string) => {
+    if (href === stateHome) return pathname === stateHome;
+    if (href === "/") return false; // "All States" — never "current" on a state page
+    return pathname === href || pathname.startsWith(`${href}/`);
+  };
+
   return (
     <>
       {/* Top bar */}
       <header className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 sticky top-0 z-30">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={toggle}
-              className="inline-flex items-center justify-center w-10 h-10 -ml-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
-              aria-label={effectiveOpen ? "Close menu" : "Open menu"}
-              aria-expanded={effectiveOpen}
-              aria-controls="site-sidebar"
-            >
-              {effectiveOpen ? (
-                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              ) : (
+            {/* Hamburger — only when the sidebar is closed. When open, the
+                single close control lives in the sidebar (no duplicate X). */}
+            {!effectiveOpen && (
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                className="inline-flex items-center justify-center w-10 h-10 -ml-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-700 transition"
+                aria-label="Open menu"
+                aria-expanded={false}
+                aria-controls="site-sidebar"
+              >
                 <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                 </svg>
-              )}
-            </button>
+              </button>
+            )}
             <Link href={`/${state}`} className="flex items-center gap-2">
               <div className="w-8 h-8 bg-teal-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-xs">CCP</span>
@@ -280,16 +279,24 @@ export default function Header({
               <p className="px-2 mb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-slate-500">
                 {col.heading}
               </p>
-              {col.links.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={onNavigate}
-                  className="block rounded-md px-2 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-50 hover:text-teal-700 dark:hover:bg-slate-800 dark:hover:text-teal-300 transition-colors"
-                >
-                  {link.label}
-                </Link>
-              ))}
+              {col.links.map((link) => {
+                const active = isActive(link.href);
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={onNavigate}
+                    aria-current={active ? "page" : undefined}
+                    className={`block rounded-md px-2 py-1.5 text-sm transition-colors ${
+                      active
+                        ? "bg-teal-50 font-semibold text-teal-700 dark:bg-teal-500/10 dark:text-teal-300"
+                        : "text-gray-700 hover:bg-gray-50 hover:text-teal-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-300"
+                    }`}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
             </div>
           ))}
         </nav>


### PR DESCRIPTION
## What changes for someone using the site

Two fixes to the new sidebar nav:

1. **No more double "X".** When the sidebar was open you saw *two* close buttons — the top-bar hamburger turned into an X, and the sidebar had its own X. Now the toggle is contextual, the way Notion/Linear/Vercel do it: a **hamburger in the top bar when the sidebar is closed**, and a **single close button inside the sidebar when it's open**. The top bar just shows the logo + Sign In + theme while open.
2. **Your current page is highlighted.** The sidebar now marks the page you're on (e.g. "Find a Course" is highlighted while you're on the course search), so a persistent menu actually tells you where you are.

Also tightened link spacing and the active/hover styling. Works in light and dark mode.

## What changes on the technical front

`components/Header.tsx`:
- The top-bar toggle is now rendered only when `!effectiveOpen`; the sidebar's existing close button is the sole close control when open. Removed the old hamburger↔X swap (and the now-unused `toggle`/`useCallback`).
- Active state via `usePathname()` + `aria-current="page"`. `isActive` matches the page or its sub-routes, with an exact match for the state home (`/{state}`) so it doesn't light up on every route, and never marks the global "All States" link active on a state page.

## Test plan
- Playwright (worktree dev server): closed → top-bar hamburger present; open → **exactly one** close control with the top-bar button hidden (desktop **and** mobile); active highlight lands on the current page; verified light + dark.
- `next build` exit 0; 630 tests pass; `tsc --noEmit` + eslint clean.

Follow-up to #1095 (the sidebar). Pure presentational change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)