### PR TITLE
test: unit-test sidebar nav + fill choose coverage gaps

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,52 +5,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
-
-// Task-based nav groups — single source of truth for the sidebar. "Find your
-// program" (the guided quiz) sits with Programs; it's ungated like /programs
-// (both notFound() when a state has no qualifying programs). See #413 for why
-// the Programs index is reachable from every page.
-const NAV_GROUPS = [
-  {
-    heading: "Explore classes",
-    items: [
-      { path: "", label: "Search" },
-      { path: "/courses", label: "Find a Course" },
-      { path: "/starting-soon", label: "Starting Soon" },
-      { path: "/colleges", label: "All Colleges" },
-    ],
-  },
-  {
-    heading: "Plan your path",
-    items: [
-      { path: "/schedule", label: "Schedule Builder" },
-      { path: "/plan", label: "Semester Planner" },
-      { path: "/transfer", label: "Transfer" },
-    ],
-  },
-  {
-    heading: "Programs & majors",
-    items: [
-      { path: "/choose", label: "Find your program" },
-      { path: "/programs", label: "Programs" },
-    ],
-  },
-];
-
-// "More" utility links — About is state-scoped; All States is the global "/".
-const MORE_ITEMS = [{ path: "/about", label: "About" }];
-
-// Guides cluster (#374) — high-traffic blog hubs surfaced in the sidebar.
-const GUIDES_ITEMS = [
-  { href: "/blog/free-community-college-classes-for-seniors", label: "Senior Waivers" },
-  { href: "/blog/how-to-check-if-community-college-course-transfers", label: "Transfer Guides" },
-  { href: "/blog/what-does-audit-a-class-mean", label: "Auditing a Class" },
-  { href: "/blog/how-to-find-late-start-community-college-classes", label: "Late-Start Classes" },
-  { href: "/blog", label: "All Articles →" },
-];
-
-const PIN_KEY = "ccp-nav-pinned";
-const DESKTOP_MQ = "(min-width: 1024px)";
+import {
+  PIN_KEY,
+  DESKTOP_MQ,
+  sidebarVisible,
+  buildNavColumns,
+  isNavLinkActive,
+  closesOnNavigate,
+} from "@/lib/nav/sidebar";
 
 export default function Header({
   state,
@@ -72,7 +34,7 @@ export default function Header({
 
   // On desktop the sidebar shows when opened OR pinned; on mobile only when
   // explicitly opened (pin is a desktop-only convenience).
-  const effectiveOpen = isDesktop ? open || pinned : open;
+  const effectiveOpen = sidebarVisible(open, pinned, isDesktop);
 
   // Track viewport so pin/push apply on desktop only.
   useEffect(() => {
@@ -133,7 +95,7 @@ export default function Header({
 
   // Clicking a link closes the menu unless it's pinned open on desktop.
   const onNavigate = () => {
-    if (!(isDesktop && pinned)) setOpen(false);
+    if (closesOnNavigate(isDesktop, pinned)) setOpen(false);
   };
 
   const togglePin = () => {
@@ -142,38 +104,9 @@ export default function Header({
     if (next) setOpen(true);
   };
 
-  // Hide transfer/planner where the state lacks the data backing them.
-  const showItem = (path: string) =>
-    (path !== "/transfer" || transferSupported) &&
-    (path !== "/plan" || prereqsAvailable);
-  const toLink = (item: { path: string; label: string }) => ({
-    href: `/${state}${item.path}`,
-    label: item.label,
-  });
-
-  const columns: { heading: string; links: { href: string; label: string }[] }[] = [
-    ...NAV_GROUPS.map((g) => ({
-      heading: g.heading,
-      links: g.items.filter((i) => showItem(i.path)).map(toLink),
-    })),
-    { heading: "Guides", links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })) },
-    {
-      heading: "More",
-      links: [
-        ...MORE_ITEMS.filter((i) => showItem(i.path)).map(toLink),
-        { href: "/", label: "All States" },
-      ],
-    },
-  ];
-
-  // Highlight the current page. State home (/{state}) matches exactly so it
-  // doesn't light up on every sub-route; others match the page or its children.
+  const columns = buildNavColumns(state, { transferSupported, prereqsAvailable });
   const stateHome = `/${state}`;
-  const isActive = (href: string) => {
-    if (href === stateHome) return pathname === stateHome;
-    if (href === "/") return false; // "All States" — never "current" on a state page
-    return pathname === href || pathname.startsWith(`${href}/`);
-  };
+  const isActive = (href: string) => isNavLinkActive(pathname, href, stateHome);
 
   return (
     <>

--- a/lib/nav/__tests__/sidebar.test.ts
+++ b/lib/nav/__tests__/sidebar.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  sidebarVisible,
+  showNavItem,
+  buildNavColumns,
+  isNavLinkActive,
+  closesOnNavigate,
+  NAV_GROUPS,
+  MORE_ITEMS,
+  type NavGating,
+} from "../sidebar";
+
+const ALL: NavGating = { transferSupported: true, prereqsAvailable: true };
+
+// --- sidebarVisible -------------------------------------------------------
+
+describe("sidebarVisible", () => {
+  it("desktop: shows when opened OR pinned", () => {
+    expect(sidebarVisible(false, false, true)).toBe(false);
+    expect(sidebarVisible(true, false, true)).toBe(true);
+    expect(sidebarVisible(false, true, true)).toBe(true);
+    expect(sidebarVisible(true, true, true)).toBe(true);
+  });
+
+  it("mobile: shows only when explicitly opened", () => {
+    expect(sidebarVisible(false, false, false)).toBe(false);
+    expect(sidebarVisible(true, false, false)).toBe(true);
+  });
+
+  // REGRESSION: a persisted desktop pin must never auto-open the mobile
+  // overlay — pin is desktop-only.
+  it("mobile: a pinned value does NOT auto-open the sidebar", () => {
+    expect(sidebarVisible(false, true, false)).toBe(false);
+  });
+});
+
+// --- showNavItem (gating) -------------------------------------------------
+
+describe("showNavItem", () => {
+  it("hides /transfer when transfers are unsupported", () => {
+    expect(showNavItem("/transfer", { ...ALL, transferSupported: false })).toBe(false);
+    expect(showNavItem("/transfer", { ...ALL, transferSupported: true })).toBe(true);
+  });
+
+  it("hides /plan when prereqs are unavailable", () => {
+    expect(showNavItem("/plan", { ...ALL, prereqsAvailable: false })).toBe(false);
+    expect(showNavItem("/plan", { ...ALL, prereqsAvailable: true })).toBe(true);
+  });
+
+  it("shows every other item regardless of gating", () => {
+    const none = { transferSupported: false, prereqsAvailable: false };
+    for (const p of ["", "/courses", "/colleges", "/choose", "/programs", "/about"]) {
+      expect(showNavItem(p, none)).toBe(true);
+    }
+  });
+});
+
+// --- buildNavColumns ------------------------------------------------------
+
+describe("buildNavColumns", () => {
+  it("emits the expected columns in order", () => {
+    const cols = buildNavColumns("va", ALL);
+    expect(cols.map((c) => c.heading)).toEqual([
+      "Explore classes",
+      "Plan your path",
+      "Programs & majors",
+      "Guides",
+      "More",
+    ]);
+  });
+
+  it("prefixes state-scoped links with /{state} and resolves Search to the home", () => {
+    const cols = buildNavColumns("va", ALL);
+    const explore = cols.find((c) => c.heading === "Explore classes")!;
+    expect(explore.links.find((l) => l.label === "Search")!.href).toBe("/va");
+    expect(explore.links.find((l) => l.label === "Find a Course")!.href).toBe("/va/courses");
+  });
+
+  it("keeps Guides links as absolute /blog hrefs (not state-prefixed)", () => {
+    const guides = buildNavColumns("va", ALL).find((c) => c.heading === "Guides")!;
+    expect(guides.links.every((l) => l.href.startsWith("/blog"))).toBe(true);
+  });
+
+  it("ends the More column with the global All States link", () => {
+    const more = buildNavColumns("va", ALL).find((c) => c.heading === "More")!;
+    expect(more.links.at(-1)).toEqual({ href: "/", label: "All States" });
+    expect(more.links.find((l) => l.label === "About")!.href).toBe("/va/about");
+  });
+
+  it("includes Find your program in Programs & majors", () => {
+    const prog = buildNavColumns("va", ALL).find((c) => c.heading === "Programs & majors")!;
+    expect(prog.links.map((l) => l.label)).toContain("Find your program");
+  });
+
+  it("omits Transfer when transfers are unsupported", () => {
+    const plan = buildNavColumns("va", { transferSupported: false, prereqsAvailable: true })
+      .find((c) => c.heading === "Plan your path")!;
+    expect(plan.links.some((l) => l.href === "/va/transfer")).toBe(false);
+    expect(plan.links.some((l) => l.href === "/va/schedule")).toBe(true);
+  });
+
+  it("omits Semester Planner when prereqs are unavailable", () => {
+    const plan = buildNavColumns("va", { transferSupported: true, prereqsAvailable: false })
+      .find((c) => c.heading === "Plan your path")!;
+    expect(plan.links.some((l) => l.href === "/va/plan")).toBe(false);
+  });
+});
+
+// --- isNavLinkActive ------------------------------------------------------
+
+describe("isNavLinkActive", () => {
+  const home = "/va";
+
+  it("marks the state home active only on an exact match", () => {
+    expect(isNavLinkActive("/va", "/va", home)).toBe(true);
+    // REGRESSION: home must NOT be active on every sub-route.
+    expect(isNavLinkActive("/va/courses", "/va", home)).toBe(false);
+  });
+
+  it("marks a page active on itself and its child routes", () => {
+    expect(isNavLinkActive("/va/courses", "/va/courses", home)).toBe(true);
+    expect(isNavLinkActive("/va/courses/ENG-111", "/va/courses", home)).toBe(true);
+  });
+
+  it("does not treat a name-prefix as a child route", () => {
+    // "/va/coursesxyz" is not under "/va/courses/"
+    expect(isNavLinkActive("/va/coursesxyz", "/va/courses", home)).toBe(false);
+  });
+
+  it("never marks the global All States link active on a state page", () => {
+    expect(isNavLinkActive("/va", "/", home)).toBe(false);
+    expect(isNavLinkActive("/va/courses", "/", home)).toBe(false);
+  });
+
+  it("does not mark a Guides (/blog) link active on a state page", () => {
+    expect(
+      isNavLinkActive("/va/courses", "/blog/what-does-audit-a-class-mean", home),
+    ).toBe(false);
+  });
+});
+
+// --- closesOnNavigate -----------------------------------------------------
+
+describe("closesOnNavigate", () => {
+  it("keeps the sidebar open only when pinned on desktop", () => {
+    expect(closesOnNavigate(true, true)).toBe(false); // desktop + pinned → stays
+    expect(closesOnNavigate(true, false)).toBe(true); // desktop transient → closes
+    expect(closesOnNavigate(false, false)).toBe(true); // mobile → closes
+    // mobile ignores pin → still closes
+    expect(closesOnNavigate(false, true)).toBe(true);
+  });
+});
+
+// --- structural invariants ------------------------------------------------
+
+describe("nav structure", () => {
+  it("has no duplicate paths across task groups + More", () => {
+    const paths = [...NAV_GROUPS.flatMap((g) => g.items.map((i) => i.path)), ...MORE_ITEMS.map((i) => i.path)];
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("every group has a heading and at least one item", () => {
+    for (const g of NAV_GROUPS) {
+      expect(g.heading.length).toBeGreaterThan(0);
+      expect(g.items.length).toBeGreaterThan(0);
+      for (const i of g.items) expect(typeof i.label).toBe("string");
+    }
+  });
+});

--- a/lib/nav/sidebar.ts
+++ b/lib/nav/sidebar.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure, framework-free logic for the site sidebar nav (components/Header.tsx).
+ *
+ * Extracted from the `"use client"` component so the decision logic — what the
+ * menu contains, when it's visible, which link is "current", whether a click
+ * closes it — can be unit-tested without React, a DOM, or Supabase. The
+ * component keeps only the React state, effects, and markup and calls into
+ * these helpers.
+ */
+
+export type NavItem = { path: string; label: string };
+export type NavGroup = { heading: string; items: NavItem[] };
+export type NavLink = { href: string; label: string };
+export type NavColumn = { heading: string; links: NavLink[] };
+
+// Task-based nav groups — single source of truth for the sidebar. "Find your
+// program" (the guided quiz) sits with Programs; it's ungated like /programs
+// (both notFound() when a state has no qualifying programs). See #413 for why
+// the Programs index is reachable from every page.
+export const NAV_GROUPS: NavGroup[] = [
+  {
+    heading: "Explore classes",
+    items: [
+      { path: "", label: "Search" },
+      { path: "/courses", label: "Find a Course" },
+      { path: "/starting-soon", label: "Starting Soon" },
+      { path: "/colleges", label: "All Colleges" },
+    ],
+  },
+  {
+    heading: "Plan your path",
+    items: [
+      { path: "/schedule", label: "Schedule Builder" },
+      { path: "/plan", label: "Semester Planner" },
+      { path: "/transfer", label: "Transfer" },
+    ],
+  },
+  {
+    heading: "Programs & majors",
+    items: [
+      { path: "/choose", label: "Find your program" },
+      { path: "/programs", label: "Programs" },
+    ],
+  },
+];
+
+// "More" utility links — About is state-scoped; All States is the global "/".
+export const MORE_ITEMS: NavItem[] = [{ path: "/about", label: "About" }];
+
+// Guides cluster (#374) — high-traffic blog hubs surfaced in the sidebar.
+export const GUIDES_ITEMS: NavLink[] = [
+  { href: "/blog/free-community-college-classes-for-seniors", label: "Senior Waivers" },
+  { href: "/blog/how-to-check-if-community-college-course-transfers", label: "Transfer Guides" },
+  { href: "/blog/what-does-audit-a-class-mean", label: "Auditing a Class" },
+  { href: "/blog/how-to-find-late-start-community-college-classes", label: "Late-Start Classes" },
+  { href: "/blog", label: "All Articles →" },
+];
+
+export const PIN_KEY = "ccp-nav-pinned";
+export const DESKTOP_MQ = "(min-width: 1024px)";
+
+export type NavGating = {
+  transferSupported: boolean;
+  prereqsAvailable: boolean;
+};
+
+/**
+ * Whether the sidebar is visible. On desktop it shows when opened OR pinned;
+ * on mobile only when explicitly opened — pin is a desktop-only convenience,
+ * so a persisted pin must never auto-open the overlay on mobile.
+ */
+export function sidebarVisible(
+  open: boolean,
+  pinned: boolean,
+  isDesktop: boolean,
+): boolean {
+  return isDesktop ? open || pinned : open;
+}
+
+/**
+ * Hide /transfer where transfers aren't supported and /plan where prereqs
+ * aren't available; every other item always shows.
+ */
+export function showNavItem(path: string, g: NavGating): boolean {
+  return (
+    (path !== "/transfer" || g.transferSupported) &&
+    (path !== "/plan" || g.prereqsAvailable)
+  );
+}
+
+/**
+ * Build the sidebar's labeled columns for a state: the gated task groups,
+ * then Guides, then a "More" column (About + the global All States link).
+ */
+export function buildNavColumns(state: string, g: NavGating): NavColumn[] {
+  const toLink = (i: NavItem): NavLink => ({
+    href: `/${state}${i.path}`,
+    label: i.label,
+  });
+  return [
+    ...NAV_GROUPS.map((grp) => ({
+      heading: grp.heading,
+      links: grp.items.filter((i) => showNavItem(i.path, g)).map(toLink),
+    })),
+    {
+      heading: "Guides",
+      links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })),
+    },
+    {
+      heading: "More",
+      links: [
+        ...MORE_ITEMS.filter((i) => showNavItem(i.path, g)).map(toLink),
+        { href: "/", label: "All States" },
+      ],
+    },
+  ];
+}
+
+/**
+ * Whether a sidebar link points at the current page. The state home
+ * (`/{state}`) matches EXACTLY so it isn't active on every sub-route; the
+ * global "All States" (`/`) is never active on a state page; everything else
+ * matches the page itself or any of its child routes.
+ */
+export function isNavLinkActive(
+  pathname: string,
+  href: string,
+  stateHome: string,
+): boolean {
+  if (href === stateHome) return pathname === stateHome;
+  if (href === "/") return false;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * A link click closes the sidebar UNLESS it's pinned open on desktop (where
+ * the student wants it to persist while navigating).
+ */
+export function closesOnNavigate(isDesktop: boolean, pinned: boolean): boolean {
+  return !(isDesktop && pinned);
+}

--- a/lib/programs/__tests__/choose.test.ts
+++ b/lib/programs/__tests__/choose.test.ts
@@ -294,3 +294,26 @@ describe("taxonomy", () => {
     );
   });
 });
+
+// --- edge cases (gaps from the session test-coverage audit) ---------------
+
+describe("recommend — edge cases", () => {
+  it("returns [] for an empty fact set", () => {
+    expect(recommend([], ans({ field: "business", goal: "job" }))).toEqual([]);
+  });
+
+  it("preserves a single match", () => {
+    const r = recommend([accounting], ans({ field: "business", goal: "pay" }));
+    expect(r.map((f) => f.slug)).toEqual(["accounting"]);
+  });
+});
+
+describe("matchesTime — null onlinePct", () => {
+  it("treats a null online share as no online availability", () => {
+    const f = fact({ slug: "x", onlinePct: null });
+    expect(matchesTime(f, "online")).toBe(false);
+    // full/part time still match regardless of online data
+    expect(matchesTime(f, "fulltime")).toBe(true);
+    expect(matchesTime(f, "parttime")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is test coverage and an internal refactor. It locks in the navigation and "Help me choose" behavior we shipped this session so future edits can't silently regress it (e.g. the double-X, the wrong active-highlight, or the menu pointing at a 404).

## What changes on the technical front

**Extracted the sidebar's decision logic into a pure module** so it can actually be unit-tested. The logic lived inside the `"use client"` `Header.tsx`, which can't be unit-tested without a DOM. New `lib/nav/sidebar.ts` holds the framework-free functions + nav data; `Header.tsx` now imports them and keeps only React state/effects/markup. Behavior is unchanged — proven by `next build` + a Playwright smoke (hamburger-when-closed, exactly one close control when open, content push on desktop, active-page highlight).

**New tests — `lib/nav/__tests__/sidebar.test.ts` (21 cases)**, including regressions for bugs we hit or designed around this session:
- `sidebarVisible`: desktop shows on open-or-pinned; mobile only on open — a persisted pin must **not** auto-open the mobile overlay.
- `isNavLinkActive`: state home active **only** on exact match (not every sub-route); a name-prefix (`/va/coursesxyz`) is **not** treated as a child of `/va/courses`; the global "All States" and Guides/blog links are never active on a state page.
- `closesOnNavigate`: a link click closes the sidebar unless pinned on desktop.
- `buildNavColumns` / `showNavItem`: column order, state-prefixed hrefs, Guides stay absolute, More ends with All States, and transfer/planner gating hides `/transfer` and `/plan`.
- Structure: no duplicate nav paths.

**`lib/programs/__tests__/choose.test.ts`** — filled the audit gaps (empty fact set, single match, null `onlinePct`). The pre-existing NaN-comparator regression and the CTA-no-404 invariant already covered the rest, so I didn't duplicate them.

## Test plan
- `npx vitest run` — **680 pass** (24 new), 0 fail.
- `tsc --noEmit` + eslint clean.
- `npm run build` exit 0 (confirms the Header extraction is behavior-equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)