### PR TITLE
test: harden coverage of this session's seat/transfer/prereq/compare edge cases

### DIFF
--- a/app/[state]/transfer/compare/__tests__/types.test.ts
+++ b/app/[state]/transfer/compare/__tests__/types.test.ts
@@ -5,9 +5,10 @@ import {
   getCellInfo,
   isHeavyTransferState,
   HEAVY_PRELOAD_THRESHOLD,
+  CELL_COLORS,
 } from "../types";
 import type { TransferMapping } from "@/lib/types";
-import type { CCCourse } from "../types";
+import type { CCCourse, CellStatus } from "../types";
 
 function mk(partial: Partial<TransferMapping>): TransferMapping {
   return {
@@ -117,5 +118,38 @@ describe("isHeavyTransferState", () => {
     // Each university is small, but 43 of them (TX-shape) sum past the cutoff.
     const unis = Array.from({ length: 43 }, () => ({ mappingCount: 4400 }));
     expect(isHeavyTransferState(unis)).toBe(true);
+  });
+});
+
+describe("getCellInfo — status, glyph, and colors (direct, not just via lookup)", () => {
+  const lookupFor = (m: TransferMapping) =>
+    new Map([[`${m.cc_prefix} ${m.cc_number}|${m.university}`, m]]);
+
+  it("direct → ✓ with the equivalent university course", () => {
+    const cell = getCellInfo(ACCT1100, "uga", lookupFor(mk({ univ_course: "ACCT 2101" })));
+    expect(cell.status).toBe("direct");
+    expect(cell.label).toBe("✓");
+    expect(cell.course).toBe("ACCT 2101");
+  });
+  it("elective → ~", () => {
+    const cell = getCellInfo(ACCT1100, "uga", lookupFor(mk({ is_elective: true, univ_course: "X 1XXX" })));
+    expect(cell.status).toBe("elective");
+    expect(cell.label).toBe("~");
+  });
+  it("no-credit → ✗ with no course", () => {
+    const cell = getCellInfo(ACCT1100, "uga", lookupFor(mk({ no_credit: true })));
+    expect(cell.status).toBe("no-credit");
+    expect(cell.label).toBe("✗");
+    expect(cell.course).toBe("");
+  });
+  it("missing mapping → unknown / —", () => {
+    const cell = getCellInfo(ACCT1100, "uga", new Map());
+    expect(cell.status).toBe("unknown");
+    expect(cell.label).toBe("—");
+  });
+  it("CELL_COLORS has an entry for every status (no missing key → no blank cell)", () => {
+    (["direct", "elective", "no-credit", "unknown"] as CellStatus[]).forEach((s) =>
+      expect(CELL_COLORS[s]).toBeTruthy(),
+    );
   });
 });

--- a/components/__tests__/prereqGraph.test.ts
+++ b/components/__tests__/prereqGraph.test.ts
@@ -136,4 +136,27 @@ describe("chainOf", () => {
     expect(lit.has(A)).toBe(true);
     expect(lit.has(B)).toBe(false);
   });
+
+  it("lights the full chain through a diamond, not the sibling branch", () => {
+    // X ← A ← D and X ← B ← D. A's chain: D (ancestor) + X (descendant) + A; not B.
+    const g = buildPrereqGraph(n(X, [n(A, [n(D)]), n(B, [n(D)])]));
+    const lit = chainOf(A, g.edges);
+    expect(lit.has(A)).toBe(true);
+    expect(lit.has(D)).toBe(true);
+    expect(lit.has(X)).toBe(true);
+    expect(lit.has(B)).toBe(false);
+  });
+});
+
+describe("buildPrereqGraph — cycle safety (defensive)", () => {
+  it("terminates and yields finite columns on a cyclic input (A↔B)", () => {
+    // Real chains are acyclic (buildChain breaks cycles), but the graph layout
+    // must never hang or produce Infinity if a cycle ever slips through.
+    const a = n(A);
+    const b = n(B, [a]);
+    a.children.push(b); // A ← B ← A
+    const g = buildPrereqGraph(n(X, [a]));
+    expect(codes(g)).toEqual([A, B, X].sort());
+    g.nodes.forEach((node) => expect(Number.isFinite(node.column)).toBe(true));
+  });
 });

--- a/lib/__tests__/compare-colleges.test.ts
+++ b/lib/__tests__/compare-colleges.test.ts
@@ -90,3 +90,29 @@ describe("applyCompare", () => {
     expect(applyCompare(rows, { sort: "name", onlineOnly: true }).map((r) => r.slug)).toEqual(["b"]);
   });
 });
+
+describe("applyCompare — evening, combined filters & tie-breaks (hardening)", () => {
+  const rows = buildCollegeCompareRows([
+    college({ slug: "a", name: "Alpha", sections: [sec({ seats_open: 2, mode: "in-person", start_time: "9:00 AM", end_time: "10:15 AM" })] }),
+    college({ slug: "b", name: "Bravo", sections: [sec({ seats_open: 50, mode: "online", days: "", start_time: "TBA", end_time: "TBA" })] }),
+    college({ slug: "e", name: "Echo", sections: [sec({ seats_open: 3, mode: "in-person", start_time: "6:00 PM", end_time: "8:45 PM" })] }),
+  ]);
+
+  it("evening-only keeps just the evening (≥5 PM) college", () => {
+    expect(applyCompare(rows, { sort: "name", eveningOnly: true }).map((r) => r.slug)).toEqual(["e"]);
+  });
+
+  it("combined open + online filters AND together", () => {
+    expect(
+      applyCompare(rows, { sort: "name", openOnly: true, onlineOnly: true }).map((r) => r.slug),
+    ).toEqual(["b"]);
+  });
+
+  it("availability sort breaks ties alphabetically by name", () => {
+    const tied = buildCollegeCompareRows([
+      college({ slug: "z", name: "Zeta", sections: [sec({ seats_open: 5 })] }),
+      college({ slug: "a2", name: "Aaa", sections: [sec({ seats_open: 5 })] }),
+    ]);
+    expect(applyCompare(tied, { sort: "availability" }).map((r) => r.name)).toEqual(["Aaa", "Zeta"]);
+  });
+});

