### PR TITLE
test(ask): pin invariants for the title→code resolver + search rescue

### DIFF
--- a/lib/__tests__/courses-titles-for-subject.test.ts
+++ b/lib/__tests__/courses-titles-for-subject.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Supabase client's query-builder chain:
+//   supabase.from("courses").select(...).eq("state",…).eq("course_prefix",…).range(start,end)
+// `range` is the terminal awaited call; we return per-`start` pages so we can
+// exercise pagination. `eqMock` captures filters so we can assert the query
+// uppercases the prefix. Installed via vi.hoisted before the subject imports.
+const { fromMock, eqMock, rangeMock, supabaseClient } = vi.hoisted(() => {
+  const state: { pages: Map<number, { data: unknown[] | null; error: unknown }> } = {
+    pages: new Map(),
+  };
+  const eqMock = vi.fn();
+  const rangeMock = vi.fn(async (start: number) =>
+    state.pages.get(start) ?? { data: [], error: null },
+  );
+  type Chain = {
+    select: () => Chain;
+    eq: (col: string, val: unknown) => Chain;
+    range: (start: number, end: number) => Promise<{ data: unknown[] | null; error: unknown }>;
+  };
+  const chain: Chain = {
+    select: () => chain,
+    eq: (col, val) => {
+      eqMock(col, val);
+      return chain;
+    },
+    range: (start, _end) => rangeMock(start),
+  };
+  const fromMock = vi.fn(() => chain);
+  return {
+    fromMock,
+    eqMock,
+    rangeMock,
+    supabaseClient: {
+      from: fromMock,
+      _setPages: (obj: Record<number, { data: unknown[] | null; error: unknown }>) => {
+        state.pages = new Map();
+        for (const k of Object.keys(obj)) state.pages.set(Number(k), obj[Number(k)]);
+      },
+    },
+  };
+});
+
+vi.mock("../supabase", () => ({ supabase: supabaseClient }));
+
+import { getCourseTitlesForSubject } from "../courses";
+
+// Each test uses a UNIQUE prefix so the real `cached()` (5-min TTL, module-level
+// Map, not resettable) never returns a previous test's result.
+beforeEach(() => {
+  fromMock.mockClear();
+  eqMock.mockClear();
+  rangeMock.mockClear();
+});
+
+describe("getCourseTitlesForSubject", () => {
+  it("uppercases the prefix in BOTH the query and the output, and dedupes (number,title)", async () => {
+    supabaseClient._setPages({
+      0: {
+        data: [
+          { course_number: "202", course_title: "Intermediate Arabic II" },
+          { course_number: "202", course_title: "Intermediate Arabic II" }, // exact dup
+          { course_number: "101", course_title: "Beginning Arabic I" },
+        ],
+        error: null,
+      },
+    });
+    const rows = await getCourseTitlesForSubject("tst", "ara"); // lowercase input
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.prefix === "ARA")).toBe(true);
+    expect(rows).toContainEqual({ prefix: "ARA", number: "202", title: "Intermediate Arabic II" });
+    // query filtered on the UPPERCASE prefix
+    expect(eqMock.mock.calls).toContainEqual(["course_prefix", "ARA"]);
+    expect(eqMock.mock.calls).toContainEqual(["state", "tst"]);
+  });
+
+  it("keeps distinct titles for the same number (title drift across terms)", async () => {
+    supabaseClient._setPages({
+      0: {
+        data: [
+          { course_number: "120", course_title: "American Sign Language 1" },
+          { course_number: "120", course_title: "1st Semester ASL" },
+        ],
+        error: null,
+      },
+    });
+    const rows = await getCourseTitlesForSubject("tst", "ASLA");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.title).sort()).toEqual(["1st Semester ASL", "American Sign Language 1"]);
+  });
+
+  it("paginates past the 1000-row page size", async () => {
+    const page0 = Array.from({ length: 1000 }, (_, i) => ({
+      course_number: `n${i}`,
+      course_title: `Title ${i}`,
+    }));
+    supabaseClient._setPages({
+      0: { data: page0, error: null },
+      1000: { data: [{ course_number: "x", course_title: "Last" }], error: null },
+    });
+    const rows = await getCourseTitlesForSubject("tst", "BIG");
+    expect(rows).toHaveLength(1001);
+    expect(rangeMock).toHaveBeenCalledTimes(2);
+    expect(rangeMock.mock.calls[0][0]).toBe(0);
+    expect(rangeMock.mock.calls[1][0]).toBe(1000);
+  });
+
+  it("skips rows with a missing number or title", async () => {
+    supabaseClient._setPages({
+      0: {
+        data: [
+          { course_number: "100", course_title: "Good" },
+          { course_number: null, course_title: "No Number" },
+          { course_number: "101", course_title: null },
+          { course_number: "", course_title: "Empty Number" },
+        ],
+        error: null,
+      },
+    });
+    const rows = await getCourseTitlesForSubject("tst", "SKIP");
+    expect(rows).toEqual([{ prefix: "SKIP", number: "100", title: "Good" }]);
+  });
+
+  it("sanitizes the course number (strips stray punctuation)", async () => {
+    supabaseClient._setPages({
+      0: { data: [{ course_number: "202:", course_title: "Has Colon" }], error: null },
+    });
+    const rows = await getCourseTitlesForSubject("tst", "SANI");
+    expect(rows).toEqual([{ prefix: "SANI", number: "202", title: "Has Colon" }]);
+  });
+
+  it("returns [] on a Supabase error (does not throw)", async () => {
+    supabaseClient._setPages({ 0: { data: null, error: { message: "boom" } } });
+    await expect(getCourseTitlesForSubject("tst", "ERRP")).resolves.toEqual([]);
+  });
+
+  it("returns [] when the subject has no rows", async () => {
+    supabaseClient._setPages({ 0: { data: [], error: null } });
+    await expect(getCourseTitlesForSubject("tst", "EMPT")).resolves.toEqual([]);
+  });
+});

