### PR TITLE
fix(isr): program + online pages now edge-cache (closes #1137)

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -50,6 +50,20 @@ function resolveCredential(title: string, credential: string): string {
 }
 export const dynamicParams = true;
 
+// REQUIRED for ISR. Next 16: "You must always return an array from
+// generateStaticParams, even if it's empty. Otherwise, the route will be
+// dynamically rendered." (node_modules/next/dist/docs/.../generate-static-params.md).
+// Returning [] prerenders nothing at build but makes every program page
+// statically render + edge-cache on first visit (revalidate above). Without
+// this export the route is fully dynamic — uncached Supabase fetches inside
+// buildMajorPlan force `cache-control: no-store` and ISR never engages, so
+// every visitor pays the full render. The college page does the same thing.
+// See issue #1137 (the unstable_cache wrap in #1098 caches the *data* but
+// could not make the *route* static — only this can).
+export function generateStaticParams() {
+  return [];
+}
+
 interface PageProps {
   params: Promise<{ state: string; id: string; slug: string }>;
 }

--- a/app/[state]/online/page.tsx
+++ b/app/[state]/online/page.tsx
@@ -21,6 +21,14 @@ import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 export const revalidate = 604800; // 7 days
 
+// Required for ISR — without it this [state] route renders dynamically and the
+// revalidate above is dead (Next 16: an empty array still opts the route into
+// static generation; omitting the export entirely makes it dynamic). Mirrors
+// every other /[state]/* page. See issue #1137.
+export function generateStaticParams() {
+  return [];
+}
+
 type PageProps = {
   params: Promise<{ state: string }>;
 };

--- a/app/__tests__/isr-route-config.test.ts
+++ b/app/__tests__/isr-route-config.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * Invariant guard for issue #1137.
+ *
+ * Next 16: a route with a dynamic segment (`[param]`) that exports
+ * `revalidate` (declaring ISR intent) but provides NEITHER
+ * `generateStaticParams` NOR `export const dynamic` is silently rendered
+ * **dynamically** — the `revalidate` is dead, every response ships
+ * `cache-control: no-store`, and ISR never engages. From the official docs:
+ *
+ *   "You must always return an array from generateStaticParams, even if it's
+ *    empty. Otherwise, the route will be dynamically rendered."
+ *
+ * This bit the program page (#1098/#1137) and the /[state]/online page. The
+ * test below fails if any new dynamic ISR route reintroduces the trap, so the
+ * fix can't silently regress when someone removes the export.
+ */
+
+const APP_DIR = join(__dirname, "..");
+
+/** Recursively collect every page.tsx whose route path contains a [dynamic]
+ *  segment (the only routes subject to the #1137 trap). */
+function findPageFiles(dir: string = APP_DIR): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") continue;
+      out.push(...findPageFiles(full));
+    } else if (entry.name === "page.tsx") {
+      // Only routes with a [dynamic] segment somewhere in their path.
+      if (relative(APP_DIR, full).includes("[")) out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("ISR route config invariant (#1137)", () => {
+  const pages = findPageFiles();
+
+  it("finds dynamic-segment page routes to check", () => {
+    // Sanity: the glob actually matched something, otherwise the test is vacuous.
+    expect(pages.length).toBeGreaterThan(5);
+  });
+
+  it("every dynamic route that exports `revalidate` also opts into static rendering", () => {
+    const offenders: string[] = [];
+
+    for (const file of pages) {
+      const src = readFileSync(file, "utf-8");
+
+      const declaresRevalidate = /export\s+const\s+revalidate\s*=/.test(src);
+      if (!declaresRevalidate) continue; // no ISR intent → not subject to the trap
+
+      const hasGenerateStaticParams = /generateStaticParams/.test(src);
+      const hasDynamicExport = /export\s+const\s+dynamic\b/.test(src);
+
+      if (!hasGenerateStaticParams && !hasDynamicExport) {
+        offenders.push(file.replace(APP_DIR, "app"));
+      }
+    }
+
+    expect(
+      offenders,
+      `These dynamic routes export \`revalidate\` but neither \`generateStaticParams\` ` +
+        `nor \`export const dynamic\`, so Next renders them dynamically and the ` +
+        `revalidate is dead (issue #1137). Add \`export function generateStaticParams() ` +
+        `{ return []; }\`:\n  ${offenders.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("the program page specifically declares generateStaticParams (regression lock for #1098/#1137)", () => {
+    const programPage = join(
+      APP_DIR,
+      "[state]",
+      "college",
+      "[id]",
+      "program",
+      "[slug]",
+      "page.tsx",
+    );
+    const src = readFileSync(programPage, "utf-8");
+    expect(/export\s+function\s+generateStaticParams/.test(src)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changes for users
Program pages (e.g. `/ca/college/cuyamaca-college/program/computer-science-for-transfer-as-t-associate-in-science-as`) and the per-state online-courses pages (`/ca/online`) now get served from Vercel's edge cache instead of re-rendering on every single visit. After the first visitor warms the cache, everyone else gets a near-instant edge response for 24h (program) / 7 days (online). Before this, every visit ran the full server render — fast since #1098, but still wasteful and slower than an edge hit.

No visible change to page content — same data, just cached at the edge the way these pages were always meant to be.

## What changes technically
Root cause of #1137: both routes declared `export const revalidate = …` (ISR intent) but had **no `generateStaticParams` export**. Per the Next 16 docs (`generate-static-params.md`):

> You must always return an array from `generateStaticParams`, even if it's empty. **Otherwise, the route will be dynamically rendered.**

A dynamically-rendered route with uncached Supabase fetches ships `cache-control: no-store` and never edge-caches — so the `revalidate` was dead. The college page already had `generateStaticParams() { return [] }` and was correctly `public`/cacheable; the program page was missing it. This was an intent-vs-implementation gap — the program page's own header comment claims it "stays static and never opts into dynamic rendering," but it did.

The `unstable_cache` wrap from #1098 caches the *data layer* but cannot make the *route* static — only `generateStaticParams` does. They're complementary: `generateStaticParams` → edge-cached HTML; `unstable_cache` → fast data on ISR regeneration.

**Second instance found by the new guard test:** `/[state]/online` had the identical bug (`revalidate = 604800`, no `generateStaticParams`, shipping `no-store` on prod). Fixed in the same PR.

## Evidence
Build route classification flips from dynamic (`ƒ`) to static/ISR (`●`):
```
●  /[state]/college/[id]/program/[slug]   (was ƒ)
●  /[state]/online                        (was ƒ)
```
Prod cache headers **before** this PR:
```
/ca/college/.../program/...  → cache-control: private, no-store   x-vercel-cache: MISS
/ca/online                   → cache-control: private, no-store   x-vercel-cache: MISS
```
Expected **after** deploy (matching the already-correct college page): `cache-control: public …`, and `x-vercel-cache: HIT` on the second request.

## Files changed
| File | Change |
|---|---|
| `app/[state]/college/[id]/program/[slug]/page.tsx` | +`generateStaticParams() { return [] }` |
| `app/[state]/online/page.tsx` | same fix (2nd instance) |
| `app/__tests__/isr-route-config.test.ts` | invariant guard (see below) |

## The guard test
`isr-route-config.test.ts` enforces: **any route with a `[dynamic]` segment that exports `revalidate` must also export `generateStaticParams` or `dynamic`** — otherwise Next renders it dynamically and the `revalidate` is silently dead. Proven non-vacuous: removing either fix turns the test red and names the offending file. This converts the #1137 trap into a machine-enforced invariant so it can't recur.

## Test plan
- [x] `npm run test:run` — 723 passed (added 3-case guard, 0 regressions)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean on changed files
- [x] `npm run build` — both routes classify as `●` (ISR), compiles clean
- [x] Guard test verified to catch a missing export (red → restored green)
- [ ] Post-merge: curl both prod URLs, confirm `cache-control: public` + `x-vercel-cache: HIT` on 2nd hit (will append)

Closes #1137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)