--- a/lib/__tests__/prereqs.test.ts
+++ b/lib/__tests__/prereqs.test.ts
@@ -22,6 +22,28 @@ describe("parsePrereqGroups", () => {
     expect(groups).toHaveLength(1); // one OR group, not three required ones
     expect(groups[0]).toHaveLength(3);
   });
+
+  it("a single course is its own required group", () => {
+    expect(parsePrereqGroups("ENG 111", ["ENG 111"])).toEqual([["ENG 111"]]);
+  });
+
+  it("'X or department approval' → just the real course, required (dept approval isn't a course)", () => {
+    // Only the course is in `courses`; the "or department approval" alternative
+    // isn't a parseable course, so the lone course is required. Acceptable — the
+    // full human text is still shown on the badge.
+    expect(parsePrereqGroups("CIVT 1550 or department approval", ["CIVT 1550"])).toEqual([
+      ["CIVT 1550"],
+    ]);
+  });
+
+  it("documents comma-without-and/or behavior: grouped together (no spurious AND split)", () => {
+    // Comma-separated with no 'and'/'or' keyword → one chunk → one group. (Real
+    // data had 0 comma-only cases; this pins the behavior so it can't regress
+    // silently into N separate required groups.)
+    const groups = parsePrereqGroups("ACCT 1010, ACCT 1020", ["ACCT 1010", "ACCT 1020"]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(2);
+  });
 });
 
 describe("buildChain groups (end-to-end OR detection)", () => {

--- a/lib/__tests__/schedule.test.ts
+++ b/lib/__tests__/schedule.test.ts
@@ -244,4 +244,16 @@ describe("scoreSeatAvailability", () => {
     expect(neutral).toBeGreaterThan(0);
     expect(neutral).toBeLessThan(15);
   });
+
+  it("averages a mix of full / open-unlimited / real-count / unknown sections", () => {
+    // per-section sub-scores: wide-open count 1.0, full 0, sentinel 0.75,
+    // unknown 0.5 → avg 0.5625 × 15 = 8.4375 → rounded to 8.4.
+    const s = score([
+      { seats_open: 25, seats_total: 30 },
+      { seats_open: 0, seats_total: 30 },
+      { seats_open: 9999, seats_total: 9999 },
+      { seats_open: null, seats_total: null },
+    ]);
+    expect(s).toBe(8.4);
+  });
 });

--- a/lib/__tests__/seats.test.ts
+++ b/lib/__tests__/seats.test.ts
@@ -129,3 +129,17 @@ describe("labels & tone", () => {
     expect(seatTone(describeSeats(null, null))).toBe("muted");
   });
 });
+
+describe("seats — edge & boundary hardening", () => {
+  it("sentinel boundary: 999 is a real count, 1000 is a sentinel", () => {
+    expect(describeSeats(999, null)).toEqual({ status: "count", open: 999 });
+    expect(describeSeats(1000, null)).toEqual({ status: "open" });
+  });
+  it("a total of 0 is not a usable total → open count only (no divide-by-zero)", () => {
+    expect(describeSeats(5, 0)).toEqual({ status: "count", open: 5 });
+  });
+  it("seatTone low/good boundary is at 5 vs 6 open seats", () => {
+    expect(seatTone(describeSeats(5, 30))).toBe("low");
+    expect(seatTone(describeSeats(6, 30))).toBe("good");
+  });
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is **tests only, no production changes**. It locks in the behavior of the data-honesty fixes shipped this session so they can't silently regress.

## What it does

A coverage-hardening pass over the modules changed this session. For each, I audited the existing tests, found the untested branches / boundaries, and added adversarial cases drawn from the **real data landmines** we discovered (sentinels, negatives, flag states, mixed-case codes, diamonds). Every new test is named for the bug it guards and **fails if that bug were reintroduced**.

| Module | Already covered | Added |
|---|---|---|
| `lib/seats` | null/neg/0/sentinel/flag/count, aggregate, labels | sentinel **boundary** (999 count vs 1000 sentinel), `total===0` (no divide-by-zero), `seatTone` 5↔6 boundary |
| `transfer/compare/types` | rankMapping, best-outcome, isHeavyTransferState | **`getCellInfo` directly** (was only tested via the lookup) — ✓/~/✗/— per status + `CELL_COLORS` completeness |
| `components/prereqGraph` | OR/AND, filter, reduction, longest-path, chainOf | **cycle-safety** (A↔B → finite columns, no hang), `chainOf` through a **diamond** |
| `lib/prereqs` | AND, OR, mixed-case | single-course, "X or department approval"→required, comma-without-keyword behavior pinned |
| `lib/compare-colleges` | sorts, open/online filters | **evening** filter, **combined** open+online, availability **tie-break** by name |
| `lib/schedule` | isFullSection, single-section scoring | **multi-section averaging** (full/sentinel/real/unknown → 8.4) |

**17 new cases.** tsc clean, eslint clean, **full suite 661 pass / 0 fail**.

## Did it catch a bug?
**No** — and that's the intended result. Every edge case the changed code already handles correctly, which confirms the seat/transfer/prereq honesty work from this session is robust under adversarial input. (If any case had failed, the plan was to report it, not silently fix it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)