--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -384,3 +384,76 @@ describe("toClassifiedIntent", () => {
     expect(result.secondaryIntent.course?.prefix).toBe("BIO");
   });
 });
+
+describe("llmClassifier — course_title mapping & code-wins", () => {
+  async function classify(input: Partial<ClassifierToolInput>) {
+    const classifier = llmClassifier({ client: fakeClient(input) });
+    return (await classifier("q", "va")).intent;
+  }
+
+  it("maps a prereqs title-by-name into courseTitle + subjectPrefix (course null)", async () => {
+    const intent = await classify({
+      type: "prereqs",
+      course_prefix: "ARA",
+      course_number: null,
+      course_title: "Intermediate Arabic II",
+    });
+    expect(intent).toEqual({
+      type: "prereqs",
+      course: null,
+      subjectPrefix: "ARA",
+      courseTitle: "Intermediate Arabic II",
+      direction: "forward",
+    });
+  });
+
+  it("CODE WINS for prereqs: a code present forces courseTitle + subjectPrefix to null", async () => {
+    const intent = await classify({
+      type: "prereqs",
+      course_prefix: "BIO",
+      course_number: "256",
+      course_title: "Genetics", // present, but must be ignored when a code exists
+    });
+    expect(intent).toEqual({
+      type: "prereqs",
+      course: { prefix: "BIO", number: "256" },
+      subjectPrefix: null,
+      courseTitle: null,
+      direction: "forward",
+    });
+  });
+
+  it("maps a transfer title-by-name into courseTitle + subjectPrefix (course null)", async () => {
+    const intent = await classify({
+      type: "transfer",
+      course_prefix: "ACC",
+      course_number: null,
+      course_title: "Principles of Accounting",
+      university: null,
+    });
+    expect(intent).toEqual({
+      type: "transfer",
+      course: null,
+      subjectPrefix: "ACC",
+      courseTitle: "Principles of Accounting",
+      university: null,
+    });
+  });
+
+  it("CODE WINS for transfer: a code present forces courseTitle to null", async () => {
+    const intent = await classify({
+      type: "transfer",
+      course_prefix: "ENG",
+      course_number: "111",
+      course_title: "Composition I",
+      university: "gmu",
+    });
+    expect(intent).toEqual({
+      type: "transfer",
+      course: { prefix: "ENG", number: "111" },
+      subjectPrefix: null,
+      courseTitle: null,
+      university: "gmu",
+    });
+  });
+});

