### PR TITLE
nav: eliminate the pinned-sidebar reload flash

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -103,6 +103,18 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">
+        {/* No-flash sidebar restore: on a hard reload of a pinned desktop
+            state page, set data-nav-open before first paint so the sidebar is
+            already open and the content already pushed — no slide-in. Runs only
+            for a 2-letter state slug (the only routes that render the sidebar),
+            so non-state pages are never shifted. Mirrors lib/nav/sidebar.ts
+            (PIN_KEY + 1024px breakpoint). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var s=location.pathname.split('/')[1]||'';if(localStorage.getItem('ccp-nav-pinned')==='1'&&window.matchMedia('(min-width: 1024px)').matches&&/^[a-z][a-z]$/.test(s)){document.documentElement.setAttribute('data-nav-open','1');}}catch(e){}})();",
+          }}
+        />
         <JsonLd data={siteJsonLd} />
         <ThemeProvider>
           <AuthProvider>

--- a/app/tailwind.source.css
+++ b/app/tailwind.source.css
@@ -84,12 +84,24 @@ body {
   }
 }
 
-/* Side navigation push (components/Header.tsx).
-   When the sidebar is open, the header sets data-nav-open on <html>. On
-   desktop (≥1024px) the body shifts right by the sidebar width (16rem = w-64)
-   so the fixed sidebar doesn't cover content; on smaller screens the sidebar
-   is an overlay, so no push. Only state pages render that header, so this
-   attribute is never set elsewhere. */
+/* Side navigation (components/Header.tsx).
+   Both the sidebar's slide AND the desktop content-push are driven by the
+   `data-nav-open` attribute on <html> — set by the header, and pre-set before
+   first paint by the inline script in app/layout.tsx. Keeping both on the same
+   attribute means a pinned reload applies them together, with no flash where
+   content jumps right while the sidebar lags behind. Only state pages render
+   the header / the #site-sidebar element, so this attribute is inert
+   elsewhere. NOTE: the inline no-flash script hardcodes the "ccp-nav-pinned"
+   key and the 1024px breakpoint — keep them in sync with lib/nav/sidebar.ts. */
+#site-sidebar {
+  transform: translateX(-100%);
+  transition: transform 0.2s ease-out;
+}
+
+html[data-nav-open="1"] #site-sidebar {
+  transform: translateX(0);
+}
+
 body {
   transition: padding-left 0.2s ease;
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -159,13 +159,14 @@ export default function Header({
         />
       )}
 
-      {/* Sidebar */}
+      {/* Sidebar. Open/closed transform lives in CSS keyed on
+          html[data-nav-open] (app/tailwind.source.css), not on this className,
+          so the inline no-flash script can show it before first paint on a
+          pinned reload — in sync with the content push. */}
       <aside
         id="site-sidebar"
         aria-label="Site navigation"
-        className={`fixed top-0 left-0 z-50 flex h-dvh w-64 flex-col border-r border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg transition-transform duration-200 ease-out ${
-          effectiveOpen ? "translate-x-0" : "-translate-x-full"
-        }`}
+        className="fixed top-0 left-0 z-50 flex h-dvh w-64 flex-col border-r border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg"
       >
         {/* Sidebar control row — aligns with the top bar height. */}
         <div className="flex h-[65px] flex-shrink-0 items-center justify-between border-b border-gray-100 dark:border-slate-700 px-4">


### PR DESCRIPTION
## What changes for someone using the site

If you've **pinned** the sidebar open on desktop and then **hard-reload** a state page, the page content used to visibly slide to the right for a moment as the app restored your pin. Now the sidebar is already open and the content already in place on the very first frame — no slide, no flash. (Clicking links / normal navigation never had this; it was only on a full reload.)

Nothing else changes visually — open/close still animates normally.

## What changes on the technical front

The sidebar's restored-open state is now applied **before first paint** instead of after React hydration:

- Both the sidebar's slide **and** the desktop content-push are now driven by the same `html[data-nav-open]` attribute via CSS (`app/tailwind.source.css`). Previously the sidebar's transform lived in a React `className`; moving it to CSS means a pre-paint attribute can position both in lockstep — no in-between state where content is pushed but the sidebar lags.
- A tiny inline script in `app/layout.tsx` sets `data-nav-open` before paint **only** when: the pin is stored (`ccp-nav-pinned`), the viewport is desktop (≥1024px), and the first path segment is a 2-letter state slug (the only routes that render the sidebar). React keeps the attribute in sync after mount, exactly as before.

The 2-letter-slug guard is what keeps this safe: non-state pages (`/`, `/blog`, `/colleges`, …) never get the attribute, so they're never pushed even if a pin is stored. The inline script hardcodes the storage key + breakpoint; a comment in both files notes they must stay in sync with `lib/nav/sidebar.ts`.

## Test plan
- Playwright (worktree dev server), **7/7**: fresh desktop closed → no push; toggle → push + sidebar on-screen; **pinned hard-reload → `data-nav-open` present pre-React, content pushed, sidebar open**; pinned + `/blog` (non-state) → NOT pushed; pinned + mobile → does not auto-open.
- `next build` exit 0; 720 tests pass; `tsc --noEmit` + eslint clean.

Follow-up polish to the sidebar (#1095/#1099). To see it: pin the sidebar on a desktop state page, then reload — no slide-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)