--- a/lib/search-intent/answer/__tests__/resolve-course.test.ts
+++ b/lib/search-intent/answer/__tests__/resolve-course.test.ts
@@ -241,3 +241,35 @@ describe("cross-state round-trip — false-resolve must be ZERO", () => {
     60_000,
   );
 });
+
+describe("matchTitle / normalizeTitle — edge cases", () => {
+  it("returns reason 'empty' for an empty/whitespace title or empty catalog", () => {
+    const cat: CatalogCourse[] = [{ prefix: "BIO", number: "101", title: "General Biology I" }];
+    expect(matchTitle(cat, "").reason).toBe("empty");
+    expect(matchTitle(cat, "   ").resolved).toBeNull();
+    expect(matchTitle([], "Anything").reason).toBe("empty");
+  });
+
+  it("does NOT treat a multi-digit course number in the title as a level numeral", () => {
+    expect(normalizeTitle("English 101")).toBe("english 101");
+    const cat: CatalogCourse[] = [
+      { prefix: "ENG", number: "1", title: "English 101" },
+      { prefix: "ENG", number: "2", title: "English 102" },
+    ];
+    expect(matchTitle(cat, "English 101").resolved).toEqual({ prefix: "ENG", number: "1" });
+    expect(matchTitle(cat, "English 102").resolved).toEqual({ prefix: "ENG", number: "2" });
+  });
+
+  it("resolves a single-token title only when it is exact AND unique", () => {
+    const unique: CatalogCourse[] = [
+      { prefix: "BIO", number: "256", title: "Genetics" },
+      { prefix: "BIO", number: "101", title: "General Biology I" },
+    ];
+    expect(matchTitle(unique, "Genetics").resolved).toEqual({ prefix: "BIO", number: "256" });
+    const ambiguous: CatalogCourse[] = [
+      { prefix: "BIO", number: "256", title: "Genetics" },
+      { prefix: "BIO", number: "257", title: "Genetics" },
+    ];
+    expect(matchTitle(ambiguous, "Genetics").resolved).toBeNull();
+  });
+});

--- a/lib/search-intent/answer/__tests__/transfer.test.ts
+++ b/lib/search-intent/answer/__tests__/transfer.test.ts
@@ -14,17 +14,19 @@ vi.mock("../validate", () => ({
 import { lookupTransfer } from "../transfer";
 import type { TransferIntent } from "../../types";
 import { getTransferInfo } from "../../../transfer";
-import { courseExists, resolveUniversity } from "../validate";
+import { courseExists, resolveCourse, resolveUniversity } from "../validate";
 import type { TransferMapping } from "../../../types";
 
 const mockGetTransferInfo = getTransferInfo as ReturnType<typeof vi.fn>;
 const mockCourseExists = courseExists as ReturnType<typeof vi.fn>;
 const mockResolveUniversity = resolveUniversity as ReturnType<typeof vi.fn>;
+const mockResolveCourse = resolveCourse as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockGetTransferInfo.mockReset();
   mockCourseExists.mockReset();
   mockResolveUniversity.mockReset();
+  mockResolveCourse.mockReset();
 });
 
 function mapping(partial: Partial<TransferMapping>): TransferMapping {
@@ -250,5 +252,52 @@ describe("lookupTransfer", () => {
       if (result.type !== "transfer") throw new Error("wrong type");
       expect(result.followups).toContain("Search for ENG courses");
     });
+  });
+});
+
+describe("lookupTransfer — title resolution", () => {
+  const BY_TITLE: TransferIntent = {
+    type: "transfer",
+    course: null,
+    subjectPrefix: "ENG",
+    courseTitle: "Composition I",
+    university: null,
+  };
+
+  it("resolves a title to a code, then runs the normal transfer lookup", async () => {
+    mockResolveCourse.mockResolvedValue({
+      resolved: { prefix: "ENG", number: "111" },
+      suggestions: [],
+    });
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([]); // exists, no mappings → "no"
+    const result = await lookupTransfer(BY_TITLE, "va");
+    expect(mockResolveCourse).toHaveBeenCalledWith("va", {
+      title: "Composition I",
+      prefixHint: "ENG",
+    });
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("no");
+    expect(result.course).toEqual({ prefix: "ENG", number: "111" });
+  });
+
+  it("falls through to subject-browse and looks up NO course when the title doesn't resolve", async () => {
+    mockResolveCourse.mockResolvedValue({
+      resolved: null,
+      suggestions: [{ code: "ENG 111", title: "Composition I" }],
+    });
+    const result = await lookupTransfer(BY_TITLE, "va");
+    expect(mockResolveCourse).toHaveBeenCalled();
+    expect(mockCourseExists).not.toHaveBeenCalled(); // never resolved a course to look up
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.reason).toBe("missing-entity");
+  });
+
+  it("does NOT attempt resolution when a code was given (code wins)", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([]);
+    await lookupTransfer(ENG_111_INTENT, "va");
+    expect(mockResolveCourse).not.toHaveBeenCalled();
   });
 });

--- a/lib/search-intent/answer/__tests__/validate-resolve-course.test.ts
+++ b/lib/search-intent/answer/__tests__/validate-resolve-course.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CatalogCourse } from "../resolve-course";
+
+// Mock ONLY getCourseTitlesForSubject; keep every other real `courses` export
+// (validate.ts and its import graph still load normally).
+vi.mock("../../../courses", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../courses")>();
+  return { ...actual, getCourseTitlesForSubject: vi.fn() };
+});
+
+import { resolveCourse } from "../validate";
+import { getCourseTitlesForSubject } from "../../../courses";
+
+const mockGet = vi.mocked(getCourseTitlesForSubject);
+
+const ARABIC: CatalogCourse[] = [
+  { prefix: "ARA", number: "101", title: "Beginning Arabic I" },
+  { prefix: "ARA", number: "102", title: "Beginning Arabic II" },
+  { prefix: "ARA", number: "201", title: "Intermediate Arabic I" },
+  { prefix: "ARA", number: "202", title: "Intermediate Arabic II" },
+];
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("resolveCourse", () => {
+  // INVARIANT: no prefix → DEFER, and never fetch the (potentially huge) catalog.
+  it("defers WITHOUT fetching when there is no prefix hint", async () => {
+    for (const prefixHint of [null, undefined, "", "   "]) {
+      const r = await resolveCourse("va", { title: "Intermediate Arabic II", prefixHint });
+      expect(r).toEqual({ resolved: null, suggestions: [] });
+    }
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  // INVARIANT: empty/whitespace title → DEFER, and never fetch.
+  it("defers WITHOUT fetching when the title is empty or whitespace", async () => {
+    for (const title of ["", "   "]) {
+      const r = await resolveCourse("va", { title, prefixHint: "ARA" });
+      expect(r).toEqual({ resolved: null, suggestions: [] });
+    }
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("defers when the subject catalog is empty", async () => {
+    mockGet.mockResolvedValue([]);
+    const r = await resolveCourse("va", { title: "Intermediate Arabic II", prefixHint: "ARA" });
+    expect(r).toEqual({ resolved: null, suggestions: [] });
+    expect(mockGet).toHaveBeenCalledWith("va", "ARA");
+  });
+
+  it("resolves a confident title match to a code", async () => {
+    mockGet.mockResolvedValue(ARABIC);
+    const r = await resolveCourse("va", { title: "Intermediate Arabic II", prefixHint: "ARA" });
+    expect(r.resolved).toEqual({ prefix: "ARA", number: "202" });
+    expect(r.suggestions).toEqual([]);
+    expect(mockGet).toHaveBeenCalledWith("va", "ARA");
+  });
+
+  it("trims the title before matching", async () => {
+    mockGet.mockResolvedValue(ARABIC);
+    const r = await resolveCourse("va", { title: "  Intermediate Arabic II  ", prefixHint: "ARA" });
+    expect(r.resolved).toEqual({ prefix: "ARA", number: "202" });
+  });
+
+  it("defers with suggestions when the title is ambiguous (never guesses)", async () => {
+    mockGet.mockResolvedValue([
+      { prefix: "ACC", number: "101", title: "Financial Accounting" },
+      { prefix: "ACC", number: "201", title: "Financial Accounting" },
+      { prefix: "ACC", number: "301", title: "Financial Accounting" },
+    ]);
+    const r = await resolveCourse("va", { title: "Financial Accounting", prefixHint: "ACC" });
+    expect(r.resolved).toBeNull();
+    expect(r.suggestions.map((s) => s.code).sort()).toEqual(["ACC 101", "ACC 201", "ACC 301"]);
+  });
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this PR adds **unit tests only**. No production code changes. Its value is protecting two features that are already live in prod (PRs #1096 title→code resolver, #1097 search-rescue filler) from silent regressions, since both run on every `/ask` query.

I wrote these as **bug-catching** tests (assert the intended invariant, fail loudly if violated), prioritizing the units that had **zero** coverage. **Result: 0 product bugs found** — the two failures I hit while writing them were both in my own test scaffolding (a wrong import depth, a mock arg-count), now fixed. The invariants below are now pinned.

## Coverage added (the gaps)

**New files**
- `lib/__tests__/courses-titles-for-subject.test.ts` — `getCourseTitlesForSubject` (mocked Supabase chain): uppercases the prefix in both query and output, dedupes `(number,title)`, keeps title drift across terms, **paginates past 1000 rows**, skips rows with null number/title, sanitizes stray punctuation in numbers, returns `[]` on error/empty.
- `lib/search-intent/answer/__tests__/validate-resolve-course.test.ts` — `resolveCourse`: **no prefix → defer without fetching** (proves we never scan the full catalog), empty/whitespace title → defer without fetching, empty catalog → defer, confident match resolves, title is trimmed, ambiguous → defer with suggestions.

**Extended**
- `transfer.test.ts` — title resolves → normal transfer lookup runs; title unresolved → subject-browse with **no course lookup**; **code present → resolution skipped** (code wins).
- `classify-llm.test.ts` — `course_title` → `courseTitle`/`subjectPrefix` mapping for prereqs + transfer; **CODE WINS** (a `course_number` forces `courseTitle` null).
- `resolve-course.test.ts` — empty title/catalog → `'empty'`; a multi-digit course number in a title is **not** treated as a level numeral; single-token title resolves only when exact **and** unique.

## Invariants now pinned
- Never resolves to a wrong course (numeral/honors guards, multi-number → defer).
- Code always wins over title in the classifier.
- Defer is safe — ambiguous title never triggers a lookup or a guess.
- No prefix → defer (no full-catalog scan on the hot path).
- Term-agnostic dedup in the subject-title catalog.

## Test plan
- `npx vitest run` → **720 passed / 12 skipped**.
- `RESOLVER_FULL_BATTERY=1 npx vitest run …/resolve-course.test.ts` → 21 passed, 0 false-resolves on VA/NC/TX/CA.
- `npx tsc --noEmit` + `eslint` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)